### PR TITLE
feat(stt): upgrade default Whisper model to Medium, add Large option

### DIFF
--- a/Sources/Typeflux/Resources/en.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/en.lproj/Localizable.strings
@@ -220,10 +220,14 @@
 "downloadSource.modelScope" = "ModelScope";
 "downloadSource.huggingFace" = "Hugging Face";
 
-"localSTT.whisperLocal.name" = "WhisperKit";
+"localSTT.whisperLocal.name" = "WhisperKit Medium";
 "localSTT.whisperLocal.summary" = "Balanced local ASR with stable English and multilingual dictation, suitable for most offline transcription needs.";
-"localSTT.whisperLocal.parameterValue" = "244M";
-"localSTT.whisperLocal.sizeValue" = "486 MB";
+"localSTT.whisperLocal.parameterValue" = "769M";
+"localSTT.whisperLocal.sizeValue" = "~1.5 GB";
+"localSTT.whisperLocalLarge.name" = "WhisperKit Large";
+"localSTT.whisperLocalLarge.summary" = "High-accuracy local ASR with the best multilingual transcription quality, ideal for demanding offline transcription tasks.";
+"localSTT.whisperLocalLarge.parameterValue" = "1.55B";
+"localSTT.whisperLocalLarge.sizeValue" = "~3 GB";
 "localSTT.senseVoiceSmall.name" = "SenseVoice";
 "localSTT.senseVoiceSmall.summary" = "Fast multilingual speech recognition with strong Mandarin, Cantonese, English, Japanese, and Korean support.";
 "localSTT.senseVoiceSmall.parameterValue" = "234M";

--- a/Sources/Typeflux/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/ja.lproj/Localizable.strings
@@ -218,10 +218,14 @@
 "downloadSource.modelScope" = "ModelScope";
 "downloadSource.huggingFace" = "Hugging Face";
 
-"localSTT.whisperLocal.name" = "Whisper Local";
+"localSTT.whisperLocal.name" = "WhisperKit Medium";
 "localSTT.whisperLocal.summary" = "安定した英語と多言語のディクテーションを備えたバランスの取れたローカル ASR で、ほとんどのオフライン文字起こしのニーズに適しています。";
-"localSTT.whisperLocal.parameterValue" = "244M";
-"localSTT.whisperLocal.sizeValue" = "486 MB";
+"localSTT.whisperLocal.parameterValue" = "769M";
+"localSTT.whisperLocal.sizeValue" = "~1.5 GB";
+"localSTT.whisperLocalLarge.name" = "WhisperKit Large";
+"localSTT.whisperLocalLarge.summary" = "最高の多言語文字起こし品質を持つ高精度ローカル ASR で、要求の厳しいオフライン文字起こしタスクに最適です。";
+"localSTT.whisperLocalLarge.parameterValue" = "1.55B";
+"localSTT.whisperLocalLarge.sizeValue" = "~3 GB";
 "localSTT.senseVoiceSmall.name" = "SenseVoice Small";
 "localSTT.senseVoiceSmall.summary" = "中国語、広東語、英語、日本語、韓国語を強力にサポートする高速多言語音声認識。";
 "localSTT.senseVoiceSmall.parameterValue" = "234M";

--- a/Sources/Typeflux/Resources/ko.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/ko.lproj/Localizable.strings
@@ -218,10 +218,14 @@
 "downloadSource.modelScope" = "ModelScope";
 "downloadSource.huggingFace" = "Hugging Face";
 
-"localSTT.whisperLocal.name" = "Whisper Local";
+"localSTT.whisperLocal.name" = "WhisperKit Medium";
 "localSTT.whisperLocal.summary" = "대부분의 오프라인 전사 요구에 적합한 안정적인 영어 및 다국어 받아쓰기를 갖춘 균형 잡힌 로컬 ASR입니다.";
