### PR TITLE
fix: add local model download source mirrors

### DIFF
--- a/Sources/Typeflux/Resources/en.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/en.lproj/Localizable.strings
@@ -463,6 +463,8 @@
 "settings.models.localModel" = "Local Model";
 "settings.models.localModels" = "Local Models";
 "settings.models.localSpeechModels" = "Local Speech Models";
+"settings.models.downloadSource" = "Download Source";
+"settings.models.downloadSourceHint" = "Choose the source before preparing or redownloading local speech models.";
 "settings.models.appleSpeech.quickest" = "Apple Speech is the quickest local option and requires no additional setup or downloads.";
 "settings.models.multimodalLLM.audioHint" = "Audio is base64-encoded and sent as input_audio to the configured chat/completions endpoint. When a persona is active, transcription and rewriting happen in a single call.";
 "settings.models.aliCloud.getAPIKey" = "Get API Key";

--- a/Sources/Typeflux/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/ja.lproj/Localizable.strings
@@ -461,6 +461,8 @@
 "settings.models.localModel" = "ローカルモデル";
 "settings.models.localModels" = "ローカルモデル";
 "settings.models.localSpeechModels" = "ローカル音声モデル";
+"settings.models.downloadSource" = "ダウンロード元";
+"settings.models.downloadSourceHint" = "ローカル音声モデルを準備または再ダウンロードする前に、ダウンロード元を選択します。";
 "settings.models.appleSpeech.quickest" = "Apple Speech は最も速いローカル オプションであり、追加のセットアップやダウンロードは必要ありません。";
 "settings.models.multimodalLLM.audioHint" = "音声はbase64でエンコードされ、input_audioとして構成されたチャット/補完エンドポイントに送信されます。ペルソナがアクティブな場合、転写と書き換えは 1 回の呼び出しで行われます。";
 "settings.models.aliCloud.getAPIKey" = "API Key を取得";

--- a/Sources/Typeflux/Resources/ko.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/ko.lproj/Localizable.strings
@@ -461,6 +461,8 @@
 "settings.models.localModel" = "로컬 모델";
 "settings.models.localModels" = "지역 모델";
 "settings.models.localSpeechModels" = "지역 음성 모델";
+"settings.models.downloadSource" = "다운로드 소스";
+"settings.models.downloadSourceHint" = "로컬 음성 모델을 준비하거나 다시 다운로드하기 전에 다운로드 소스를 선택합니다.";
 "settings.models.appleSpeech.quickest" = "Apple Speech은 가장 빠른 로컬 옵션이며 추가 설정이나 다운로드가 필요하지 않습니다.";
 "settings.models.multimodalLLM.audioHint" = "오디오는 base64로 인코딩되어 구성된 채팅/완료 엔드포인트에 input_audio로 전송됩니다. 페르소나가 활성화되면 단일 호출로 전사 및 재작성이 발생합니다.";
 "settings.models.aliCloud.getAPIKey" = "API Key 받기";

--- a/Sources/Typeflux/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/zh-Hans.lproj/Localizable.strings
@@ -463,6 +463,8 @@
 "settings.models.localModel" = "本地模型";
 "settings.models.localModels" = "本地模型";
 "settings.models.localSpeechModels" = "本地语音模型";
+"settings.models.downloadSource" = "下载源";
+"settings.models.downloadSourceHint" = "在准备或重新下载本地语音模型前选择下载来源。";
 "settings.models.appleSpeech.quickest" = "Apple Speech 是最快的本地选项，无需额外准备或下载。";
 "settings.models.multimodalLLM.audioHint" = "音频会以 base64 编码，通过 input_audio 发送到配置的 chat/completions 接口。启用人设时，转写与改写会在一次调用中完成。";
 "settings.models.aliCloud.getAPIKey" = "获取 API Key";

--- a/Sources/Typeflux/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/zh-Hant.lproj/Localizable.strings
@@ -461,6 +461,8 @@
 "settings.models.localModel" = "本地模型";
 "settings.models.localModels" = "本地模型";
 "settings.models.localSpeechModels" = "本地語音模型";
