### PR TITLE
Optimize local model cold starts

### DIFF
--- a/Sources/Typeflux/LLM/OllamaLLMService.swift
+++ b/Sources/Typeflux/LLM/OllamaLLMService.swift
@@ -1,6 +1,8 @@
 import Foundation
 
 final class OllamaLLMService: LLMService {
+    static let localModelKeepAlive = "15m"
+
     private let settingsStore: SettingsStore
     private let modelManager: OllamaLocalModelManager
 
@@ -64,17 +66,13 @@ final class OllamaLLMService: LLMService {
         var urlRequest = URLRequest(url: url)
         urlRequest.httpMethod = "POST"
         urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        var body: [String: Any] = [
-            "model": settingsStore.ollamaModel,
-            "stream": false,
-            "messages": [
-                ["role": "system", "content": systemPrompt],
-                ["role": "user", "content": userPrompt],
-            ],
-            "options": [
-                "temperature": 0.1,
-            ],
-        ]
+        var body = Self.makeChatRequestBody(
+            model: settingsStore.ollamaModel,
+            systemPrompt: systemPrompt,
+            userPrompt: userPrompt,
+            stream: false,
+            temperature: 0.1,
+        )
         if let schema {
             body["format"] = schema.jsonObject
         }
@@ -134,17 +132,13 @@ final class OllamaLLMService: LLMService {
                 effectiveSystemPrompt += "\n\n\(extra)"
             }
         }
-        let body: [String: Any] = [
-            "model": settingsStore.ollamaModel,
-            "stream": true,
-            "messages": [
-                ["role": "system", "content": effectiveSystemPrompt],
-                ["role": "user", "content": prompts.user],
-            ],
-            "options": [
-                "temperature": 0.4,
-            ],
-        ]
+        let body = Self.makeChatRequestBody(
+            model: settingsStore.ollamaModel,
+            systemPrompt: effectiveSystemPrompt,
+            userPrompt: prompts.user,
+            stream: true,
+            temperature: 0.4,
+        )
 
         urlRequest.httpBody = try JSONSerialization.data(withJSONObject: body)
         NetworkDebugLogger.logRequest(urlRequest)
@@ -198,6 +192,27 @@ final class OllamaLLMService: LLMService {
         }
 
         return finalText
+    }
+
+    static func makeChatRequestBody(
+        model: String,
+        systemPrompt: String,
+        userPrompt: String,
+        stream: Bool,
+        temperature: Double,
+    ) -> [String: Any] {
+        [
+            "model": model,
+            "stream": stream,
+            "keep_alive": localModelKeepAlive,
+            "messages": [
+                ["role": "system", "content": systemPrompt],
+                ["role": "user", "content": userPrompt],
+            ],
+            "options": [
+                "temperature": temperature,
+            ],
+        ]
     }
 }
 

--- a/Sources/Typeflux/STT/LocalModelTranscriber.swift
+++ b/Sources/Typeflux/STT/LocalModelTranscriber.swift
@@ -1,17 +1,40 @@
 import Foundation
 