-"localSTT.whisperLocal.parameterValue" = "244M";
-"localSTT.whisperLocal.sizeValue" = "486 MB";
+"localSTT.whisperLocal.parameterValue" = "769M";
+"localSTT.whisperLocal.sizeValue" = "~1.5 GB";
+"localSTT.whisperLocalLarge.name" = "WhisperKit Large";
+"localSTT.whisperLocalLarge.summary" = "최고의 다국어 전사 품질을 갖춘 고정밀 로컬 ASR로, 까다로운 오프라인 전사 작업에 이상적입니다.";
+"localSTT.whisperLocalLarge.parameterValue" = "1.55B";
+"localSTT.whisperLocalLarge.sizeValue" = "~3 GB";
 "localSTT.senseVoiceSmall.name" = "SenseVoice Small";
 "localSTT.senseVoiceSmall.summary" = "중국어, 광둥어, 영어, 일본어, 한국어를 강력하게 지원하는 빠른 다국어 음성 인식.";
 "localSTT.senseVoiceSmall.parameterValue" = "234M";

--- a/Sources/Typeflux/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/zh-Hans.lproj/Localizable.strings
@@ -220,10 +220,14 @@
 "downloadSource.modelScope" = "ModelScope";
 "downloadSource.huggingFace" = "Hugging Face";
 
-"localSTT.whisperLocal.name" = "WhisperKit";
+"localSTT.whisperLocal.name" = "WhisperKit Medium";
 "localSTT.whisperLocal.summary" = "均衡的本地 ASR，英文和多语言听写表现稳定，适合大多数离线转写场景。";
-"localSTT.whisperLocal.parameterValue" = "244M";
-"localSTT.whisperLocal.sizeValue" = "486 MB";
+"localSTT.whisperLocal.parameterValue" = "769M";
+"localSTT.whisperLocal.sizeValue" = "~1.5 GB";
+"localSTT.whisperLocalLarge.name" = "WhisperKit Large";
+"localSTT.whisperLocalLarge.summary" = "高精度本地 ASR，多语言转写质量最佳，适合对识别准确度要求较高的离线场景。";
+"localSTT.whisperLocalLarge.parameterValue" = "1.55B";
+"localSTT.whisperLocalLarge.sizeValue" = "~3 GB";
 "localSTT.senseVoiceSmall.name" = "SenseVoice";
 "localSTT.senseVoiceSmall.summary" = "快速的多语言语音识别，对普通话、粤语、英语、日语和韩语支持较强。";
 "localSTT.senseVoiceSmall.parameterValue" = "234M";

--- a/Sources/Typeflux/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/zh-Hant.lproj/Localizable.strings
@@ -218,10 +218,14 @@
 "downloadSource.modelScope" = "ModelScope";
 "downloadSource.huggingFace" = "Hugging Face";
 
-"localSTT.whisperLocal.name" = "WhisperKit";
+"localSTT.whisperLocal.name" = "WhisperKit Medium";
 "localSTT.whisperLocal.summary" = "均衡的本地 ASR，英文與多語言聽寫表現穩定，適合多數離線轉寫情境。";
-"localSTT.whisperLocal.parameterValue" = "244M";
-"localSTT.whisperLocal.sizeValue" = "486 MB";
+"localSTT.whisperLocal.parameterValue" = "769M";
+"localSTT.whisperLocal.sizeValue" = "~1.5 GB";
+"localSTT.whisperLocalLarge.name" = "WhisperKit Large";
+"localSTT.whisperLocalLarge.summary" = "高精度本地 ASR，多語言轉寫品質最佳，適合對辨識準確度要求較高的離線情境。";
+"localSTT.whisperLocalLarge.parameterValue" = "1.55B";
+"localSTT.whisperLocalLarge.sizeValue" = "~3 GB";
 "localSTT.senseVoiceSmall.name" = "SenseVoice";
 "localSTT.senseVoiceSmall.summary" = "快速的多語言語音辨識，對普通話、粵語、英語、日語與韓語支援較強。";
 "localSTT.senseVoiceSmall.parameterValue" = "234M";

