### PR TITLE
修复 Persona 回写原应用焦点丢失和选区失效问题

### DIFF
--- a/Sources/Typeflux/Overlay/OverlayController.swift
+++ b/Sources/Typeflux/Overlay/OverlayController.swift
@@ -264,6 +264,27 @@ final class OverlayController {
         }
     }
 
+    /// Immediately hides the overlay window and resets state, running synchronously
+    /// on the main thread. Use this before returning focus to the original application
+    /// so the panel is guaranteed to be hidden before activation.
+    func dismissImmediately() {
+        let work = { [weak self] in
+            guard let self else { return }
+            self.dismissWorkItem?.cancel()
+            self.dismissWorkItem = nil
+            self.window?.orderOut(nil)
+            self.model.detailText = ""
+            self.model.level = 0
+            self.model.processingProgress = 0
+            self.removeKeyMonitoring()
+        }
+        if Thread.isMainThread {
+            work()
+        } else {
+            DispatchQueue.main.sync(execute: work)
+        }
+    }
+
     func dismiss(after delay: TimeInterval) {
         if !Thread.isMainThread {
             DispatchQueue.main.async { [weak self] in self?.dismiss(after: delay) }

--- a/Sources/Typeflux/TextInjection/AXTextInjector.swift
+++ b/Sources/Typeflux/TextInjection/AXTextInjector.swift
@@ -14,7 +14,7 @@ final class AXTextInjector: TextInjector {
 
     private static var didRequestAccessibility = false
     private static let pasteRestoreDelayNanoseconds: UInt64 = 180_000_000
-    private static let focusRestoreDelayMicroseconds: useconds_t = 80_000
+    private static let focusRestoreDelayMicroseconds: useconds_t = 250_000
     private static let selectedTextTimeoutMilliseconds = 200
     private static let copySelectionTimeoutMilliseconds = 180
     private static let copyShortcutKeyCode: CGKeyCode = 8
@@ -226,9 +226,12 @@ final class AXTextInjector: TextInjector {
             )
         }
 
+        var contextRestored = false
+
         if replaceSelection,
            let context = activeSelectionContext() {
             restoreSelectionContext(context)
+            contextRestored = true
             if context.range != nil,
                try insertTextViaAX(text, into: context.element, replaceSelection: true, selectionRange: context.range) {
                 latestSelectionContext = nil
@@ -243,7 +246,7 @@ final class AXTextInjector: TextInjector {
             return
         }
 
-        try setTextViaPaste(text, replaceSelection: replaceSelection)
+        try setTextViaPaste(text, replaceSelection: replaceSelection, contextAlreadyRestored: contextRestored)
         if replaceSelection {
             latestSelectionContext = nil
         }
@@ -273,14 +276,16 @@ final class AXTextInjector: TextInjector {
         return false
     }
 
-    private func setTextViaPaste(_ text: String, replaceSelection: Bool) throws {
+    private func setTextViaPaste(_ text: String, replaceSelection: Bool, contextAlreadyRestored: Bool = false) throws {
         let pasteboard = NSPasteboard.general
         let previousString = pasteboard.string(forType: .string)
         let targetPID: pid_t?
 
         if replaceSelection, let context = activeSelectionContext() {
             targetPID = context.processID
-            restoreSelectionContext(context)
+            if !contextAlreadyRestored {
+                restoreSelectionContext(context)
+            }
         } else {
             targetPID = frontmostProcessID()
         }
@@ -409,7 +414,24 @@ final class AXTextInjector: TextInjector {
         if let processID = context.processID,
            let app = NSRunningApplication(processIdentifier: processID) {
             app.activate(options: [.activateIgnoringOtherApps])
-            usleep(Self.focusRestoreDelayMicroseconds)
+
+            // Wait for the target app to actually become frontmost.
+            // Some apps (WeChat, Sublime Text, Electron) need extra time.
+            let deadline = Date().addingTimeInterval(0.8)
+            var activated = false
+            while Date() < deadline {
+                usleep(50_000) // 50ms per check
+                if NSWorkspace.shared.frontmostApplication?.processIdentifier == processID {
+                    activated = true
+                    break
+                }
+            }
+
+            if !activated {
+                // Retry activation once and give a final wait
+                app.activate(options: [.activateIgnoringOtherApps])
+                usleep(Self.focusRestoreDelayMicroseconds)
+            }
         }
 
         _ = setFocused(true, on: context.element)

--- a/Sources/Typeflux/Workflow/WorkflowController.swift
+++ b/Sources/Typeflux/Workflow/WorkflowController.swift
@@ -950,13 +950,7 @@ final class WorkflowController {
     }
 
     private func dismissOverlayForExternalReplacement() {
-        if Thread.isMainThread {
-            overlayController.dismiss(after: 0)
-        } else {
-            DispatchQueue.main.sync {
-                self.overlayController.dismiss(after: 0)
-            }
-        }
+        overlayController.dismissImmediately()
         usleep(Self.selectionRestoreDelayMicroseconds)
     }
 


### PR DESCRIPTION
浮层 dismiss 改为同步执行，消除面板与原应用争抢焦点的竞态；
应用激活改为轮询验证（最长 800ms），适配微信/Sublime 等慢激活应用；
消除 restoreSelectionContext 重复调用导致选区被重置的问题。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Overlay dismissal now responds immediately when triggered
  * Text selection restoration refined to prevent redundant operations  
  * Application focus restoration improved with enhanced timing and polling logic

<!-- end of auto-generated comment: release notes by coderabbit.ai -->