### PR TITLE
feat(vocabulary): reduce auto-vocabulary observation window from 60s to 30s

### DIFF
--- a/Sources/Typeflux/Workflow/WorkflowController.swift
+++ b/Sources/Typeflux/Workflow/WorkflowController.swift
@@ -9,7 +9,7 @@ final class WorkflowController {
     static let tapToLockThreshold: TimeInterval = 0.22
     static let minimumRecordingDuration: TimeInterval = 0.35
     static let selectionRestoreDelayMicroseconds: useconds_t = 120_000
-    static let automaticVocabularyObservationWindow: TimeInterval = 60
+    static let automaticVocabularyObservationWindow: TimeInterval = 30
     static let automaticVocabularyPollInterval: Duration = .seconds(1)
     static let automaticVocabularyStartupDelay: Duration = .milliseconds(600)
     static let automaticVocabularyBaselineRetryDelay: Duration = .milliseconds(400)


### PR DESCRIPTION
## Summary

- Reduces `automaticVocabularyObservationWindow` from 60s to 30s in `WorkflowController.swift`
- This makes the auto-vocabulary feature respond faster after the user finishes editing

## Test plan

- [ ] Trigger a voice input, then edit the transcribed text
- [ ] Verify vocabulary analysis runs after ~30s of idle time instead of ~60s

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Reduced the automatic vocabulary observation window from 60 to 30 seconds for faster performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->