+protocol LocalWhisperKitTranscribing: AnyObject {
+    func transcribeStream(
+        audioFile: AudioFile,
+        onUpdate: @escaping @Sendable (TranscriptionSnapshot) async -> Void,
+    ) async throws -> String
+
+    func prepare(onProgress: ((Double, String) -> Void)?) async throws
+}
+
 final class LocalModelTranscriber: Transcriber {
+    static let defaultWhisperKitKeepAliveDuration: TimeInterval = 15 * 60
+
     private let settingsStore: SettingsStore
-    private let modelManager: LocalModelManager
+    private let modelManager: LocalSTTModelManaging
+    private let whisperKitTranscriberFactory: (String, String) -> LocalWhisperKitTranscribing
+    private let whisperKitKeepAliveDuration: TimeInterval
     private let whisperKitCacheLock = NSLock()
     /// Single active WhisperKit pipeline cache keyed by model name + resolved model folder.
     /// WhisperKit keeps CoreML graphs resident after the first load, so we drop stale
     /// entries on model switch to release memory from the previously selected model.
-    private var whisperKitCache: [String: WhisperKitTranscriber] = [:]
+    private var whisperKitCache: [String: LocalWhisperKitTranscribing] = [:]
+    private var whisperKitCacheExpirationTask: Task<Void, Never>?
 
-    init(settingsStore: SettingsStore, modelManager: LocalModelManager) {
+    init(
+        settingsStore: SettingsStore,
+        modelManager: LocalSTTModelManaging,
+        whisperKitKeepAliveDuration: TimeInterval = defaultWhisperKitKeepAliveDuration,
+        whisperKitTranscriberFactory: @escaping (String, String) -> LocalWhisperKitTranscribing = { modelName, modelFolder in
+            WhisperKitTranscriber(modelName: modelName, modelFolder: modelFolder)
+        },
+    ) {
         self.settingsStore = settingsStore
         self.modelManager = modelManager
+        self.whisperKitKeepAliveDuration = whisperKitKeepAliveDuration
+        self.whisperKitTranscriberFactory = whisperKitTranscriberFactory
     }
 
     func transcribe(audioFile: AudioFile) async throws -> String {
@@ -75,34 +98,60 @@ final class LocalModelTranscriber: Transcriber {
             throw notPreparedError()
         }
 
-        try await modelManager.prepareModel(settingsStore: settingsStore)
+        try await modelManager.prepareModel(settingsStore: settingsStore, onUpdate: nil)
         guard let prepared = modelManager.preparedModelInfo(settingsStore: settingsStore) else {
             throw preparedPathUnavailableError()
         }
         return prepared
     }
 
-    private func whisperKitTranscriber(for identifier: String, modelFolder: String) -> WhisperKitTranscriber {
+    private func whisperKitTranscriber(for identifier: String, modelFolder: String) -> LocalWhisperKitTranscribing {
         let modelName = identifier.hasPrefix("whisperkit-")
             ? String(identifier.dropFirst("whisperkit-".count))
             : identifier
         let cacheKey = "\(modelName)|\(modelFolder)"
         whisperKitCacheLock.lock()
         if let cached = whisperKitCache[cacheKey] {
+            scheduleWhisperKitCacheExpiration(for: cacheKey)
             whisperKitCacheLock.unlock()
             return cached
         }
 
         whisperKitCache.removeAll(keepingCapacity: true)
-        let transcriber = WhisperKitTranscriber(modelName: modelName, modelFolder: modelFolder)
+        let transcriber = whisperKitTranscriberFactory(modelName, modelFolder)
         whisperKitCache[cacheKey] = transcriber
+        scheduleWhisperKitCacheExpiration(for: cacheKey)
         whisperKitCacheLock.unlock()
         return transcriber
     }
 
     private func removeWhisperKitCache(keepingCapacity: Bool) {
         whisperKitCacheLock.lock()
+        whisperKitCacheExpirationTask?.cancel()
+        whisperKitCacheExpirationTask = nil
         whisperKitCache.removeAll(keepingCapacity: keepingCapacity)
+        whisperKitCacheLock.unlock()
+    }
+
+    private func scheduleWhisperKitCacheExpiration(for cacheKey: String) {
+        whisperKitCacheExpirationTask?.cancel()
+        let keepAliveDuration = whisperKitKeepAliveDuration
+        whisperKitCacheExpirationTask = Task { [weak self] in
+            let nanoseconds = UInt64(max(keepAliveDuration, 0) * 1_000_000_000)
+            if nanoseconds > 0 {
+                try? await Task.sleep(nanoseconds: nanoseconds)
+            }
+            guard !Task.isCancelled else { return }
+            self?.expireWhisperKitCache(cacheKey: cacheKey)
+        }
+    }
+
+    private func expireWhisperKitCache(cacheKey: String) {
+        whisperKitCacheLock.lock()
+        whisperKitCache.removeValue(forKey: cacheKey)
+        if whisperKitCache.isEmpty {
+            whisperKitCacheExpirationTask = nil
+        }
         whisperKitCacheLock.unlock()
     }
 
@@ -145,7 +194,7 @@ extension LocalModelTranscriber: RecordingPrewarmingTranscriber {
         guard let modelInfo = modelManager.preparedModelInfo(settingsStore: settingsStore) else { return }
         let model = selectedModelIdentifier()
         let transcriber = whisperKitTranscriber(for: model, modelFolder: modelInfo.storagePath)
-        try? await transcriber.prepare()
+        try? await transcriber.prepare(onProgress: nil)
     }
 
     func cancelPreparedRecording() async {

--- a/Sources/Typeflux/STT/WhisperKitTranscriber.swift
+++ b/Sources/Typeflux/STT/WhisperKitTranscriber.swift
@@ -152,3 +152,5 @@ final class WhisperKitTranscriber: Transcriber {
         pipelineLock.unlock()
     }
 }
+
+extension WhisperKitTranscriber: LocalWhisperKitTranscribing {}

--- a/Tests/TypefluxTests/LLMServiceTests.swift
+++ b/Tests/TypefluxTests/LLMServiceTests.swift
@@ -115,4 +115,20 @@ final class LLMServiceTests: XCTestCase {
         let schema = LLMJSONSchema(name: "test", schema: [:], strict: false)
         XCTAssertFalse(schema.strict)
     }
+
+    func testOllamaChatRequestKeepsLocalModelWarmForFifteenMinutes() throws {
+        let body = OllamaLLMService.makeChatRequestBody(
+            model: "llama3",
+            systemPrompt: "system",
+            userPrompt: "user",
+            stream: true,
+            temperature: 0.4,
+        )
+
+        XCTAssertEqual(body["keep_alive"] as? String, "15m")
+        XCTAssertEqual(body["model"] as? String, "llama3")
+        XCTAssertEqual(body["stream"] as? Bool, true)
+        let options = try XCTUnwrap(body["options"] as? [String: Any])
+        XCTAssertEqual(options["temperature"] as? Double, 0.4)
+    }
 }

--- a/Tests/TypefluxTests/LocalModelTranscriberTests.swift
+++ b/Tests/TypefluxTests/LocalModelTranscriberTests.swift
@@ -169,6 +169,42 @@ final class LocalModelTranscriberTests: XCTestCase {
         XCTAssertNotNil(manager.preparedModelInfo(settingsStore: settingsStore))
     }
 
+    func testWhisperKitTranscriberCacheExpiresAfterIdleKeepAliveWindow() async throws {
+        let suiteName = "LocalModelTranscriberTests-\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let settingsStore = SettingsStore(defaults: defaults)
+        settingsStore.sttProvider = .localModel
+        settingsStore.localSTTModel = .whisperLocal
+        settingsStore.localSTTModelIdentifier = "whisperkit-base"
+        settingsStore.localSTTDownloadSource = .huggingFace
+        settingsStore.localSTTAutoSetup = false
+
+        let manager = FakeLocalSTTModelManager(preparedInfo: LocalSTTPreparedModelInfo(
+            storagePath: "/tmp/typeflux-whisperkit-test",
+            sourceDisplayName: ModelDownloadSource.huggingFace.displayName,
+        ))
+        let factory = FakeWhisperKitTranscriberFactory()
+        let transcriber = LocalModelTranscriber(
+            settingsStore: settingsStore,
+            modelManager: manager,
+            whisperKitKeepAliveDuration: 0.05,
+            whisperKitTranscriberFactory: factory.makeTranscriber(modelName:modelFolder:),
+        )
+        let audioFile = try makeTestWAVFile()
+
+        _ = try await transcriber.transcribe(audioFile: audioFile)
+        _ = try await transcriber.transcribe(audioFile: audioFile)
+        XCTAssertEqual(factory.createdTranscribers.count, 1)
+
+        try await Task.sleep(nanoseconds: 120_000_000)
+        _ = try await transcriber.transcribe(audioFile: audioFile)
+
+        XCTAssertEqual(factory.createdTranscribers.count, 2)
+        XCTAssertEqual(factory.createdTranscribers.map(\.modelName), ["base", "base"])
+    }
+
     func testSherpaLayoutRejectsASCIIExecutableFixture() throws {
         let modelFolder = try makeSherpaModelFolder(for: .qwen3ASR, useMachORuntime: false)
         let layout = try XCTUnwrap(SherpaOnnxModelLayout.layout(for: .qwen3ASR))
@@ -480,6 +516,63 @@ private final class FakeSherpaOnnxInstaller: SherpaOnnxModelInstalling {
 
         return storageURL.path
     }
+}
+
+private final class FakeLocalSTTModelManager: LocalSTTModelManaging {
+    private let preparedInfo: LocalSTTPreparedModelInfo?
+
+    init(preparedInfo: LocalSTTPreparedModelInfo?) {
+        self.preparedInfo = preparedInfo
+    }
+
+    func prepareModel(
+        settingsStore _: SettingsStore,
+        onUpdate _: (@Sendable (LocalSTTPreparationUpdate) -> Void)?,
+    ) async throws {}
+
+    func preparedModelInfo(settingsStore _: SettingsStore) -> LocalSTTPreparedModelInfo? {
+        preparedInfo
+    }
+
+    func isModelDownloaded(_: LocalSTTModel) -> Bool {
+        preparedInfo != nil
+    }
+
+    func deleteModelFiles(_: LocalSTTModel) throws {}
+
+    func storagePath(for configuration: LocalSTTConfiguration) -> String {
+        "/tmp/\(configuration.modelIdentifier)"
+    }
+}
+
+private final class FakeWhisperKitTranscriberFactory {
+    private(set) var createdTranscribers: [FakeWhisperKitTranscriber] = []
+
+    func makeTranscriber(modelName: String, modelFolder: String) -> LocalWhisperKitTranscribing {
+        let transcriber = FakeWhisperKitTranscriber(modelName: modelName, modelFolder: modelFolder)
+        createdTranscribers.append(transcriber)
+        return transcriber
+    }
+}
+
+private final class FakeWhisperKitTranscriber: LocalWhisperKitTranscribing {
+    let modelName: String
+    let modelFolder: String
+
+    init(modelName: String, modelFolder: String) {
+        self.modelName = modelName
+        self.modelFolder = modelFolder
+    }
+
+    func transcribeStream(
+        audioFile _: AudioFile,
+        onUpdate: @escaping @Sendable (TranscriptionSnapshot) async -> Void,
+    ) async throws -> String {
+        await onUpdate(TranscriptionSnapshot(text: "cached transcript", isFinal: true))
+        return "cached transcript"
+    }
+
+    func prepare(onProgress _: ((Double, String) -> Void)?) async throws {}
 }
 
 private final class StaticArchiveDownloader: SherpaOnnxArchiveDownloading {


### PR DESCRIPTION
## Summary
- keep WhisperKit local STT models cached only for a 15-minute idle window, then evict the cached transcriber so memory can be released
- add Ollama chat keep_alive=15m for local LLM requests
- add focused tests for WhisperKit cache expiry and Ollama keep_alive payloads

## Tests
- swift test --filter LocalModelTranscriberTests --filter LLMServiceTests