--- a/Sources/Typeflux/STT/AutoModelDownloadService.swift
+++ b/Sources/Typeflux/STT/AutoModelDownloadService.swift
@@ -128,7 +128,7 @@ final class AutoModelDownloadService {
         guard let config, let path else { return nil }
 
         switch config.model {
-        case .whisperLocal:
+        case .whisperLocal, .whisperLocalLarge:
             let modelName = config.modelIdentifier.hasPrefix("whisperkit-")
                 ? String(config.modelIdentifier.dropFirst("whisperkit-".count))
                 : config.modelIdentifier

--- a/Sources/Typeflux/STT/LocalModelDownloadCatalog.swift
+++ b/Sources/Typeflux/STT/LocalModelDownloadCatalog.swift
@@ -3,7 +3,7 @@ import Foundation
 enum LocalModelDownloadCatalog {
     private static let huggingFaceEndpoint = "https://huggingface.co"
     private static let whisperKitRepositoryID = "argmaxinc/whisperkit-coreml"
-    private static let whisperKitDefaultModelName = "whisperkit-small"
+    private static let whisperKitDefaultModelName = "whisperkit-medium"
     private static let sherpaOnnxRuntimeRootDirectory = "sherpa-onnx-v1.12.35-osx-universal2-shared-no-tts"
     private static let senseVoiceRootDirectory = "sherpa-onnx-sense-voice-zh-en-ja-ko-yue-2024-07-17"
     private static let qwen3ASRRootDirectory = "sherpa-onnx-qwen3-asr-0.6B-int8-2026-03-25"
@@ -34,7 +34,7 @@ enum LocalModelDownloadCatalog {
 
     static func sherpaOnnxModelArchiveURL(for model: LocalSTTModel, source _: ModelDownloadSource) -> URL? {
         switch model {
-        case .whisperLocal:
+        case .whisperLocal, .whisperLocalLarge:
             nil
         case .senseVoiceSmall:
             URL(string: "https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/\(senseVoiceRootDirectory).tar.bz2")!
@@ -45,7 +45,7 @@ enum LocalModelDownloadCatalog {
 
     static func sherpaOnnxModelDirectoryName(for model: LocalSTTModel) -> String? {
         switch model {
-        case .whisperLocal:
+        case .whisperLocal, .whisperLocalLarge:
             nil
         case .senseVoiceSmall:
             senseVoiceRootDirectory

--- a/Sources/Typeflux/STT/LocalModelManager.swift
+++ b/Sources/Typeflux/STT/LocalModelManager.swift
@@ -123,7 +123,7 @@ final class LocalModelManager: LocalSTTModelManaging {
         try fileManager.createDirectory(at: resourceURL, withIntermediateDirectories: true)
 
         switch configuration.model {
-        case .whisperLocal:
+        case .whisperLocal, .whisperLocalLarge:
             resultPath = try await prepareWhisperKit(
                 configuration: configuration,
                 downloadBasePath: downloadBasePath,
@@ -297,7 +297,7 @@ final class LocalModelManager: LocalSTTModelManaging {
         }
 
         switch model {
-        case .whisperLocal:
+        case .whisperLocal, .whisperLocalLarge:
             return isUsableWhisperKitModelFolder(storagePath)
         case .senseVoiceSmall, .qwen3ASR:
             guard let layout = SherpaOnnxModelLayout.layout(for: model) else {

--- a/Sources/Typeflux/STT/LocalModelTranscriber.swift
+++ b/Sources/Typeflux/STT/LocalModelTranscriber.swift
@@ -39,7 +39,7 @@ final class LocalModelTranscriber: Transcriber {
         )
 
         switch settingsStore.localSTTModel {
-        case .whisperLocal:
+        case .whisperLocal, .whisperLocalLarge:
             let modelInfo = try await preparedModelInfo()
             let transcriber = whisperKitTranscriber(for: model, modelFolder: modelInfo.storagePath)
             return try await transcriber.transcribeStream(audioFile: audioFile, onUpdate: onUpdate)
@@ -138,7 +138,7 @@ extension LocalModelTranscriber: RecordingPrewarmingTranscriber {
     /// Eagerly initialises the WhisperKit CoreML pipeline so the first
     /// real transcription call doesn't pay the cold-start penalty.
     func prepareForRecording() async {
-        guard settingsStore.localSTTModel == .whisperLocal else {
+        guard settingsStore.localSTTModel == .whisperLocal || settingsStore.localSTTModel == .whisperLocalLarge else {
             removeWhisperKitCache(keepingCapacity: false)
             return
         }

--- a/Sources/Typeflux/STT/SherpaOnnxSupport.swift
+++ b/Sources/Typeflux/STT/SherpaOnnxSupport.swift
@@ -12,7 +12,7 @@ struct SherpaOnnxModelLayout {
         downloadSource: ModelDownloadSource = .huggingFace,
     ) -> SherpaOnnxModelLayout? {
         switch model {
-        case .whisperLocal:
+        case .whisperLocal, .whisperLocalLarge:
             return nil
         case .senseVoiceSmall:
             guard let modelRootDirectory = LocalModelDownloadCatalog.sherpaOnnxModelDirectoryName(for: model),
@@ -367,7 +367,7 @@ final class SherpaOnnxCommandLineDecoder {
     ) throws -> [String] {
         let modelDirectory = layout.modelDirectoryURL(storageURL: storageURL)
         switch model {
-        case .whisperLocal:
+        case .whisperLocal, .whisperLocalLarge:
             throw NSError(
                 domain: "SherpaOnnxCommandLineDecoder",
                 code: 4,

--- a/Sources/Typeflux/Settings/AppPreferences.swift
+++ b/Sources/Typeflux/Settings/AppPreferences.swift
@@ -78,11 +78,12 @@ enum STTProvider: String, CaseIterable, Codable {
 
 enum LocalSTTModel: String, CaseIterable, Codable {
     case whisperLocal
+    case whisperLocalLarge
     case senseVoiceSmall
     case qwen3ASR
 
     static var displayOrder: [LocalSTTModel] {
-        [.senseVoiceSmall, .whisperLocal, .qwen3ASR]
+        [.senseVoiceSmall, .whisperLocal, .whisperLocalLarge, .qwen3ASR]
     }
 
     struct Specs {
@@ -95,6 +96,8 @@ enum LocalSTTModel: String, CaseIterable, Codable {
         switch self {
         case .whisperLocal:
             L("localSTT.whisperLocal.name")
+        case .whisperLocalLarge:
+            L("localSTT.whisperLocalLarge.name")
         case .senseVoiceSmall:
             L("localSTT.senseVoiceSmall.name")
         case .qwen3ASR:
@@ -106,6 +109,8 @@ enum LocalSTTModel: String, CaseIterable, Codable {
         switch self {
         case .whisperLocal:
             LocalModelDownloadCatalog.whisperKitDefaultModelIdentifier
+        case .whisperLocalLarge:
+            "whisperkit-large-v3"
         case .senseVoiceSmall:
             "sensevoice-small-coreml"
         case .qwen3ASR:
@@ -115,7 +120,7 @@ enum LocalSTTModel: String, CaseIterable, Codable {
 
     var recommendedDownloadSource: ModelDownloadSource {
         switch self {
-        case .whisperLocal:
+        case .whisperLocal, .whisperLocalLarge:
             .huggingFace
         case .senseVoiceSmall:
             .huggingFace
@@ -128,7 +133,7 @@ enum LocalSTTModel: String, CaseIterable, Codable {
         switch self {
         case .senseVoiceSmall:
             L("settings.models.recommended")
-        case .whisperLocal, .qwen3ASR:
+        case .whisperLocal, .whisperLocalLarge, .qwen3ASR:
             nil
         }
     }
@@ -140,6 +145,12 @@ enum LocalSTTModel: String, CaseIterable, Codable {
                 summary: L("localSTT.whisperLocal.summary"),
                 parameterValue: L("localSTT.whisperLocal.parameterValue"),
                 sizeValue: L("localSTT.whisperLocal.sizeValue"),
+            )
+        case .whisperLocalLarge:
+            Specs(
+                summary: L("localSTT.whisperLocalLarge.summary"),
+                parameterValue: L("localSTT.whisperLocalLarge.parameterValue"),
+                sizeValue: L("localSTT.whisperLocalLarge.sizeValue"),
             )
         case .senseVoiceSmall:
             Specs(

--- a/Tests/TypefluxTests/AppPreferencesTests.swift
+++ b/Tests/TypefluxTests/AppPreferencesTests.swift
@@ -52,7 +52,8 @@ final class AppPreferencesTests: XCTestCase {
     }
 
     func testLocalSTTModelDefaultIdentifiers() {
-        XCTAssertEqual(LocalSTTModel.whisperLocal.defaultModelIdentifier, "whisperkit-small")
+        XCTAssertEqual(LocalSTTModel.whisperLocal.defaultModelIdentifier, "whisperkit-medium")
+        XCTAssertEqual(LocalSTTModel.whisperLocalLarge.defaultModelIdentifier, "whisperkit-large-v3")
         XCTAssertEqual(LocalSTTModel.senseVoiceSmall.defaultModelIdentifier, "sensevoice-small-coreml")
         XCTAssertTrue(LocalSTTModel.qwen3ASR.defaultModelIdentifier.contains("Qwen3-ASR"))
     }
@@ -65,6 +66,7 @@ final class AppPreferencesTests: XCTestCase {
     func testOnlySenseVoiceHasRecommendationBadge() {
         XCTAssertNotNil(LocalSTTModel.senseVoiceSmall.recommendationBadgeTitle)
         XCTAssertNil(LocalSTTModel.whisperLocal.recommendationBadgeTitle)
+        XCTAssertNil(LocalSTTModel.whisperLocalLarge.recommendationBadgeTitle)
         XCTAssertNil(LocalSTTModel.qwen3ASR.recommendationBadgeTitle)
     }
 

--- a/Tests/TypefluxTests/LocalModelTranscriberTests.swift
+++ b/Tests/TypefluxTests/LocalModelTranscriberTests.swift
@@ -324,7 +324,7 @@ final class LocalModelTranscriberTests: XCTestCase {
         let modelDirectory = root.appendingPathComponent(layout.modelRootDirectory, isDirectory: true)
         try FileManager.default.createDirectory(at: modelDirectory, withIntermediateDirectories: true)
         switch model {
-        case .whisperLocal:
+        case .whisperLocal, .whisperLocalLarge:
             break
         case .senseVoiceSmall:
             try Data("fixture".utf8).write(to: modelDirectory.appendingPathComponent("model.int8.onnx"))

--- a/Tests/TypefluxTests/SherpaOnnxModelLayoutTests.swift
+++ b/Tests/TypefluxTests/SherpaOnnxModelLayoutTests.swift
@@ -47,7 +47,7 @@ final class SherpaOnnxModelLayoutTests: XCTestCase {
     }
 
     func testDownloadCatalogProvidesLocalModelDownloadLocations() throws {
-        XCTAssertEqual(LocalModelDownloadCatalog.whisperKitDefaultModelIdentifier, "whisperkit-small")
+        XCTAssertEqual(LocalModelDownloadCatalog.whisperKitDefaultModelIdentifier, "whisperkit-medium")
         XCTAssertEqual(
             LocalModelDownloadCatalog.whisperKitModelRepository(source: .huggingFace),
             "argmaxinc/whisperkit-coreml",


### PR DESCRIPTION
## Summary

- Upgrades the default WhisperKit model from `small` (244M params, 486 MB) to `medium` (769M params, ~1.5 GB) for better transcription accuracy
- Adds a new **WhisperKit Large** model option (`whisperkit-large-v3`, 1.55B params, ~3 GB) that users can select in settings
- Updates all 5 localization files (en, zh-Hans, zh-Hant, ja, ko) with accurate specs and descriptions
- All existing tests pass; new test assertions for the updated identifiers

## Changes

- `LocalModelDownloadCatalog`: default model name `whisperkit-small` → `whisperkit-medium`
- `AppPreferences`: new `whisperLocalLarge` case in `LocalSTTModel` enum with `whisperkit-large-v3` identifier
- STT layer (`LocalModelManager`, `LocalModelTranscriber`, `AutoModelDownloadService`, `SherpaOnnxSupport`): handle `whisperLocalLarge` alongside `whisperLocal` in all switch statements
- Localization strings updated for all locales

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced WhisperKit Large model variant for enhanced speech-to-text accuracy (1.55B parameters, ~3 GB storage).

* **Updates**
  * Renamed WhisperKit to WhisperKit Medium with updated specifications (769M parameters, ~1.5 GB storage).
  * Extended localization support across English, Japanese, Korean, Simplified Chinese, and Traditional Chinese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->