### PR TITLE
TYP-10: Prepare first release (v1.0.0)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,28 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build release bundle
+        run: ./scripts/build_release.sh
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: .build/release/Typeflux.zip
+          generate_release_notes: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,13 +16,21 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Install create-dmg
+        run: brew install create-dmg
+
       - name: Build release bundle
         run: ./scripts/build_release.sh
+
+      - name: Build DMG installer
+        run: ./scripts/build_dmg.sh
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          files: .build/release/Typeflux.zip
+          files: |
+            .build/release/Typeflux.zip
+            .build/release/Typeflux.dmg
           generate_release_notes: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,27 @@
+# Changelog
+
+All notable changes to Typeflux will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.0.0] - 2026-04-17
+
+### Added
+
+- Initial release of Typeflux, a macOS menu-bar voice input tool.
+- Hold-to-talk workflow with a floating overlay and real-time status.
+- Dictation mode: transcribe speech and insert text at the current cursor position.
+- Editing mode: rewrite selected text using a voice instruction.
+- Multiple STT backends: Apple Speech, Whisper API, OpenAI-compatible remote APIs, local WhisperKit, Alibaba Cloud realtime ASR, Doubao realtime ASR, and multimodal LLM transcription.
+- Multiple LLM backends: OpenAI-compatible services and Ollama for local model serving.
+- Streaming transcription previews for responsive feedback.
+- Clipboard synchronization and automatic text injection with accessibility fallback.
+- Session history with SQLite storage, audio replay, export to Markdown, and configurable retention policies.
+- Settings UI for hotkeys, STT/LLM providers, personas, model options, and appearance preferences.
+- Usage statistics and privacy-conscious local-first architecture.
+- Onboarding flow for first-time users.
+- Built-in agent loop with tool calling support and MCP client integration.
+- Automatic vocabulary monitoring for per-app customization.
+
+[1.0.0]: https://github.com/mylxsw/typeflux/releases/tag/v1.0.0

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,10 @@ test:
 coverage:
 	./scripts/coverage.sh
 
+release:
+	./scripts/build_release.sh
+
 format:
 	./scripts/format.sh
 
-.PHONY: run dev build test coverage format
+.PHONY: run dev build test coverage release format

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,10 @@ coverage:
 release:
 	./scripts/build_release.sh
 
+dmg:
+	./scripts/build_dmg.sh
+
 format:
 	./scripts/format.sh
 
-.PHONY: run dev build test coverage release format
+.PHONY: run dev build test coverage release dmg format

--- a/README.md
+++ b/README.md
@@ -102,6 +102,22 @@ For some providers, you may also need:
 - local model files for local speech or local LLM workflows
 - a valid code signing identity if you want a stable local development app identity across rebuilds
 
