### PR TITLE
feat: complete macOS release signing workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,11 +19,56 @@ jobs:
       - name: Install create-dmg
         run: brew install create-dmg
 
-      - name: Build release bundle
-        run: ./scripts/build_release.sh
+      - name: Import Developer ID certificate
+        env:
+          CERTIFICATE_BASE64: ${{ secrets.APPLE_CERTIFICATE_BASE64 }}
+          CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+        run: |
+          KEYCHAIN_PATH="$RUNNER_TEMP/signing.keychain-db"
+          KEYCHAIN_PASSWORD="$(openssl rand -hex 16)"
 
-      - name: Build DMG installer
-        run: ./scripts/build_dmg.sh
+          # Decode certificate
+          echo "$CERTIFICATE_BASE64" | base64 --decode -o "$RUNNER_TEMP/certificate.p12"
+
+          # Create a temporary keychain
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+
+          # Import certificate into the keychain
+          security import "$RUNNER_TEMP/certificate.p12" \
+            -P "$CERTIFICATE_PASSWORD" \
+            -A -t cert -f pkcs12 \
+            -k "$KEYCHAIN_PATH"
+
+          # Allow codesign to access the keychain without prompting
+          security set-key-partition-list \
+            -S apple-tool:,apple: \
+            -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+
+          # Make it the default and add to search list
+          security list-keychains -d user -s "$KEYCHAIN_PATH" $(security list-keychains -d user | tr -d '"')
+
+          echo "KEYCHAIN_PATH=$KEYCHAIN_PATH" >> "$GITHUB_ENV"
+          echo "KEYCHAIN_PASSWORD=$KEYCHAIN_PASSWORD" >> "$GITHUB_ENV"
+
+      - name: Store notarytool credentials
+        env:
+          NOTARYTOOL_APPLE_ID: ${{ secrets.NOTARYTOOL_APPLE_ID }}
+          NOTARYTOOL_PASSWORD: ${{ secrets.NOTARYTOOL_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          xcrun notarytool store-credentials "typeflux-notary" \
+            --apple-id "$NOTARYTOOL_APPLE_ID" \
+            --password "$NOTARYTOOL_PASSWORD" \
+            --team-id "$APPLE_TEAM_ID" \
+            --keychain "$KEYCHAIN_PATH"
+
+      - name: Build, sign, notarize, and staple
+        env:
+          CODESIGN_IDENTITY: ${{ secrets.CODESIGN_IDENTITY }}
+          NOTARY_PROFILE: typeflux-notary
+        run: ./scripts/release_notarize.sh
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
@@ -34,3 +79,8 @@ jobs:
           generate_release_notes: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Clean up keychain
+        if: always()
+        run: |
+          security delete-keychain "$KEYCHAIN_PATH" || true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,16 +1,33 @@
 name: Release
 
 on:
-  push:
-    tags:
-      - 'v*'
+  release:
+    types:
+      - published
+
+concurrency:
+  group: release-${{ github.event.release.tag_name || github.ref }}
+  cancel-in-progress: false
 
 permissions:
   contents: write
 
 jobs:
-  build:
+  build-signed-macos-app:
     runs-on: macos-latest
+    timeout-minutes: 60
+    env:
+      APP_NAME: Typeflux
+      APPLE_CERTIFICATE_PATH: ${{ runner.temp }}/developer-id-application.p12
+      BUILD_DIR: .build/release
+      CODESIGN_IDENTITY: ${{ secrets.CODESIGN_IDENTITY }}
+      KEYCHAIN_PATH: ${{ runner.temp }}/typeflux-release.keychain-db
+      NOTARY_KEYCHAIN: ${{ runner.temp }}/typeflux-release.keychain-db
+      NOTARY_PROFILE: typeflux-release
+      NOTARYTOOL_APPLE_ID: ${{ secrets.NOTARYTOOL_APPLE_ID }}
+      NOTARYTOOL_PASSWORD: ${{ secrets.NOTARYTOOL_PASSWORD }}
+      NOTARY_SUBMIT_RETRIES: 3
+      NOTARY_POLL_INTERVAL_SECONDS: 15
 
     steps:
       - name: Checkout
@@ -21,66 +38,72 @@ jobs:
 
       - name: Import Developer ID certificate
         env:
-          CERTIFICATE_BASE64: ${{ secrets.APPLE_CERTIFICATE_BASE64 }}
-          CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_CERTIFICATE_BASE64: ${{ secrets.APPLE_CERTIFICATE_BASE64 }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
         run: |
-          KEYCHAIN_PATH="$RUNNER_TEMP/signing.keychain-db"
-          KEYCHAIN_PASSWORD="$(openssl rand -hex 16)"
+          set -euo pipefail
 
-          # Decode certificate
-          echo "$CERTIFICATE_BASE64" | base64 --decode -o "$RUNNER_TEMP/certificate.p12"
+          KEYCHAIN_PASSWORD="$(openssl rand -hex 32)"
+          echo "::add-mask::$KEYCHAIN_PASSWORD"
 
-          # Create a temporary keychain
+          echo "$APPLE_CERTIFICATE_BASE64" | base64 --decode > "$APPLE_CERTIFICATE_PATH"
+
           security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
           security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
           security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
-
-          # Import certificate into the keychain
-          security import "$RUNNER_TEMP/certificate.p12" \
-            -P "$CERTIFICATE_PASSWORD" \
-            -A -t cert -f pkcs12 \
+          security import "$APPLE_CERTIFICATE_PATH" \
+            -P "$APPLE_CERTIFICATE_PASSWORD" \
+            -A \
+            -t cert \
+            -f pkcs12 \
             -k "$KEYCHAIN_PATH"
-
-          # Allow codesign to access the keychain without prompting
-          security set-key-partition-list \
-            -S apple-tool:,apple: \
-            -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
-
-          # Make it the default and add to search list
           security list-keychains -d user -s "$KEYCHAIN_PATH" $(security list-keychains -d user | tr -d '"')
+          security set-key-partition-list \
+            -S apple-tool:,apple:,codesign: \
+            -s \
+            -k "$KEYCHAIN_PASSWORD" \
+            "$KEYCHAIN_PATH"
 
-          echo "KEYCHAIN_PATH=$KEYCHAIN_PATH" >> "$GITHUB_ENV"
-          echo "KEYCHAIN_PASSWORD=$KEYCHAIN_PASSWORD" >> "$GITHUB_ENV"
-
-      - name: Store notarytool credentials
+      - name: Configure Apple notarization profile
         env:
-          NOTARYTOOL_APPLE_ID: ${{ secrets.NOTARYTOOL_APPLE_ID }}
-          NOTARYTOOL_PASSWORD: ${{ secrets.NOTARYTOOL_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: |
-          xcrun notarytool store-credentials "typeflux-notary" \
+          set -euo pipefail
+
+          xcrun notarytool store-credentials "$NOTARY_PROFILE" \
             --apple-id "$NOTARYTOOL_APPLE_ID" \
-            --password "$NOTARYTOOL_PASSWORD" \
             --team-id "$APPLE_TEAM_ID" \
+            --password "$NOTARYTOOL_PASSWORD" \
             --keychain "$KEYCHAIN_PATH"
 
-      - name: Build, sign, notarize, and staple
-        env:
-          CODESIGN_IDENTITY: ${{ secrets.CODESIGN_IDENTITY }}
-          NOTARY_PROFILE: typeflux-notary
+      - name: Build, sign, notarize, staple, and package
         run: ./scripts/release_notarize.sh
 
-      - name: Create GitHub Release
+      - name: Verify release artifacts
+        run: |
+          set -euo pipefail
+
+          test -f "$BUILD_DIR/$APP_NAME.dmg"
+          test -f "$BUILD_DIR/$APP_NAME.zip"
+          codesign --verify --deep --strict --verbose=2 "$BUILD_DIR/$APP_NAME.app"
+          spctl --assess --type execute --verbose=4 "$BUILD_DIR/$APP_NAME.app"
+          xcrun stapler validate "$BUILD_DIR/$APP_NAME.dmg"
+
+      - name: Upload release assets
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ github.event.release.tag_name }}
           files: |
             .build/release/Typeflux.zip
             .build/release/Typeflux.dmg
-          generate_release_notes: true
+          fail_on_unmatched_files: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Clean up keychain
+      - name: Cleanup signing keychain
         if: always()
         run: |
+          set -euo pipefail
+
           security delete-keychain "$KEYCHAIN_PATH" || true
+          rm -f "$APPLE_CERTIFICATE_PATH"

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -6,6 +6,84 @@ For a command-by-command overview, see [MAKE_COMMANDS.md](./MAKE_COMMANDS.md).
 
 ## Recommended Release Path
 
+For official GitHub releases, publish a GitHub Release. The `Release` workflow
+then builds the macOS app, signs it with a Developer ID Application certificate,
+notarizes it with Apple, packages it into a DMG, and uploads `Typeflux.dmg` and
+`Typeflux.zip` as release assets.
+
+For local release validation, use the one-step notarized release command:
+
+```bash
+make release-notarize
+```
+
+## GitHub Actions Release Workflow
+
+The workflow in `.github/workflows/release.yml` runs when a GitHub Release is
+published. It requires the repository secrets below.
+
+### Required GitHub Actions Secrets
+
+| Secret | What it is | Format |
+| --- | --- | --- |
+| `APPLE_CERTIFICATE_BASE64` | Base64-encoded `.p12` export of the Developer ID Application certificate and private key used for macOS distribution signing. | Single-line base64 text |
+| `APPLE_CERTIFICATE_PASSWORD` | Password used when exporting the `.p12` certificate from Keychain Access. | Plain secret value |
+| `APPLE_TEAM_ID` | Apple Developer Team ID for the account that owns the certificate and notarization credentials. | 10-character team ID |
+| `CODESIGN_IDENTITY` | Exact signing identity name used by `codesign`. | `Developer ID Application: Name (TEAMID)` |
+| `NOTARYTOOL_APPLE_ID` | Apple ID email address used for notarization. | Apple ID email |
+| `NOTARYTOOL_PASSWORD` | App-specific password for the Apple ID used by `notarytool`. | App-specific password |
+
+### Creating the Certificate Secret
+
+1. In Apple Developer, open **Certificates, Identifiers & Profiles**.
+2. Create or select a **Developer ID Application** certificate for the target team.
+3. Install the certificate on a trusted Mac so it appears in Keychain Access with
+   its private key.
+4. In Keychain Access, select the certificate and private key together.
+5. Choose **File > Export Items...** and save as `developer-id-application.p12`.
+6. Set a strong export password. Save this password as
+   `APPLE_CERTIFICATE_PASSWORD`.
+7. Encode the `.p12` file:
+
+```bash
+base64 -i developer-id-application.p12 | pbcopy
+```
+
+8. Save the copied single-line value as `APPLE_CERTIFICATE_BASE64`.
+
+### Finding the Signing Identity
+
+On the Mac that has the certificate installed, run:
+
+```bash
+security find-identity -v -p codesigning
+```
+
+Copy the exact Developer ID Application identity, for example:
+
+```text
+Developer ID Application: Example Company, Inc. (ABCDE12345)
+```
+
+Save that value as `CODESIGN_IDENTITY`.
+
+### Creating Notarization Credentials
+
+1. Confirm the Apple account has access to the same Apple Developer team.
+2. Find the team ID in Apple Developer under **Membership details**. Save it as
+   `APPLE_TEAM_ID`.
+3. Create an app-specific password at
+   `https://account.apple.com/account/manage`.
+4. Save the Apple ID email as `NOTARYTOOL_APPLE_ID`.
+5. Save the app-specific password as `NOTARYTOOL_PASSWORD`.
+
+The workflow stores those credentials in a temporary runner keychain profile
+named `typeflux-release` before calling `scripts/release_notarize.sh`.
+The temporary keychain password is generated inside the workflow run and does
+not need to be configured as a repository secret.
+
+## Local Release Path
+
 The preferred release flow is the one-step notarized release command:
 
 ```bash
@@ -52,11 +130,14 @@ Optional overrides:
 export CODESIGN_IDENTITY="$APPLE_DISTRIBUTION"
 export NOTARY_SUBMIT_RETRIES=3
 export NOTARY_POLL_INTERVAL_SECONDS=15
+export NOTARY_KEYCHAIN="/path/to/custom.keychain-db"
 ```
 
 Notes:
 
 - `CODESIGN_IDENTITY` takes priority over `APPLE_DISTRIBUTION`
+- `NOTARY_KEYCHAIN` is optional and only needed when the notary profile lives in
+  a non-default keychain
 - the release script retries transient notarization submission failures
 - if Apple returns a submission ID and the local client times out afterward, the script continues tracking that submission instead of restarting blindly
 

--- a/scripts/build_release.sh
+++ b/scripts/build_release.sh
@@ -6,6 +6,15 @@ BUILD_DIR="${ROOT_DIR}/.build/release"
 APP_NAME="Typeflux"
 APP_BUNDLE="${BUILD_DIR}/${APP_NAME}.app"
 APP_EXECUTABLE="${APP_BUNDLE}/Contents/MacOS/${APP_NAME}"
+ZIP_PATH="${BUILD_DIR}/${APP_NAME}.zip"
+
+create_zip_archive() {
+  rm -f "$ZIP_PATH"
+  (
+    cd "$BUILD_DIR"
+    ditto -c -k --sequesterRsrc --keepParent "$APP_NAME.app" "$APP_NAME.zip"
+  )
+}
 
 echo "Building Typeflux release bundle..."
 
@@ -51,13 +60,7 @@ elif command -v codesign >/dev/null 2>&1; then
   echo "Signed with ad-hoc identity"
 fi
 
-# Create a ZIP archive for distribution
-ZIP_PATH="${BUILD_DIR}/${APP_NAME}.zip"
-rm -f "$ZIP_PATH"
-(
-  cd "$BUILD_DIR"
-  ditto -c -k --sequesterRsrc --keepParent "$APP_NAME.app" "$APP_NAME.zip"
-)
+create_zip_archive
 
 echo "Release bundle created: $APP_BUNDLE"
 echo "Release archive created: $ZIP_PATH"

--- a/scripts/release_notarize.sh
+++ b/scripts/release_notarize.sh
@@ -6,8 +6,10 @@ BUILD_DIR="${ROOT_DIR}/.build/release"
 APP_NAME="Typeflux"
 APP_BUNDLE="${BUILD_DIR}/${APP_NAME}.app"
 DMG_PATH="${BUILD_DIR}/${APP_NAME}.dmg"
+ZIP_PATH="${BUILD_DIR}/${APP_NAME}.zip"
 NOTARY_POLL_INTERVAL_SECONDS="${NOTARY_POLL_INTERVAL_SECONDS:-15}"
 NOTARY_SUBMIT_RETRIES="${NOTARY_SUBMIT_RETRIES:-3}"
+NOTARY_KEYCHAIN="${NOTARY_KEYCHAIN:-}"
 
 CODESIGN_IDENTITY="${CODESIGN_IDENTITY:-${APPLE_DISTRIBUTION:-}}"
 export CODESIGN_IDENTITY
@@ -40,6 +42,19 @@ parse_notary_field() {
   awk -F': ' -v key="$field_name" '$1 ~ key"$" {print $2; exit}' <<<"$raw_output"
 }
 
+run_notarytool() {
+  local subcommand="$1"
+  shift
+
+  local args=("$subcommand" "$@" --keychain-profile "$NOTARY_PROFILE")
+
+  if [[ -n "$NOTARY_KEYCHAIN" ]]; then
+    args+=(--keychain "$NOTARY_KEYCHAIN")
+  fi
+
+  xcrun notarytool "${args[@]}"
+}
+
 submit_for_notarization() {
   local attempt submit_log submit_output submission_id
 
@@ -47,7 +62,7 @@ submit_for_notarization() {
     log "Submitting ${DMG_PATH} for notarization (attempt ${attempt}/${NOTARY_SUBMIT_RETRIES})..."
     submit_log="$(mktemp)"
 
-    if xcrun notarytool submit "$DMG_PATH" --keychain-profile "$NOTARY_PROFILE" 2>&1 | tee "$submit_log" >&2; then
+    if run_notarytool submit "$DMG_PATH" 2>&1 | tee "$submit_log" >&2; then
       submit_output="$(<"$submit_log")"
       submission_id="$(parse_notary_field "id" "$submit_output")"
       rm -f "$submit_log"
@@ -81,7 +96,7 @@ wait_for_notarization() {
 
   while true; do
     info_output="$(
-      xcrun notarytool info "$submission_id" --keychain-profile "$NOTARY_PROFILE" 2>&1
+      run_notarytool info "$submission_id" 2>&1
     )"
     submission_status="$(parse_notary_field "status" "$info_output")"
 
@@ -98,7 +113,7 @@ wait_for_notarization() {
       *)
         echo "$info_output" >&2
         log "Fetching notarization log for ${submission_id}..."
-        xcrun notarytool log "$submission_id" --keychain-profile "$NOTARY_PROFILE" || true
+        run_notarytool log "$submission_id" || true
         fail "Notarization failed with status: ${submission_status}"
         ;;
     esac
@@ -113,6 +128,15 @@ staple_artifacts() {
   log "Stapling notarization ticket to ${DMG_PATH}..."
   xcrun stapler staple "$DMG_PATH"
   xcrun stapler validate "$DMG_PATH"
+}
+
+refresh_zip_archive() {
+  log "Refreshing ZIP archive after stapling..."
+  rm -f "$ZIP_PATH"
+  (
+    cd "$BUILD_DIR"
+    ditto -c -k --sequesterRsrc --keepParent "$APP_NAME.app" "$APP_NAME.zip"
+  )
 }
 
 main() {
@@ -139,9 +163,11 @@ main() {
 
   wait_for_notarization "$submission_id"
   staple_artifacts
+  refresh_zip_archive
 
   log "Release workflow completed successfully."
   log "App: ${APP_BUNDLE}"
+  log "ZIP: ${ZIP_PATH}"
   log "DMG: ${DMG_PATH}"
 }
 


### PR DESCRIPTION
## Summary

References [TYP-16](/TYP/issues/TYP-16).

- Update `.github/workflows/release.yml` to run on GitHub Release publish, import the Developer ID certificate, configure `notarytool`, build/sign/notarize/staple/package the macOS app, verify artifacts, and upload `Typeflux.dmg` plus `Typeflux.zip`.
- Refresh the release ZIP after stapling so the uploaded ZIP contains the stapled app bundle.
- Document every required GitHub Actions secret and the setup steps for certificate export, signing identity lookup, and notarization credentials.

## Test Instructions

- `bash -n scripts/build_release.sh scripts/build_dmg.sh scripts/release_notarize.sh`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "release.yml parses"'`
- `git diff --check`
- `swift build`
- `make release`
- `swift test`

## Screenshots

Not applicable; release automation and documentation only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow to trigger from GitHub Release events instead of git tags.
  * Implemented automatic code signing and Apple notarization for macOS releases.
  * Added comprehensive artifact verification and validation steps.
  * Refactored release build scripts for improved maintainability.

* **Documentation**
  * Expanded release process documentation with detailed setup instructions and required credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->