+"settings.models.downloadSource" = "下載源";
+"settings.models.downloadSourceHint" = "在準備或重新下載本地語音模型前選擇下載來源。";
 "settings.models.appleSpeech.quickest" = "Apple Speech 是最快的本地選項，無需額外準備或下載。";
 "settings.models.multimodalLLM.audioHint" = "音訊會以 base64 編碼，透過 input_audio 傳送到配置的 chat/completions 介面。啟用人設時，轉寫與改寫會在一次呼叫中完成。";
 "settings.models.aliCloud.getAPIKey" = "取得 API Key";

--- a/Sources/Typeflux/STT/LocalModelDownloadCatalog.swift
+++ b/Sources/Typeflux/STT/LocalModelDownloadCatalog.swift
@@ -8,6 +8,10 @@ enum LocalModelDownloadCatalog {
     private static let sherpaOnnxRuntimeRootDirectory = "sherpa-onnx-v1.12.35-osx-universal2-shared-no-tts"
     private static let senseVoiceRootDirectory = "sherpa-onnx-sense-voice-zh-en-ja-ko-yue-2024-07-17"
     private static let qwen3ASRRootDirectory = "sherpa-onnx-qwen3-asr-0.6B-int8-2026-03-25"
+    private static let senseVoiceMirrorRepositoryID =
+        "csukuangfj/sherpa-onnx-sense-voice-zh-en-ja-ko-yue-2024-07-17"
+    private static let qwen3ASROnnxModelScopeRepositoryID = "zengshuishui/Qwen3-ASR-onnx"
+    private static let qwen3ASRTokenizerModelScopeRepositoryID = "Qwen/Qwen3-ASR-0.6B"
 
     static var whisperKitDefaultModelIdentifier: String {
         whisperKitDefaultModelName
@@ -45,13 +49,80 @@ enum LocalModelDownloadCatalog {
     }
 
     static func sherpaOnnxModelArchiveURL(for model: LocalSTTModel, source: ModelDownloadSource) -> URL? {
-        switch model {
-        case .whisperLocal, .whisperLocalLarge:
+        sherpaOnnxModelArtifact(for: model, source: source)?.archiveURL
+    }
+
+    static func sherpaOnnxModelArtifact(
+        for model: LocalSTTModel,
+        source: ModelDownloadSource,
+    ) -> SherpaOnnxModelArtifact? {
+        switch (model, source) {
+        case (.whisperLocal, _), (.whisperLocalLarge, _):
             nil
-        case .senseVoiceSmall:
-            sherpaOnnxASRModelArchiveURL(archiveName: "\(senseVoiceRootDirectory).tar.bz2", source: source)
-        case .qwen3ASR:
-            sherpaOnnxASRModelArchiveURL(archiveName: "\(qwen3ASRRootDirectory).tar.bz2", source: source)
+        case (.senseVoiceSmall, .huggingFace):
+            .archive(
+                url: sherpaOnnxASRModelArchiveURL(archiveName: "\(senseVoiceRootDirectory).tar.bz2"),
+                fileName: "\(senseVoiceRootDirectory).tar.bz2",
+            )
+        case (.qwen3ASR, .huggingFace):
+            .archive(
+                url: sherpaOnnxASRModelArchiveURL(archiveName: "\(qwen3ASRRootDirectory).tar.bz2"),
+                fileName: "\(qwen3ASRRootDirectory).tar.bz2",
+            )
+        case (.senseVoiceSmall, .modelScope):
+            .files([
+                sherpaOnnxFile(
+                    resolveBaseURL: huggingFaceChinaMirrorEndpoint,
+                    repositoryID: senseVoiceMirrorRepositoryID,
+                    sourcePath: "model.int8.onnx",
+                    destinationPath: "\(senseVoiceRootDirectory)/model.int8.onnx",
+                ),
+                sherpaOnnxFile(
+                    resolveBaseURL: huggingFaceChinaMirrorEndpoint,
+                    repositoryID: senseVoiceMirrorRepositoryID,
+                    sourcePath: "tokens.txt",
+                    destinationPath: "\(senseVoiceRootDirectory)/tokens.txt",
+                ),
+            ])
+        case (.qwen3ASR, .modelScope):
+            .files([
+                sherpaOnnxFile(
+                    resolveBaseURL: "https://modelscope.cn/models",
+                    repositoryID: qwen3ASROnnxModelScopeRepositoryID,
+                    sourcePath: "model_0.6B/conv_frontend.onnx",
+                    destinationPath: "\(qwen3ASRRootDirectory)/conv_frontend.onnx",
+                ),
+                sherpaOnnxFile(
+                    resolveBaseURL: "https://modelscope.cn/models",
+                    repositoryID: qwen3ASROnnxModelScopeRepositoryID,
+                    sourcePath: "model_0.6B/encoder.int8.onnx",
+                    destinationPath: "\(qwen3ASRRootDirectory)/encoder.int8.onnx",
+                ),
+                sherpaOnnxFile(
+                    resolveBaseURL: "https://modelscope.cn/models",
+                    repositoryID: qwen3ASROnnxModelScopeRepositoryID,
+                    sourcePath: "model_0.6B/decoder.int8.onnx",
+                    destinationPath: "\(qwen3ASRRootDirectory)/decoder.int8.onnx",
+                ),
+                sherpaOnnxFile(
+                    resolveBaseURL: "https://modelscope.cn/models",
+                    repositoryID: qwen3ASRTokenizerModelScopeRepositoryID,
+                    sourcePath: "merges.txt",
+                    destinationPath: "\(qwen3ASRRootDirectory)/tokenizer/merges.txt",
+                ),
+                sherpaOnnxFile(
+                    resolveBaseURL: "https://modelscope.cn/models",
+                    repositoryID: qwen3ASRTokenizerModelScopeRepositoryID,
+                    sourcePath: "tokenizer_config.json",
+                    destinationPath: "\(qwen3ASRRootDirectory)/tokenizer/tokenizer_config.json",
+                ),
+                sherpaOnnxFile(
+                    resolveBaseURL: "https://modelscope.cn/models",
+                    repositoryID: qwen3ASRTokenizerModelScopeRepositoryID,
+                    sourcePath: "vocab.json",
+                    destinationPath: "\(qwen3ASRRootDirectory)/tokenizer/vocab.json",
+                ),
+            ])
         }
     }
 
@@ -66,12 +137,19 @@ enum LocalModelDownloadCatalog {
         }
     }
 
-    private static func sherpaOnnxASRModelArchiveURL(archiveName: String, source: ModelDownloadSource) -> URL {
-        switch source {
-        case .huggingFace:
-            URL(string: "https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/\(archiveName)")!
-        case .modelScope:
-            URL(string: "https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/\(archiveName)")!
-        }
+    private static func sherpaOnnxASRModelArchiveURL(archiveName: String) -> URL {
+        URL(string: "https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/\(archiveName)")!
+    }
+
+    private static func sherpaOnnxFile(
+        resolveBaseURL: String,
+        repositoryID: String,
+        sourcePath: String,
+        destinationPath: String,
+    ) -> SherpaOnnxModelFile {
+        SherpaOnnxModelFile(
+            url: URL(string: "\(resolveBaseURL)/\(repositoryID)/resolve/master/\(sourcePath)")!,
+            relativePath: destinationPath,
+        )
     }
 }

--- a/Sources/Typeflux/STT/LocalModelDownloadCatalog.swift
+++ b/Sources/Typeflux/STT/LocalModelDownloadCatalog.swift
@@ -2,6 +2,7 @@ import Foundation
 
 enum LocalModelDownloadCatalog {
     private static let huggingFaceEndpoint = "https://huggingface.co"
+    private static let huggingFaceChinaMirrorEndpoint = "https://hf-mirror.com"
     private static let whisperKitRepositoryID = "argmaxinc/whisperkit-coreml"
     private static let whisperKitDefaultModelName = "whisperkit-medium"
     private static let sherpaOnnxRuntimeRootDirectory = "sherpa-onnx-v1.12.35-osx-universal2-shared-no-tts"
@@ -16,30 +17,41 @@ enum LocalModelDownloadCatalog {
         whisperKitRepositoryID
     }
 
-    static func whisperKitModelRepositoryURL(source _: ModelDownloadSource) -> URL {
-        URL(string: "\(huggingFaceEndpoint)/\(whisperKitRepositoryID)")!
+    static func whisperKitModelRepositoryURL(source: ModelDownloadSource) -> URL {
+        URL(string: "\(whisperKitModelEndpoint(source: source))/\(whisperKitRepositoryID)")!
     }
 
-    static func whisperKitModelEndpoint(source _: ModelDownloadSource) -> String {
-        huggingFaceEndpoint
+    static func whisperKitModelEndpoint(source: ModelDownloadSource) -> String {
+        switch source {
+        case .huggingFace:
+            huggingFaceEndpoint
+        case .modelScope:
+            huggingFaceChinaMirrorEndpoint
+        }
     }
 
-    static func sherpaOnnxRuntimeArchiveURL(source _: ModelDownloadSource) -> URL {
-        URL(string: "https://github.com/k2-fsa/sherpa-onnx/releases/download/v1.12.35/\(sherpaOnnxRuntimeRootDirectory).tar.bz2")!
+    static func sherpaOnnxRuntimeArchiveURL(source: ModelDownloadSource) -> URL {
+        let archiveName = "\(sherpaOnnxRuntimeRootDirectory).tar.bz2"
+        switch source {
+        case .huggingFace:
+            return URL(string: "https://github.com/k2-fsa/sherpa-onnx/releases/download/v1.12.35/\(archiveName)")!
+        case .modelScope:
+            return URL(string: "https://sourceforge.net/projects/sherpa-onnx.mirror/files/v1.12.35/\(archiveName)/download")!
+        }
     }
 
     static var sherpaOnnxRuntimeDirectoryName: String {
         sherpaOnnxRuntimeRootDirectory
     }
 
-    static func sherpaOnnxModelArchiveURL(for model: LocalSTTModel, source _: ModelDownloadSource) -> URL? {
+    static func sherpaOnnxModelArchiveURL(for model: LocalSTTModel, source: ModelDownloadSource) -> URL? {
         switch model {
         case .whisperLocal, .whisperLocalLarge:
             nil
         case .senseVoiceSmall:
-            URL(string: "https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/\(senseVoiceRootDirectory).tar.bz2")!
+            sherpaOnnxASRModelArchiveURL(archiveName: "\(senseVoiceRootDirectory).tar.bz2", source: source)
         case .qwen3ASR:
-            URL(string: "https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/\(qwen3ASRRootDirectory).tar.bz2")!
+            sherpaOnnxASRModelArchiveURL(archiveName: "\(qwen3ASRRootDirectory).tar.bz2", source: source)
         }
     }
 
@@ -51,6 +63,15 @@ enum LocalModelDownloadCatalog {
             senseVoiceRootDirectory
         case .qwen3ASR:
             qwen3ASRRootDirectory
+        }
+    }
+
+    private static func sherpaOnnxASRModelArchiveURL(archiveName: String, source: ModelDownloadSource) -> URL {
+        switch source {
+        case .huggingFace:
+            URL(string: "https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/\(archiveName)")!
+        case .modelScope:
+            URL(string: "https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/\(archiveName)")!
         }
     }
 }

--- a/Sources/Typeflux/STT/SherpaOnnxSupport.swift
+++ b/Sources/Typeflux/STT/SherpaOnnxSupport.swift
@@ -1,11 +1,34 @@
 import Foundation
 
+struct SherpaOnnxModelFile: Equatable {
+    let url: URL
+    let relativePath: String
+}
+
+enum SherpaOnnxModelArtifact: Equatable {
+    case archive(url: URL, fileName: String)
+    case files([SherpaOnnxModelFile])
+
+    var archiveURL: URL? {
+        switch self {
+        case let .archive(url, _):
+            url
+        case .files:
+            nil
+        }
+    }
+}
+
 struct SherpaOnnxModelLayout {
     let runtimeArchiveURL: URL
     let runtimeRootDirectory: String
-    let modelArchiveURL: URL
+    let modelArtifact: SherpaOnnxModelArtifact
     let modelRootDirectory: String
     let requiredRelativePaths: [String]
+
+    var modelArchiveURL: URL? {
+        modelArtifact.archiveURL
+    }
 
     static func layout(
         for model: LocalSTTModel,
@@ -16,7 +39,7 @@ struct SherpaOnnxModelLayout {
             return nil
         case .senseVoiceSmall:
             guard let modelRootDirectory = LocalModelDownloadCatalog.sherpaOnnxModelDirectoryName(for: model),
-                  let modelArchiveURL = LocalModelDownloadCatalog.sherpaOnnxModelArchiveURL(
+                  let modelArtifact = LocalModelDownloadCatalog.sherpaOnnxModelArtifact(
                     for: model,
                     source: downloadSource,
                   )
@@ -26,7 +49,7 @@ struct SherpaOnnxModelLayout {
             return SherpaOnnxModelLayout(
                 runtimeArchiveURL: LocalModelDownloadCatalog.sherpaOnnxRuntimeArchiveURL(source: downloadSource),
                 runtimeRootDirectory: LocalModelDownloadCatalog.sherpaOnnxRuntimeDirectoryName,
-                modelArchiveURL: modelArchiveURL,
+                modelArtifact: modelArtifact,
                 modelRootDirectory: modelRootDirectory,
                 requiredRelativePaths: [
                     "\(LocalModelDownloadCatalog.sherpaOnnxRuntimeDirectoryName)/bin/sherpa-onnx-offline",
@@ -38,7 +61,7 @@ struct SherpaOnnxModelLayout {
             )
         case .qwen3ASR:
             guard let modelRootDirectory = LocalModelDownloadCatalog.sherpaOnnxModelDirectoryName(for: model),
-                  let modelArchiveURL = LocalModelDownloadCatalog.sherpaOnnxModelArchiveURL(
+                  let modelArtifact = LocalModelDownloadCatalog.sherpaOnnxModelArtifact(
                     for: model,
                     source: downloadSource,
                   )
@@ -48,7 +71,7 @@ struct SherpaOnnxModelLayout {
             return SherpaOnnxModelLayout(
                 runtimeArchiveURL: LocalModelDownloadCatalog.sherpaOnnxRuntimeArchiveURL(source: downloadSource),
                 runtimeRootDirectory: LocalModelDownloadCatalog.sherpaOnnxRuntimeDirectoryName,
-                modelArchiveURL: modelArchiveURL,
+                modelArtifact: modelArtifact,
                 modelRootDirectory: modelRootDirectory,
                 requiredRelativePaths: [
                     "\(LocalModelDownloadCatalog.sherpaOnnxRuntimeDirectoryName)/bin/sherpa-onnx-offline",
@@ -222,11 +245,10 @@ final class SherpaOnnxModelInstaller: SherpaOnnxModelInstalling {
             storagePath: storageURL.path,
             source: nil,
         ))
-        try await downloadAndExtract(
-            archiveURL: layout.modelArchiveURL,
+        try await prepareModelArtifact(
+            layout.modelArtifact,
             destinationURL: storageURL,
             extractedRootDirectoryName: layout.modelRootDirectory,
-            archiveFileName: "\(layout.modelRootDirectory).tar.bz2",
         )
 
         guard layout.isInstalled(storageURL: storageURL, fileManager: fileManager) else {
@@ -289,6 +311,55 @@ final class SherpaOnnxModelInstaller: SherpaOnnxModelInstalling {
 
             try? fileManager.removeItem(at: localArchiveURL)
             try? fileManager.removeItem(at: temporaryDirectory)
+        }
+    }
+
+    private func prepareModelArtifact(
+        _ artifact: SherpaOnnxModelArtifact,
+        destinationURL: URL,
+        extractedRootDirectoryName: String,
+    ) async throws {
+        switch artifact {
+        case let .archive(url, fileName):
+            try await downloadAndExtract(
+                archiveURL: url,
+                destinationURL: destinationURL,
+                extractedRootDirectoryName: extractedRootDirectoryName,
+                archiveFileName: fileName,
+            )
+        case let .files(files):
+            try await downloadExtractedFiles(
+                files,
+                destinationURL: destinationURL,
+                extractedRootDirectoryName: extractedRootDirectoryName,
+            )
+        }
+    }
+
+    private func downloadExtractedFiles(
+        _ files: [SherpaOnnxModelFile],
+        destinationURL: URL,
+        extractedRootDirectoryName: String,
+    ) async throws {
+        try await RequestRetry.perform(operationName: "Sherpa-ONNX model file download") { [self] in
+            let extractedRootURL = destinationURL.appendingPathComponent(
+                extractedRootDirectoryName,
+                isDirectory: true,
+            )
+            if fileManager.fileExists(atPath: extractedRootURL.path) {
+                try fileManager.removeItem(at: extractedRootURL)
+            }
+
+            try fileManager.createDirectory(at: extractedRootURL, withIntermediateDirectories: true)
+
+            for file in files {
+                let destinationFileURL = destinationURL.appendingPathComponent(file.relativePath, isDirectory: false)
+                try fileManager.createDirectory(
+                    at: destinationFileURL.deletingLastPathComponent(),
+                    withIntermediateDirectories: true,
+                )
+                try await downloadArchive(from: file.url, to: destinationFileURL)
+            }
         }
     }
 

--- a/Sources/Typeflux/Settings/SettingsView.swift
+++ b/Sources/Typeflux/Settings/SettingsView.swift
@@ -3459,6 +3459,25 @@ struct StudioView: View {
 
             case .localSTT:
                 VStack(alignment: .leading, spacing: StudioTheme.Spacing.smallMedium) {
+                    VStack(alignment: .leading, spacing: StudioTheme.Spacing.xSmall) {
+                        Text(L("settings.models.downloadSource"))
+                            .font(.studioBody(StudioTheme.Typography.caption, weight: .semibold))
+                            .foregroundStyle(StudioTheme.textSecondary)
+
+                        StudioMenuPicker(
+                            options: ModelDownloadSource.allCases.map { ($0.displayName, $0) },
+                            selection: Binding(
+                                get: { viewModel.localSTTDownloadSource },
+                                set: viewModel.setLocalSTTDownloadSource,
+                            ),
+                            width: 240,
+                        )
+
+                        Text(L("settings.models.downloadSourceHint"))
+                            .font(.studioBody(StudioTheme.Typography.caption))
+                            .foregroundStyle(StudioTheme.textSecondary)
+                    }
+
                     Text(L("settings.models.localModel"))
                         .font(.studioBody(StudioTheme.Typography.caption, weight: .semibold))
                         .foregroundStyle(StudioTheme.textSecondary)

--- a/Sources/Typeflux/Settings/SettingsViewModel.swift
+++ b/Sources/Typeflux/Settings/SettingsViewModel.swift
@@ -1059,7 +1059,10 @@ final class StudioViewModel: ObservableObject {
     }
 
     func setLocalSTTDownloadSource(_ value: ModelDownloadSource) {
-        localSTTDownloadSource = value; settingsStore.localSTTDownloadSource = value
+        localSTTDownloadSource = value
+        settingsStore.localSTTDownloadSource = value
+        refreshLocalSTTStoragePath()
+        refreshLocalSTTPreparedState()
     }
 
     func setLocalSTTAutoSetup(_ value: Bool) {

--- a/Tests/TypefluxTests/LocalModelTranscriberTests.swift
+++ b/Tests/TypefluxTests/LocalModelTranscriberTests.swift
@@ -277,7 +277,7 @@ final class LocalModelTranscriberTests: XCTestCase {
         let downloader = FlakyArchiveDownloader(
             archiveMap: [
                 layout.runtimeArchiveURL: runtimeArchiveURL,
-                layout.modelArchiveURL: modelArchiveURL,
+                try XCTUnwrap(layout.modelArchiveURL): modelArchiveURL,
             ],
             failuresBeforeSuccess: 2,
         )
@@ -342,7 +342,7 @@ final class LocalModelTranscriberTests: XCTestCase {
             processRunner: ProcessCommandRunner(),
             archiveDownloader: StaticArchiveDownloader(archiveMap: [
                 layout.runtimeArchiveURL: runtimeArchiveURL,
-                layout.modelArchiveURL: modelArchiveURL,
+                try XCTUnwrap(layout.modelArchiveURL): modelArchiveURL,
             ]),
         )
 

--- a/Tests/TypefluxTests/SherpaOnnxModelLayoutTests.swift
+++ b/Tests/TypefluxTests/SherpaOnnxModelLayoutTests.swift
@@ -41,7 +41,7 @@ final class SherpaOnnxModelLayoutTests: XCTestCase {
     func testSenseVoiceSmallModelArchiveURL() throws {
         let layout = try XCTUnwrap(SherpaOnnxModelLayout.layout(for: .senseVoiceSmall))
         XCTAssertEqual(
-            layout.modelArchiveURL.absoluteString,
+            try XCTUnwrap(layout.modelArchiveURL).absoluteString,
             "https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/sherpa-onnx-sense-voice-zh-en-ja-ko-yue-2024-07-17.tar.bz2",
         )
     }
@@ -91,13 +91,42 @@ final class SherpaOnnxModelLayoutTests: XCTestCase {
             LocalModelDownloadCatalog.sherpaOnnxRuntimeArchiveURL(source: .modelScope).absoluteString,
             "https://sourceforge.net/projects/sherpa-onnx.mirror/files/v1.12.35/sherpa-onnx-v1.12.35-osx-universal2-shared-no-tts.tar.bz2/download",
         )
-        XCTAssertEqual(
-            try XCTUnwrap(LocalModelDownloadCatalog.sherpaOnnxModelArchiveURL(
-                for: .senseVoiceSmall,
-                source: .modelScope,
-            )).absoluteString,
-            "https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/sherpa-onnx-sense-voice-zh-en-ja-ko-yue-2024-07-17.tar.bz2",
-        )
+        XCTAssertNil(LocalModelDownloadCatalog.sherpaOnnxModelArchiveURL(for: .senseVoiceSmall, source: .modelScope))
+        XCTAssertNil(LocalModelDownloadCatalog.sherpaOnnxModelArchiveURL(for: .qwen3ASR, source: .modelScope))
+    }
+
+    func testModelScopeSenseVoiceUsesExtractedFilesFromChinaMirror() throws {
+        let layout = try XCTUnwrap(SherpaOnnxModelLayout.layout(for: .senseVoiceSmall, downloadSource: .modelScope))
+
+        guard case let .files(files) = layout.modelArtifact else {
+            return XCTFail("Expected ModelScope SenseVoice layout to use extracted files")
+        }
+
+        XCTAssertEqual(files.map(\.relativePath), [
+            "sherpa-onnx-sense-voice-zh-en-ja-ko-yue-2024-07-17/model.int8.onnx",
+            "sherpa-onnx-sense-voice-zh-en-ja-ko-yue-2024-07-17/tokens.txt",
+        ])
+        XCTAssertTrue(files.allSatisfy { $0.url.host != "github.com" })
+        XCTAssertTrue(files.allSatisfy { $0.url.absoluteString.hasPrefix("https://hf-mirror.com/") })
+    }
+
+    func testModelScopeQwen3ASRUsesExtractedFilesFromDomesticSources() throws {
+        let layout = try XCTUnwrap(SherpaOnnxModelLayout.layout(for: .qwen3ASR, downloadSource: .modelScope))
+
+        guard case let .files(files) = layout.modelArtifact else {
+            return XCTFail("Expected ModelScope Qwen3-ASR layout to use extracted files")
+        }
+
+        XCTAssertEqual(files.map(\.relativePath), [
+            "sherpa-onnx-qwen3-asr-0.6B-int8-2026-03-25/conv_frontend.onnx",
+            "sherpa-onnx-qwen3-asr-0.6B-int8-2026-03-25/encoder.int8.onnx",
+            "sherpa-onnx-qwen3-asr-0.6B-int8-2026-03-25/decoder.int8.onnx",
+            "sherpa-onnx-qwen3-asr-0.6B-int8-2026-03-25/tokenizer/merges.txt",
+            "sherpa-onnx-qwen3-asr-0.6B-int8-2026-03-25/tokenizer/tokenizer_config.json",
+            "sherpa-onnx-qwen3-asr-0.6B-int8-2026-03-25/tokenizer/vocab.json",
+        ])
+        XCTAssertTrue(files.allSatisfy { $0.url.host != "github.com" })
+        XCTAssertTrue(files.allSatisfy { $0.url.absoluteString.hasPrefix("https://modelscope.cn/") })
     }
 
     func testSenseVoiceSmallRequiredPaths() throws {

--- a/Tests/TypefluxTests/SherpaOnnxModelLayoutTests.swift
+++ b/Tests/TypefluxTests/SherpaOnnxModelLayoutTests.swift
@@ -74,6 +74,32 @@ final class SherpaOnnxModelLayoutTests: XCTestCase {
         XCTAssertNil(LocalModelDownloadCatalog.sherpaOnnxModelArchiveURL(for: .whisperLocal, source: .huggingFace))
     }
 
+    func testDownloadCatalogProvidesChinaMirrorLocations() throws {
+        XCTAssertEqual(
+            LocalModelDownloadCatalog.whisperKitModelRepository(source: .modelScope),
+            "argmaxinc/whisperkit-coreml",
+        )
+        XCTAssertEqual(
+            LocalModelDownloadCatalog.whisperKitModelRepositoryURL(source: .modelScope).absoluteString,
+            "https://hf-mirror.com/argmaxinc/whisperkit-coreml",
+        )
+        XCTAssertEqual(
+            LocalModelDownloadCatalog.whisperKitModelEndpoint(source: .modelScope),
+            "https://hf-mirror.com",
+        )
+        XCTAssertEqual(
+            LocalModelDownloadCatalog.sherpaOnnxRuntimeArchiveURL(source: .modelScope).absoluteString,
+            "https://sourceforge.net/projects/sherpa-onnx.mirror/files/v1.12.35/sherpa-onnx-v1.12.35-osx-universal2-shared-no-tts.tar.bz2/download",
+        )
+        XCTAssertEqual(
+            try XCTUnwrap(LocalModelDownloadCatalog.sherpaOnnxModelArchiveURL(
+                for: .senseVoiceSmall,
+                source: .modelScope,
+            )).absoluteString,
+            "https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/sherpa-onnx-sense-voice-zh-en-ja-ko-yue-2024-07-17.tar.bz2",
+        )
+    }
+
     func testSenseVoiceSmallRequiredPaths() throws {
         let layout = try XCTUnwrap(SherpaOnnxModelLayout.layout(for: .senseVoiceSmall))
         XCTAssertEqual(layout.requiredRelativePaths.count, 5)


### PR DESCRIPTION
## Summary
- References [TYP-17](/TYP/issues/TYP-17).
- Makes local model download catalog resolution source-aware for WhisperKit and Sherpa runtime downloads.
- Adds a local STT download source selector in settings and refreshes prepared-state display when it changes.
- Adds localization and focused catalog tests for the mirror path.

## Test Instructions
- `swift test --filter TypefluxTests.SherpaOnnxModelLayoutTests`
- `swift test --filter TypefluxTests.LocalizationResourceTests`

## Notes / Risk
- WhisperKit can use `hf-mirror.com` for the mirror source.
- Sherpa runtime can use the SourceForge mirror.
- Exact Sherpa ASR model tar archives for SenseVoice/Qwen3 still need a verified domestic host or extracted ModelScope asset downloader; the current PR preserves the existing GitHub model archives for those assets to avoid breaking extraction semantics.

## Screenshots
- Not captured in this heartbeat; settings UI changed only by adding the source selector.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Download Source" setting in local model configuration so users can select a preferred source before preparing or re-downloading local speech models.
  * Support for multiple download sources and alternative mirrors (including domestic mirror options).
  * Multilingual localization added for the new setting and its hint (EN, JA, KO, ZH-Hans, ZH-Hant).

* **Tests**
  * Added tests validating mirror/source-specific download behaviors and layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->