+## Installation
+
+### Download the latest release
+
+The easiest way to install Typeflux is to download the pre-built `.app` bundle from the [Releases](https://github.com/mylxsw/typeflux/releases) page:
+
+1. Download `Typeflux.zip` from the latest release.
+2. Unzip the archive.
+3. Drag `Typeflux.app` to your **Applications** folder.
+4. Launch Typeflux from Applications.
+5. Grant the requested permissions (Microphone, Accessibility, and Speech Recognition) when prompted.
+
+### Build from source
+
+If you prefer to build from source, follow the steps below.
+
 ## Getting Started
 
 ### Build

--- a/app/Info.plist
+++ b/app/Info.plist
@@ -19,7 +19,7 @@
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.1.0</string>
+    <string>1.0.0</string>
     <key>CFBundleVersion</key>
     <string>1</string>
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,0 +1,150 @@
+# Typeflux Release Guide
+
+This document explains how to build, sign, package, and distribute Typeflux as a macOS `.app` bundle using a DMG installer.
+
+---
+
+## Prerequisites
+
+- macOS 13 or later
+- Xcode with Swift 5.9+ toolchain
+- A valid Apple Developer ID certificate for notarized distribution (recommended)
+- `create-dmg` installed (see installation below)
+
+### Install `create-dmg`
+
+\`\`\`bash
+brew install create-dmg
+\`\`\`
+
+---
+
+## 1. Build the Release App Bundle
+
+Use the provided release script to build a production-ready `.app` bundle:
+
+\`\`\`bash
+make release
+\`\`\`
+
+Or run the script directly:
+
+\`\`\`bash
+./scripts/build_release.sh
+\`\`\`
+
+Output:
+- `.build/release/Typeflux.app` — the signed app bundle
+- `.build/release/Typeflux.zip` — a ZIP archive for quick distribution
+
+### Code Signing
+
+The release script will automatically sign the bundle if a signing identity is available.
+
+- **Ad-hoc signing** (local testing): the script signs with `-` automatically.
+- **Developer ID signing** (distribution): export your identity before building:
+
+\`\`\`bash
+export CODESIGN_IDENTITY="Developer ID Application: Your Name (TEAMID)"
+make release
+\`\`\`
+
+---
+
+## 2. Create a DMG Installer
+
+Run the DMG build script after the release app bundle is ready:
+
+\`\`\`bash
+./scripts/build_dmg.sh
+\`\`\`
+
+Output:
+- `.build/release/Typeflux.dmg` — the final distributable DMG
+
+### What the DMG script does
+
+1. Creates a temporary staging folder.
+2. Copies the signed `Typeflux.app` into it.
+3. Creates a symbolic link to `/Applications` for drag-and-drop installation.
+4. Uses `create-dmg` to produce a polished DMG with:
+   - Window title and icon size
+   - Drag-and-drop layout (app on the left, Applications alias on the right)
+   - Code signing of the DMG itself (if `CODESIGN_IDENTITY` is set)
+
+### Customizing the DMG appearance
+
+Edit `scripts/build_dmg.sh` to change:
+
+- Window size and position
+- Background image or color
+- Icon arrangement
+
+---
+
+## 3. Notarization (Recommended for Distribution)
+
+If you are distributing outside the Mac App Store, notarize the DMG with Apple:
+
+\`\`\`bash
+xcrun notarytool submit .build/release/Typeflux.dmg \
+  --keychain-profile "AC_PASSWORD" \
+  --wait
+\`\`\`
+
+After successful notarization, staple the ticket:
+
+\`\`\`bash
+xcrun stapler staple .build/release/Typeflux.dmg
+\`\`\`
+
+> **Note:** Replace `"AC_PASSWORD"` with your actual notarytool keychain profile name.
+
+---
+
+## 4. Distribute the Release
+
+### GitHub Releases (Automated)
+
+The repository includes `.github/workflows/release.yml`. Pushing a version tag triggers the workflow:
+
+\`\`\`bash
+git tag v1.0.0
+git push origin v1.0.0
+\`\`\`
+
+The workflow currently uploads `Typeflux.zip`. To also upload the DMG, extend the workflow to run `build_dmg.sh` and attach the resulting `.dmg` file.
+
+### Manual Distribution
+
+Upload the final artifacts to your chosen distribution channel:
+
+- **GitHub Releases**: attach both `Typeflux.dmg` and `Typeflux.zip`
+- **Direct download**: host `Typeflux.dmg` on your website or CDN
+- **Homebrew Cask** (optional): submit a cask formula pointing to the DMG URL
+
+---
+
+## 5. Release Checklist
+
+- [ ] Version bumped in `app/Info.plist`
+- [ ] `CHANGELOG.md` updated
+- [ ] `swift build` passes
+- [ ] `swift test` passes
+- [ ] Release app bundle signed (`Typeflux.app`)
+- [ ] DMG created and tested on a clean macOS install
+- [ ] DMG notarized and stapled (if distributing externally)
+- [ ] Git tag pushed (`vX.Y.Z`)
+- [ ] GitHub Release drafted and published
+- [ ] Download links updated in `README.md`
+
+---
+
+## Quick Reference
+
+| Step | Command | Output |
+|------|---------|--------|
+| Build release app | `make release` | `.build/release/Typeflux.app` |
+| Create DMG | `./scripts/build_dmg.sh` | `.build/release/Typeflux.dmg` |
+| Notarize DMG | `xcrun notarytool submit ...` | — |
+| Trigger GitHub Release | `git push origin v1.0.0` | Release artifact uploaded |

--- a/scripts/build_dmg.sh
+++ b/scripts/build_dmg.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BUILD_DIR="${ROOT_DIR}/.build/release"
+APP_NAME="Typeflux"
+APP_BUNDLE="${BUILD_DIR}/${APP_NAME}.app"
+DMG_NAME="${APP_NAME}.dmg"
+DMG_PATH="${BUILD_DIR}/${DMG_NAME}"
+STAGING_DIR="${BUILD_DIR}/dmg-staging"
+
+if ! command -v create-dmg >/dev/null 2>&1; then
+  echo "Error: create-dmg is not installed. Install it with: brew install create-dmg"
+  exit 1
+fi
+
+if [[ ! -d "$APP_BUNDLE" ]]; then
+  echo "Error: $APP_BUNDLE not found. Run './scripts/build_release.sh' first."
+  exit 1
+fi
+
+echo "Creating DMG for $APP_NAME..."
+
+rm -rf "$STAGING_DIR"
+mkdir -p "$STAGING_DIR"
+
+cp -R "$APP_BUNDLE" "$STAGING_DIR/"
+ln -s /Applications "$STAGING_DIR/Applications"
+
+rm -f "$DMG_PATH"
+
+create-dmg \
+  --volname "$APP_NAME" \
+  --window-size 800 400 \
+  --icon-size 100 \
+  --app-drop-link 600 185 \
+  --icon "${APP_NAME}.app" 200 185 \
+  "$DMG_PATH" \
+  "$STAGING_DIR"
+
+rm -rf "$STAGING_DIR"
+
+# Sign the DMG if a signing identity is available
+if [[ -n "${CODESIGN_IDENTITY:-}" ]] && command -v codesign >/dev/null 2>&1; then
+  codesign --sign "$CODESIGN_IDENTITY" "$DMG_PATH"
+  echo "Signed DMG with identity: $CODESIGN_IDENTITY"
+fi
+
+echo "DMG created: $DMG_PATH"

--- a/scripts/build_release.sh
+++ b/scripts/build_release.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BUILD_DIR="${ROOT_DIR}/.build/release"
+APP_NAME="Typeflux"
+APP_BUNDLE="${BUILD_DIR}/${APP_NAME}.app"
+
+echo "Building Typeflux release bundle..."
+
+swift build --package-path "$ROOT_DIR" -c release
+
+BIN_DIR="$(swift build --package-path "$ROOT_DIR" -c release --show-bin-path)"
+BIN="$BIN_DIR/Typeflux"
+RESOURCE_BUNDLE="$BIN_DIR/Typeflux_Typeflux.bundle"
+
+rm -rf "$APP_BUNDLE"
+mkdir -p "$APP_BUNDLE/Contents/MacOS"
+mkdir -p "$APP_BUNDLE/Contents/Resources"
+
+cp "$ROOT_DIR/app/Info.plist" "$APP_BUNDLE/Contents/Info.plist"
+cp "$BIN" "$APP_BUNDLE/Contents/MacOS/Typeflux"
+cp "$ROOT_DIR/app/Typeflux.icns" "$APP_BUNDLE/Contents/Resources/Typeflux.icns"
+cp -R "$RESOURCE_BUNDLE" "$APP_BUNDLE/Contents/Resources/Typeflux_Typeflux.bundle"
+
+chmod +x "$APP_BUNDLE/Contents/MacOS/Typeflux"
+
+# Sign the bundle if an identity is available
+if [[ -n "${CODESIGN_IDENTITY:-}" ]] && command -v codesign >/dev/null 2>&1; then
+  codesign --force --deep --sign "$CODESIGN_IDENTITY" --identifier "dev.typeflux" "$APP_BUNDLE"
+  echo "Signed with identity: $CODESIGN_IDENTITY"
+elif command -v codesign >/dev/null 2>&1; then
+  codesign --force --deep --sign - --identifier "dev.typeflux" "$APP_BUNDLE"
+  echo "Signed with ad-hoc identity"
+fi
+
+# Create a ZIP archive for distribution
+ZIP_PATH="${BUILD_DIR}/${APP_NAME}.zip"
+rm -f "$ZIP_PATH"
+(
+  cd "$BUILD_DIR"
+  ditto -c -k --sequesterRsrc --keepParent "$APP_NAME.app" "$APP_NAME.zip"
+)
+
+echo "Release bundle created: $APP_BUNDLE"
+echo "Release archive created: $ZIP_PATH"


### PR DESCRIPTION
## TYP-10: Prepare first release (v1.0.0)

### Summary of Changes

This PR prepares Typeflux for its first public release by adding packaging automation, documentation, and versioning updates.

- **Added `CHANGELOG.md`** documenting all features in the initial v1.0.0 release.
- **Added `scripts/build_release.sh`** to build and code-sign a production `.app` bundle and a ZIP archive.
- **Added `scripts/build_dmg.sh`** to create a polished DMG installer with drag-and-drop layout (requires `create-dmg`).
- **Added `docs/RELEASE.md`** — a comprehensive release guide covering:
  - Build prerequisites
  - Code signing (ad-hoc and Developer ID)
  - DMG creation
  - Apple notarization and stapling
  - GitHub Releases distribution
  - Release checklist
- **Updated `.github/workflows/release.yml`** to automatically build and upload both `Typeflux.zip` and `Typeflux.dmg` when a `v*` tag is pushed.
- **Updated `Makefile`** with `release` and `dmg` targets.
- **Updated `README.md`** with end-user installation instructions and a link to the Releases page.
- **Bumped `CFBundleShortVersionString`** in `app/Info.plist` from `0.1.0` to `1.0.0`.

### How to Test

1. Run `swift build` — should compile successfully.
2. Run `swift test` — all tests should pass.
3. Run `make release` — verify `.build/release/Typeflux.app` and `.build/release/Typeflux.zip` are created.
4. If `create-dmg` is installed (`brew install create-dmg`), run `make dmg` — verify `.build/release/Typeflux.dmg` is created.
5. Inspect `docs/RELEASE.md` for clarity and completeness.

### Publishing the Release

After this PR is merged, publish v1.0.0 by running:

```bash
git checkout main
git pull
git tag v1.0.0
git push origin v1.0.0
```

The GitHub Actions workflow will then build and attach the release artifacts automatically.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added installation guide with step-by-step instructions for pre-built app bundles.
  * Introduced comprehensive changelog documenting v1.0.0 features and updates.

* **Chores**
  * Bumped app version to 1.0.0.
  * Enabled automated release distribution with DMG installer and ZIP archive.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->