### PR TITLE
feat: complete Sherpa ASR domestic artifact downloads

### DIFF
--- a/Sources/Typeflux/STT/LocalModelDownloadCatalog.swift
+++ b/Sources/Typeflux/STT/LocalModelDownloadCatalog.swift
@@ -8,6 +8,10 @@ enum LocalModelDownloadCatalog {
     private static let sherpaOnnxRuntimeRootDirectory = "sherpa-onnx-v1.12.35-osx-universal2-shared-no-tts"
     private static let senseVoiceRootDirectory = "sherpa-onnx-sense-voice-zh-en-ja-ko-yue-2024-07-17"
     private static let qwen3ASRRootDirectory = "sherpa-onnx-qwen3-asr-0.6B-int8-2026-03-25"
+    private static let senseVoiceMirrorRepositoryID =
+        "csukuangfj/sherpa-onnx-sense-voice-zh-en-ja-ko-yue-2024-07-17"
+    private static let qwen3ASROnnxModelScopeRepositoryID = "zengshuishui/Qwen3-ASR-onnx"
+    private static let qwen3ASRTokenizerModelScopeRepositoryID = "Qwen/Qwen3-ASR-0.6B"
 
     static var whisperKitDefaultModelIdentifier: String {
         whisperKitDefaultModelName
@@ -45,13 +49,80 @@ enum LocalModelDownloadCatalog {
     }
 
     static func sherpaOnnxModelArchiveURL(for model: LocalSTTModel, source: ModelDownloadSource) -> URL? {
-        switch model {
-        case .whisperLocal, .whisperLocalLarge:
+        sherpaOnnxModelArtifact(for: model, source: source)?.archiveURL
+    }
+
+    static func sherpaOnnxModelArtifact(
+        for model: LocalSTTModel,
+        source: ModelDownloadSource,
+    ) -> SherpaOnnxModelArtifact? {
+        switch (model, source) {
+        case (.whisperLocal, _), (.whisperLocalLarge, _):
             nil
-        case .senseVoiceSmall:
-            sherpaOnnxASRModelArchiveURL(archiveName: "\(senseVoiceRootDirectory).tar.bz2", source: source)
-        case .qwen3ASR:
-            sherpaOnnxASRModelArchiveURL(archiveName: "\(qwen3ASRRootDirectory).tar.bz2", source: source)
+        case (.senseVoiceSmall, .huggingFace):
+            .archive(
+                url: sherpaOnnxASRModelArchiveURL(archiveName: "\(senseVoiceRootDirectory).tar.bz2"),
+                fileName: "\(senseVoiceRootDirectory).tar.bz2",
+            )
+        case (.qwen3ASR, .huggingFace):
+            .archive(
+                url: sherpaOnnxASRModelArchiveURL(archiveName: "\(qwen3ASRRootDirectory).tar.bz2"),
+                fileName: "\(qwen3ASRRootDirectory).tar.bz2",
+            )
+        case (.senseVoiceSmall, .modelScope):
+            .files([
+                sherpaOnnxFile(
+                    resolveBaseURL: huggingFaceChinaMirrorEndpoint,
+                    repositoryID: senseVoiceMirrorRepositoryID,
+                    sourcePath: "model.int8.onnx",
+                    destinationPath: "\(senseVoiceRootDirectory)/model.int8.onnx",
+                ),
+                sherpaOnnxFile(
+                    resolveBaseURL: huggingFaceChinaMirrorEndpoint,
+                    repositoryID: senseVoiceMirrorRepositoryID,
+                    sourcePath: "tokens.txt",
+                    destinationPath: "\(senseVoiceRootDirectory)/tokens.txt",
+                ),
+            ])
+        case (.qwen3ASR, .modelScope):
+            .files([
+                sherpaOnnxFile(
+                    resolveBaseURL: "https://modelscope.cn/models",
+                    repositoryID: qwen3ASROnnxModelScopeRepositoryID,
+                    sourcePath: "model_0.6B/conv_frontend.onnx",
+                    destinationPath: "\(qwen3ASRRootDirectory)/conv_frontend.onnx",
+                ),
+                sherpaOnnxFile(
+                    resolveBaseURL: "https://modelscope.cn/models",
+                    repositoryID: qwen3ASROnnxModelScopeRepositoryID,
+                    sourcePath: "model_0.6B/encoder.int8.onnx",
+                    destinationPath: "\(qwen3ASRRootDirectory)/encoder.int8.onnx",
+                ),
+                sherpaOnnxFile(
+                    resolveBaseURL: "https://modelscope.cn/models",
+                    repositoryID: qwen3ASROnnxModelScopeRepositoryID,
+                    sourcePath: "model_0.6B/decoder.int8.onnx",
+                    destinationPath: "\(qwen3ASRRootDirectory)/decoder.int8.onnx",
+                ),
+                sherpaOnnxFile(
+                    resolveBaseURL: "https://modelscope.cn/models",
+                    repositoryID: qwen3ASRTokenizerModelScopeRepositoryID,
+                    sourcePath: "merges.txt",
+                    destinationPath: "\(qwen3ASRRootDirectory)/tokenizer/merges.txt",
+                ),
+                sherpaOnnxFile(
+                    resolveBaseURL: "https://modelscope.cn/models",
+                    repositoryID: qwen3ASRTokenizerModelScopeRepositoryID,
+                    sourcePath: "tokenizer_config.json",
+                    destinationPath: "\(qwen3ASRRootDirectory)/tokenizer/tokenizer_config.json",
+                ),
+                sherpaOnnxFile(
+                    resolveBaseURL: "https://modelscope.cn/models",
+                    repositoryID: qwen3ASRTokenizerModelScopeRepositoryID,
+                    sourcePath: "vocab.json",
+                    destinationPath: "\(qwen3ASRRootDirectory)/tokenizer/vocab.json",
+                ),
+            ])
         }
     }
 
@@ -66,12 +137,19 @@ enum LocalModelDownloadCatalog {
         }
     }
 
-    private static func sherpaOnnxASRModelArchiveURL(archiveName: String, source: ModelDownloadSource) -> URL {
-        switch source {
-        case .huggingFace:
-            URL(string: "https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/\(archiveName)")!
-        case .modelScope:
-            URL(string: "https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/\(archiveName)")!
-        }
+    private static func sherpaOnnxASRModelArchiveURL(archiveName: String) -> URL {
+        URL(string: "https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/\(archiveName)")!
+    }
+
+    private static func sherpaOnnxFile(
+        resolveBaseURL: String,
+        repositoryID: String,
+        sourcePath: String,
+        destinationPath: String,
+    ) -> SherpaOnnxModelFile {
+        SherpaOnnxModelFile(
+            url: URL(string: "\(resolveBaseURL)/\(repositoryID)/resolve/master/\(sourcePath)")!,
+            relativePath: destinationPath,
+        )
     }
 }

--- a/Sources/Typeflux/STT/SherpaOnnxSupport.swift
+++ b/Sources/Typeflux/STT/SherpaOnnxSupport.swift
@@ -1,11 +1,34 @@
 import Foundation
 
+struct SherpaOnnxModelFile: Equatable {
+    let url: URL
+    let relativePath: String
+}
+
+enum SherpaOnnxModelArtifact: Equatable {
+    case archive(url: URL, fileName: String)
+    case files([SherpaOnnxModelFile])
+
+    var archiveURL: URL? {
+        switch self {
+        case let .archive(url, _):
+            url
+        case .files:
+            nil
+        }
+    }
+}
+
 struct SherpaOnnxModelLayout {
     let runtimeArchiveURL: URL
     let runtimeRootDirectory: String
-    let modelArchiveURL: URL
+    let modelArtifact: SherpaOnnxModelArtifact
     let modelRootDirectory: String
     let requiredRelativePaths: [String]
+
+    var modelArchiveURL: URL? {
+        modelArtifact.archiveURL
+    }
 
     static func layout(
         for model: LocalSTTModel,
@@ -16,7 +39,7 @@ struct SherpaOnnxModelLayout {
             return nil
         case .senseVoiceSmall:
             guard let modelRootDirectory = LocalModelDownloadCatalog.sherpaOnnxModelDirectoryName(for: model),
-                  let modelArchiveURL = LocalModelDownloadCatalog.sherpaOnnxModelArchiveURL(
+                  let modelArtifact = LocalModelDownloadCatalog.sherpaOnnxModelArtifact(
                     for: model,
                     source: downloadSource,
                   )
@@ -26,7 +49,7 @@ struct SherpaOnnxModelLayout {
             return SherpaOnnxModelLayout(
                 runtimeArchiveURL: LocalModelDownloadCatalog.sherpaOnnxRuntimeArchiveURL(source: downloadSource),
                 runtimeRootDirectory: LocalModelDownloadCatalog.sherpaOnnxRuntimeDirectoryName,
-                modelArchiveURL: modelArchiveURL,
+                modelArtifact: modelArtifact,
                 modelRootDirectory: modelRootDirectory,
                 requiredRelativePaths: [
                     "\(LocalModelDownloadCatalog.sherpaOnnxRuntimeDirectoryName)/bin/sherpa-onnx-offline",
@@ -38,7 +61,7 @@ struct SherpaOnnxModelLayout {
             )
         case .qwen3ASR:
             guard let modelRootDirectory = LocalModelDownloadCatalog.sherpaOnnxModelDirectoryName(for: model),
-                  let modelArchiveURL = LocalModelDownloadCatalog.sherpaOnnxModelArchiveURL(
+                  let modelArtifact = LocalModelDownloadCatalog.sherpaOnnxModelArtifact(
                     for: model,
                     source: downloadSource,
                   )
@@ -48,7 +71,7 @@ struct SherpaOnnxModelLayout {
             return SherpaOnnxModelLayout(
                 runtimeArchiveURL: LocalModelDownloadCatalog.sherpaOnnxRuntimeArchiveURL(source: downloadSource),
                 runtimeRootDirectory: LocalModelDownloadCatalog.sherpaOnnxRuntimeDirectoryName,
-                modelArchiveURL: modelArchiveURL,
+                modelArtifact: modelArtifact,
                 modelRootDirectory: modelRootDirectory,
                 requiredRelativePaths: [
                     "\(LocalModelDownloadCatalog.sherpaOnnxRuntimeDirectoryName)/bin/sherpa-onnx-offline",
@@ -222,11 +245,10 @@ final class SherpaOnnxModelInstaller: SherpaOnnxModelInstalling {
             storagePath: storageURL.path,
             source: nil,
         ))
-        try await downloadAndExtract(
-            archiveURL: layout.modelArchiveURL,
+        try await prepareModelArtifact(
+            layout.modelArtifact,
             destinationURL: storageURL,
             extractedRootDirectoryName: layout.modelRootDirectory,
-            archiveFileName: "\(layout.modelRootDirectory).tar.bz2",
         )
 
         guard layout.isInstalled(storageURL: storageURL, fileManager: fileManager) else {
@@ -289,6 +311,55 @@ final class SherpaOnnxModelInstaller: SherpaOnnxModelInstalling {
 
             try? fileManager.removeItem(at: localArchiveURL)
             try? fileManager.removeItem(at: temporaryDirectory)
+        }
+    }
+
+    private func prepareModelArtifact(
+        _ artifact: SherpaOnnxModelArtifact,
+        destinationURL: URL,
+        extractedRootDirectoryName: String,
+    ) async throws {
+        switch artifact {
+        case let .archive(url, fileName):
+            try await downloadAndExtract(
+                archiveURL: url,
+                destinationURL: destinationURL,
+                extractedRootDirectoryName: extractedRootDirectoryName,
+                archiveFileName: fileName,
+            )
+        case let .files(files):
+            try await downloadExtractedFiles(
+                files,
+                destinationURL: destinationURL,
+                extractedRootDirectoryName: extractedRootDirectoryName,
+            )
+        }
+    }
+
+    private func downloadExtractedFiles(
+        _ files: [SherpaOnnxModelFile],
+        destinationURL: URL,
+        extractedRootDirectoryName: String,
+    ) async throws {
+        try await RequestRetry.perform(operationName: "Sherpa-ONNX model file download") { [self] in
+            let extractedRootURL = destinationURL.appendingPathComponent(
+                extractedRootDirectoryName,
+                isDirectory: true,
+            )
+            if fileManager.fileExists(atPath: extractedRootURL.path) {
+                try fileManager.removeItem(at: extractedRootURL)
+            }
+
+            try fileManager.createDirectory(at: extractedRootURL, withIntermediateDirectories: true)
+
+            for file in files {
+                let destinationFileURL = destinationURL.appendingPathComponent(file.relativePath, isDirectory: false)
+                try fileManager.createDirectory(
+                    at: destinationFileURL.deletingLastPathComponent(),
+                    withIntermediateDirectories: true,
+                )
+                try await downloadArchive(from: file.url, to: destinationFileURL)
+            }
         }
     }
 

--- a/Tests/TypefluxTests/LocalModelTranscriberTests.swift
+++ b/Tests/TypefluxTests/LocalModelTranscriberTests.swift
@@ -277,7 +277,7 @@ final class LocalModelTranscriberTests: XCTestCase {
         let downloader = FlakyArchiveDownloader(
             archiveMap: [
                 layout.runtimeArchiveURL: runtimeArchiveURL,
-                layout.modelArchiveURL: modelArchiveURL,
+                try XCTUnwrap(layout.modelArchiveURL): modelArchiveURL,
             ],
             failuresBeforeSuccess: 2,
         )
@@ -342,7 +342,7 @@ final class LocalModelTranscriberTests: XCTestCase {
             processRunner: ProcessCommandRunner(),
             archiveDownloader: StaticArchiveDownloader(archiveMap: [
                 layout.runtimeArchiveURL: runtimeArchiveURL,
-                layout.modelArchiveURL: modelArchiveURL,
+                try XCTUnwrap(layout.modelArchiveURL): modelArchiveURL,
             ]),
         )
 

--- a/Tests/TypefluxTests/SherpaOnnxModelLayoutTests.swift
+++ b/Tests/TypefluxTests/SherpaOnnxModelLayoutTests.swift
@@ -41,7 +41,7 @@ final class SherpaOnnxModelLayoutTests: XCTestCase {
     func testSenseVoiceSmallModelArchiveURL() throws {
         let layout = try XCTUnwrap(SherpaOnnxModelLayout.layout(for: .senseVoiceSmall))
         XCTAssertEqual(
-            layout.modelArchiveURL.absoluteString,
+            try XCTUnwrap(layout.modelArchiveURL).absoluteString,
             "https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/sherpa-onnx-sense-voice-zh-en-ja-ko-yue-2024-07-17.tar.bz2",
         )
     }
@@ -91,13 +91,42 @@ final class SherpaOnnxModelLayoutTests: XCTestCase {
             LocalModelDownloadCatalog.sherpaOnnxRuntimeArchiveURL(source: .modelScope).absoluteString,
             "https://sourceforge.net/projects/sherpa-onnx.mirror/files/v1.12.35/sherpa-onnx-v1.12.35-osx-universal2-shared-no-tts.tar.bz2/download",
         )
-        XCTAssertEqual(
-            try XCTUnwrap(LocalModelDownloadCatalog.sherpaOnnxModelArchiveURL(
-                for: .senseVoiceSmall,
-                source: .modelScope,
-            )).absoluteString,
-            "https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/sherpa-onnx-sense-voice-zh-en-ja-ko-yue-2024-07-17.tar.bz2",
-        )
+        XCTAssertNil(LocalModelDownloadCatalog.sherpaOnnxModelArchiveURL(for: .senseVoiceSmall, source: .modelScope))
+        XCTAssertNil(LocalModelDownloadCatalog.sherpaOnnxModelArchiveURL(for: .qwen3ASR, source: .modelScope))
+    }
+
+    func testModelScopeSenseVoiceUsesExtractedFilesFromChinaMirror() throws {
+        let layout = try XCTUnwrap(SherpaOnnxModelLayout.layout(for: .senseVoiceSmall, downloadSource: .modelScope))
+
+        guard case let .files(files) = layout.modelArtifact else {
+            return XCTFail("Expected ModelScope SenseVoice layout to use extracted files")
+        }
+
+        XCTAssertEqual(files.map(\.relativePath), [
+            "sherpa-onnx-sense-voice-zh-en-ja-ko-yue-2024-07-17/model.int8.onnx",
+            "sherpa-onnx-sense-voice-zh-en-ja-ko-yue-2024-07-17/tokens.txt",
+        ])
+        XCTAssertTrue(files.allSatisfy { $0.url.host != "github.com" })
+        XCTAssertTrue(files.allSatisfy { $0.url.absoluteString.hasPrefix("https://hf-mirror.com/") })
+    }
+
+    func testModelScopeQwen3ASRUsesExtractedFilesFromDomesticSources() throws {
+        let layout = try XCTUnwrap(SherpaOnnxModelLayout.layout(for: .qwen3ASR, downloadSource: .modelScope))
+
+        guard case let .files(files) = layout.modelArtifact else {
+            return XCTFail("Expected ModelScope Qwen3-ASR layout to use extracted files")
+        }
+
+        XCTAssertEqual(files.map(\.relativePath), [
+            "sherpa-onnx-qwen3-asr-0.6B-int8-2026-03-25/conv_frontend.onnx",
+            "sherpa-onnx-qwen3-asr-0.6B-int8-2026-03-25/encoder.int8.onnx",
+            "sherpa-onnx-qwen3-asr-0.6B-int8-2026-03-25/decoder.int8.onnx",
+            "sherpa-onnx-qwen3-asr-0.6B-int8-2026-03-25/tokenizer/merges.txt",
+            "sherpa-onnx-qwen3-asr-0.6B-int8-2026-03-25/tokenizer/tokenizer_config.json",
+            "sherpa-onnx-qwen3-asr-0.6B-int8-2026-03-25/tokenizer/vocab.json",
+        ])
+        XCTAssertTrue(files.allSatisfy { $0.url.host != "github.com" })
+        XCTAssertTrue(files.allSatisfy { $0.url.absoluteString.hasPrefix("https://modelscope.cn/") })
     }
 
     func testSenseVoiceSmallRequiredPaths() throws {


### PR DESCRIPTION
## Summary

- Completes [TYP-18](/TYP/issues/TYP-18) as a follow-up to [TYP-17](/TYP/issues/TYP-17).
- Adds extracted-file Sherpa model artifacts so the ModelScope download source no longer resolves SenseVoice or Qwen3-ASR model files through GitHub.
- Keeps Hugging Face archive downloads unchanged and keeps prepared-model records source-sensitive through the existing source field.
- Adds catalog tests proving `.modelScope` Sherpa ASR model archive URLs are no longer GitHub-backed and validate the domestic file URLs.

## How to test

- `swift test --filter TypefluxTests.SherpaOnnxModelLayoutTests`
- `swift test --filter TypefluxTests.LocalModelTranscriberTests`
- `swift test`

## Screenshots

Not applicable; download plumbing only.
