### PR TITLE
fix(vocabulary): repair silent auto-add failures and rank terms by usage

### DIFF
--- a/Sources/Typeflux/LLM/PromptCatalog.swift
+++ b/Sources/Typeflux/LLM/PromptCatalog.swift
@@ -314,21 +314,18 @@ enum PromptCatalog {
         return (
             system: """
             You decide whether user-corrected terms should be added to a speech transcription vocabulary.
-            Your goal is to keep only stable vocabulary entries that are likely to improve future speech recognition accuracy.
-            You may keep a candidate only if it clearly belongs to one of these two categories:
-            1. A word or short phrase that speech recognition is likely to mishear or misspell.
+            Your goal is to keep entries that are likely to improve future speech recognition accuracy.
+            Prefer keeping any correction that looks like one of these:
+            1. A word or short phrase that speech recognition is likely to mishear or misspell (capitalization fixes, spacing fixes, homophones, brand spellings all qualify).
             2. A professional term, product name, model name, framework name, API name, protocol name, command, code identifier, or other domain-specific term.
-            Reject anything that does not clearly match the two categories above.
-            Always reject:
-            - common everyday words
-            - generic rewrites or paraphrases
+            When the correction spans two or more tokens (e.g. "Open AI" → "OpenAI", "read me" → "readme"), keep the corrected form — those are exactly the mistakes an ASR vocabulary fixes.
+            Reject only clear non-terms:
+            - common everyday words with no correction value
             - filler words or conversational fragments
             - punctuation-only changes
-            - grammar fixes
-            - complete clauses or sentence fragments
-            - long phrases or copied chunks of text
+            - pure grammar fixes with no new terminology
+            - complete clauses or sentence fragments copied from the transcript
             - content added only to clarify meaning, tone, or context
-            - anything uncertain or ambiguous
             A valid vocabulary entry must be short and term-like:
             - usually 1 term or a very short phrase
             - not a full sentence
@@ -336,7 +333,7 @@ enum PromptCatalog {
             - not more than 3 English words
             - not more than 8 Chinese characters unless it is clearly a fixed technical term
             Minimum length requirements (reject anything shorter):
-            - English / Latin / alphanumeric terms must be at least 4 characters and contain letters (e.g. "GPT4", "LLM4", "Rust" OK; "AI", "UI", "Go", "123", "X" rejected).
+            - English / Latin / alphanumeric terms must be at least 3 characters and contain letters (e.g. "GPT", "API", "LLM", "iOS", "Rust" OK; "AI", "UI", "Go", "123", "X" rejected).
             - Chinese terms must contain at least 2 Han characters (e.g. "向量", "推理" OK; single-character terms rejected).
             - Mixed terms containing any Han character must still be at least 2 characters total.
             Good examples:
@@ -353,7 +350,7 @@ enum PromptCatalog {
             - today afternoon meeting
             - let me explain this
             - a whole sentence copied from the transcript
-            If a candidate is not clearly suitable, reject it.
+            When in doubt about a candidate that looks like a real term/name/acronym, keep it — duplicates and noise are inexpensive to prune later; missing a real domain term hurts recognition quality.
             Return strict JSON only in the form {"terms":["term1","term2"]}.
             Return at most 3 terms.
             If nothing qualifies, return {"terms":[]}.
@@ -371,9 +368,8 @@ enum PromptCatalog {
 
             \(xmlSection(tag: "existing_vocabulary", content: existingSummary))
 
-            Keep only the candidates that are strong long-term vocabulary entries for speech recognition.
-            Prefer precision over recall.
-            If uncertain, return an empty list.
+            Keep the candidates that look like real domain terms, product/model/framework/API names, code identifiers, or spacing/capitalization corrections that speech recognition is likely to mishear.
+            Lean toward keeping genuine term-like corrections; reject only obvious non-terms per the system guidance.
             Return strict JSON only.
             """,
         )

--- a/Sources/Typeflux/Settings/VocabularyStore.swift
+++ b/Sources/Typeflux/Settings/VocabularyStore.swift
@@ -23,17 +23,48 @@ struct VocabularyEntry: Codable, Identifiable, Equatable {
     let term: String
     let source: VocabularySource
     let createdAt: Date
+    var occurrenceCount: Int
 
-    init(id: UUID = UUID(), term: String, source: VocabularySource, createdAt: Date = Date()) {
+    init(
+        id: UUID = UUID(),
+        term: String,
+        source: VocabularySource,
+        createdAt: Date = Date(),
+        occurrenceCount: Int = 1,
+    ) {
         self.id = id
         self.term = term
         self.source = source
         self.createdAt = createdAt
+        self.occurrenceCount = max(0, occurrenceCount)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case term
+        case source
+        case createdAt
+        case occurrenceCount
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(UUID.self, forKey: .id)
+        term = try container.decode(String.self, forKey: .term)
+        source = try container.decode(VocabularySource.self, forKey: .source)
+        createdAt = try container.decode(Date.self, forKey: .createdAt)
+        // Legacy entries saved before the occurrenceCount field existed decode as 1 so
+        // they participate in ranking without being pushed to the bottom of the list.
+        occurrenceCount = try container.decodeIfPresent(Int.self, forKey: .occurrenceCount) ?? 1
     }
 }
 
 enum VocabularyStore {
     private static let key = "vocabulary.entries"
+    /// Maximum number of terms returned to speech recognition as hints. Beyond this
+    /// point most ASR backends either truncate silently or waste prompt budget, so
+    /// we cap the list and let ranking decide who stays.
+    static let activeTermLimit = 100
 
     static func load() -> [VocabularyEntry] {
         guard let data = UserDefaults.standard.data(forKey: key) else {
@@ -65,14 +96,33 @@ enum VocabularyStore {
         }
     }
 
+    /// Add a new term, or bump the occurrence count if the normalized term already exists.
+    /// Duplicate adds intentionally increment the counter so that "user manually re-added"
+    /// and "auto-vocab re-approved" both reinforce ranking, not silently no-op.
+    @discardableResult
     static func add(term: String, source: VocabularySource = .manual) -> [VocabularyEntry] {
         let normalized = normalize(term)
         guard !normalized.isEmpty else { return load() }
+        let lowered = normalized.lowercased()
 
         var entries = load()
-        guard !entries.contains(where: { normalize($0.term) == normalized }) else { return entries }
+        if let index = entries.firstIndex(where: { normalize($0.term).lowercased() == lowered }) {
+            let existing = entries[index]
+            entries[index] = VocabularyEntry(
+                id: existing.id,
+                term: existing.term,
+                source: existing.source,
+                createdAt: existing.createdAt,
+                occurrenceCount: existing.occurrenceCount + 1,
+            )
+            save(entries)
+            return entries
+        }
 
-        entries.insert(VocabularyEntry(term: normalized, source: source), at: 0)
+        entries.insert(
+            VocabularyEntry(term: normalized, source: source, occurrenceCount: 1),
+            at: 0,
+        )
         save(entries)
         return entries
     }
@@ -90,7 +140,9 @@ enum VocabularyStore {
 
         var entries = load()
         guard let index = entries.firstIndex(where: { $0.id == id }) else { return entries }
-        guard !entries.contains(where: { $0.id != id && normalize($0.term) == normalized }) else { return entries }
+        guard !entries.contains(where: { $0.id != id && normalize($0.term).lowercased() == normalized.lowercased() }) else {
+            return entries
+        }
 
         let existing = entries[index]
         entries[index] = VocabularyEntry(
@@ -98,13 +150,68 @@ enum VocabularyStore {
             term: normalized,
             source: existing.source,
             createdAt: existing.createdAt,
+            occurrenceCount: existing.occurrenceCount,
         )
         save(entries)
         return entries
     }
 
+    /// Scan `text` for any existing vocabulary terms (case-insensitive substring
+    /// match) and increment their occurrence count. Returns the names of terms that
+    /// were bumped. Safe to call from any dictation/edit path — no-op when nothing
+    /// matches or the text is empty.
+    @discardableResult
+    static func incrementOccurrences(in text: String) -> [String] {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return [] }
+
+        var entries = load()
+        guard !entries.isEmpty else { return [] }
+
+        let lowercasedText = trimmed.lowercased()
+        var bumped: [String] = []
+        for index in entries.indices {
+            let lowered = entries[index].term.lowercased()
+            guard !lowered.isEmpty, lowercasedText.contains(lowered) else { continue }
+            let existing = entries[index]
+            entries[index] = VocabularyEntry(
+                id: existing.id,
+                term: existing.term,
+                source: existing.source,
+                createdAt: existing.createdAt,
+                occurrenceCount: existing.occurrenceCount + 1,
+            )
+            bumped.append(existing.term)
+        }
+
+        guard !bumped.isEmpty else { return [] }
+        save(entries)
+        return bumped
+    }
+
+    /// Top-ranked terms used as speech-recognition hints. Capped at
+    /// `activeTermLimit`; higher occurrence count wins, ties broken by later
+    /// `createdAt`. ASR backends consume this list.
     static func activeTerms() -> [String] {
+        rankedEntries().prefix(activeTermLimit).map(\.term)
+    }
+
+    /// Full term list, unsorted by rank. Use this for deduplication, settings UI,
+    /// and LLM "existing vocabulary" prompts — anywhere the ASR cap would lose
+    /// useful signal.
+    static func allTerms() -> [String] {
         load().map(\.term)
+    }
+
+    /// Entries sorted by (occurrenceCount DESC, createdAt DESC). Exposed for UI
+    /// and diagnostics; ASR callers should use `activeTerms()`.
+    static func rankedEntries() -> [VocabularyEntry] {
+        load().sorted { lhs, rhs in
+            if lhs.occurrenceCount != rhs.occurrenceCount {
+                return lhs.occurrenceCount > rhs.occurrenceCount
+            }
+            return lhs.createdAt > rhs.createdAt
+        }
     }
 
     private static func deduplicated(_ entries: [VocabularyEntry]) -> [VocabularyEntry] {
@@ -117,7 +224,7 @@ enum VocabularyStore {
                 return lhs.createdAt > rhs.createdAt
             }
             .filter { entry in
-                let normalized = normalize(entry.term)
+                let normalized = normalize(entry.term).lowercased()
                 guard !normalized.isEmpty, !seen.contains(normalized) else { return false }
                 seen.insert(normalized)
                 return true

--- a/Sources/Typeflux/Workflow/AutomaticVocabularyMonitor.swift
+++ b/Sources/Typeflux/Workflow/AutomaticVocabularyMonitor.swift
@@ -233,7 +233,9 @@ enum AutomaticVocabularyMonitor {
 
     private static func isValidLatinOrNumberToken(_ token: String) -> Bool {
         let trimmed = token.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard trimmed.count >= 4, trimmed.count <= 32 else { return false }
+        // Dropped from 4 to 3: common tech acronyms (GPT, API, LLM, ASR, gRPC) get
+        // manually corrected all the time. LLM-side validation keeps the noise out.
+        guard trimmed.count >= 3, trimmed.count <= 32 else { return false }
         return trimmed.rangeOfCharacter(from: .letters) != nil
     }
 
@@ -297,7 +299,9 @@ enum AutomaticVocabularyMonitor {
         }
 
         guard trimmed.rangeOfCharacter(from: .letters) != nil else { return false }
-        return trimmed.count >= 4
+        // Aligns with the candidate tokenizer: allow 3-char acronyms like "API",
+        // "GPT" that users frequently correct by hand.
+        return trimmed.count >= 3
     }
 
     private static func extractJSONObjectOrArray(from response: String) -> String? {

--- a/Sources/Typeflux/Workflow/WorkflowController+AutomaticVocabulary.swift
+++ b/Sources/Typeflux/Workflow/WorkflowController+AutomaticVocabulary.swift
@@ -1,5 +1,16 @@
 import Foundation
 
+/// Snapshot of a currently running automatic-vocabulary observation. Lives on
+/// `WorkflowController` so an incoming schedule can finalize (run analysis with
+/// whatever has been observed so far) before the previous task is cancelled.
+struct AutomaticVocabularyActiveSession {
+    let sessionID: UUID
+    let insertedText: String
+    var baselineText: String?
+    var latestObservedText: String?
+    var hasObservedChange: Bool
+}
+
 extension WorkflowController {
     struct AutomaticVocabularyExpectedApp: Equatable {
         let bundleIdentifier: String?
@@ -9,8 +20,13 @@ extension WorkflowController {
 
     // swiftlint:disable:next function_body_length cyclomatic_complexity
     func scheduleAutomaticVocabularyObservation(for insertedText: String) {
+        // If a previous observation is still running and has seen user edits, try
+        // to finalize it before starting the new one. Otherwise the user's
+        // follow-up dictation silently throws away a partially observed session.
+        finalizePreviousAutomaticVocabularySessionIfNeeded()
         automaticVocabularyObservationTask?.cancel()
         automaticVocabularyObservationTask = nil
+        automaticVocabularyActiveSession = nil
 
         guard settingsStore.automaticVocabularyCollectionEnabled else {
             logAutomaticVocabulary("skip scheduling: feature disabled")
@@ -23,8 +39,17 @@ extension WorkflowController {
             return
         }
 
+        let sessionID = UUID()
+        automaticVocabularyActiveSession = AutomaticVocabularyActiveSession(
+            sessionID: sessionID,
+            insertedText: normalizedInsertedText,
+            baselineText: nil,
+            latestObservedText: nil,
+            hasObservedChange: false,
+        )
         logAutomaticVocabulary(
-            "session scheduled | insertedText=\(automaticVocabularyPreview(normalizedInsertedText)) "
+            "session scheduled | session=\(shortSessionID(sessionID)) "
+                + "| insertedText=\(automaticVocabularyPreview(normalizedInsertedText)) "
                 + "| observationWindow=\(Int(Self.automaticVocabularyObservationWindow))s "
                 + "| idleSettleDelay=\(Self.automaticVocabularyIdleSettleDelay)s",
         )
@@ -32,7 +57,8 @@ extension WorkflowController {
         automaticVocabularyObservationTask = Task { [weak self] in
             guard let self else { return }
 
-            guard let initialSnapshot = await readInitialEditableSnapshot() else {
+            guard let initialSnapshot = await readInitialEditableSnapshot(sessionID: sessionID) else {
+                clearActiveAutomaticVocabularySession(for: sessionID)
                 return
             }
             let expectedApp = automaticVocabularyExpectedApp(from: initialSnapshot)
@@ -40,7 +66,7 @@ extension WorkflowController {
             do {
                 try await Task.sleep(for: Self.automaticVocabularyStartupDelay)
             } catch {
-                logAutomaticVocabulary("session cancelled before startup delay finished")
+                logAutomaticVocabulary("session cancelled before startup delay finished | session=\(shortSessionID(sessionID))")
                 return
             }
 
@@ -50,19 +76,26 @@ extension WorkflowController {
             )
             guard let baselineText = baselineSnapshot.text else {
                 logAutomaticVocabulary(
-                    "session aborted: failed to read baseline input text | "
+                    "session aborted: failed to read baseline input text | session=\(shortSessionID(sessionID)) | "
                         + describeCurrentInputTextSnapshot(baselineSnapshot),
                 )
+                clearActiveAutomaticVocabularySession(for: sessionID)
                 return
             }
             guard automaticVocabularyMatchesExpectedApp(baselineSnapshot, expectedApp: expectedApp) else {
                 logAutomaticVocabulary(
-                    "session aborted: focused app changed before baseline was captured | expected="
+                    "session aborted: focused app changed before baseline was captured | session=\(shortSessionID(sessionID)) | expected="
                         + describeAutomaticVocabularyExpectedApp(expectedApp)
                         + " | actual="
                         + describeCurrentInputTextSnapshot(baselineSnapshot),
                 )
+                clearActiveAutomaticVocabularySession(for: sessionID)
                 return
+            }
+
+            updateActiveAutomaticVocabularySession(sessionID: sessionID) { session in
+                session.baselineText = baselineText
+                session.latestObservedText = baselineText
             }
 
             var observationState = AutomaticVocabularyMonitor.makeObservationState(
@@ -70,7 +103,8 @@ extension WorkflowController {
                 startedAt: Date(),
             )
             logAutomaticVocabulary(
-                "session started | baselineText=\(automaticVocabularyPreview(baselineText))",
+                "session started | session=\(shortSessionID(sessionID)) "
+                    + "| baselineText=\(automaticVocabularyPreview(baselineText))",
             )
             let deadline = Date().addingTimeInterval(Self.automaticVocabularyObservationWindow)
             var exitReason: AutomaticVocabularySessionExit = .deadlineReached
@@ -85,7 +119,7 @@ extension WorkflowController {
                 do {
                     try await Task.sleep(for: Self.automaticVocabularyPollInterval)
                 } catch {
-                    logAutomaticVocabulary("session cancelled during polling")
+                    logAutomaticVocabulary("session cancelled during polling | session=\(shortSessionID(sessionID))")
                     return
                 }
 
@@ -93,18 +127,19 @@ extension WorkflowController {
                 let currentSnapshot = await textInjector.currentInputTextSnapshot()
                 guard let currentText = currentSnapshot.text else {
                     logAutomaticVocabulary(
-                        "poll skipped: failed to read current input text | "
+                        "poll skipped: failed to read current input text | session=\(shortSessionID(sessionID)) | "
                             + describeCurrentInputTextSnapshot(currentSnapshot),
                     )
                     continue pollingLoop
                 }
                 guard automaticVocabularyMatchesExpectedApp(currentSnapshot, expectedApp: expectedApp) else {
                     logAutomaticVocabulary(
-                        "session aborted: focused app changed during observation | expected="
+                        "session aborted: focused app changed during observation | session=\(shortSessionID(sessionID)) | expected="
                             + describeAutomaticVocabularyExpectedApp(expectedApp)
                             + " | actual="
                             + describeCurrentInputTextSnapshot(currentSnapshot),
                     )
+                    clearActiveAutomaticVocabularySession(for: sessionID)
                     return
                 }
 
@@ -115,8 +150,13 @@ extension WorkflowController {
                     state: &observationState,
                 )
                 if didChange {
+                    updateActiveAutomaticVocabularySession(sessionID: sessionID) { session in
+                        session.latestObservedText = currentText
+                        session.hasObservedChange = true
+                    }
                     logAutomaticVocabulary(
-                        "change observed | latestText=\(automaticVocabularyPreview(currentText))",
+                        "change observed | session=\(shortSessionID(sessionID)) "
+                            + "| latestText=\(automaticVocabularyPreview(currentText))",
                     )
                 }
 
@@ -131,11 +171,14 @@ extension WorkflowController {
             }
 
             logAutomaticVocabulary(
-                "observation finished | reason=\(exitReason) "
+                "observation finished | session=\(shortSessionID(sessionID)) "
+                    + "| reason=\(exitReason) "
                     + "| finalText=\(automaticVocabularyPreview(observationState.latestObservedText))",
             )
 
+            clearActiveAutomaticVocabularySession(for: sessionID)
             await runAutomaticVocabularyAnalysis(
+                sessionID: sessionID,
                 insertedText: normalizedInsertedText,
                 baselineText: observationState.baselineText,
                 finalText: observationState.latestObservedText,
@@ -144,12 +187,13 @@ extension WorkflowController {
     }
 
     func runAutomaticVocabularyAnalysis(
+        sessionID: UUID = UUID(),
         insertedText: String,
         baselineText: String,
         finalText: String,
     ) async {
         guard finalText != baselineText else {
-            logAutomaticVocabulary("analysis skipped: final text unchanged from baseline")
+            logAutomaticVocabulary("analysis skipped: final text unchanged from baseline | session=\(shortSessionID(sessionID))")
             return
         }
 
@@ -157,7 +201,7 @@ extension WorkflowController {
             from: baselineText,
             to: finalText,
         ) else {
-            logAutomaticVocabulary("analysis skipped: no candidate terms found after diff")
+            logAutomaticVocabulary("analysis skipped: no candidate terms found after diff | session=\(shortSessionID(sessionID))")
             return
         }
 
@@ -165,7 +209,7 @@ extension WorkflowController {
             change: change,
             insertedText: insertedText,
         ) {
-            logAutomaticVocabulary("analysis skipped: change resembles initial text insertion")
+            logAutomaticVocabulary("analysis skipped: change resembles initial text insertion | session=\(shortSessionID(sessionID))")
             return
         }
 
@@ -181,7 +225,8 @@ extension WorkflowController {
                 final: finalText,
             )
             logAutomaticVocabulary(
-                "analysis skipped: edit too large | editRatio=\(String(format: "%.2f", ratio)) "
+                "analysis skipped: edit too large | session=\(shortSessionID(sessionID)) "
+                    + "| editRatio=\(String(format: "%.2f", ratio)) "
                     + "| insertedLen=\(insertedText.count) "
                     + "| baselineLen=\(baselineText.count) | finalLen=\(finalText.count)",
             )
@@ -190,7 +235,8 @@ extension WorkflowController {
 
         let candidateSummary = change.candidateTerms.joined(separator: ", ")
         logAutomaticVocabulary(
-            "diff detected | oldFragment=\(automaticVocabularyPreview(change.oldFragment)) "
+            "diff detected | session=\(shortSessionID(sessionID)) "
+                + "| oldFragment=\(automaticVocabularyPreview(change.oldFragment)) "
                 + "| newFragment=\(automaticVocabularyPreview(change.newFragment)) "
                 + "| candidates=\(candidateSummary)",
         )
@@ -201,15 +247,15 @@ extension WorkflowController {
                 change: change,
             )
             let approvedSummary = acceptedTerms.joined(separator: ", ")
-            logAutomaticVocabulary("llm decision received | approvedTerms=\(approvedSummary)")
+            logAutomaticVocabulary("llm decision received | session=\(shortSessionID(sessionID)) | approvedTerms=\(approvedSummary)")
             let addedTerms = addAutomaticVocabularyTerms(acceptedTerms)
             guard !addedTerms.isEmpty else {
-                logAutomaticVocabulary("analysis completed: no new terms added")
+                logAutomaticVocabulary("analysis completed: no new terms added | session=\(shortSessionID(sessionID))")
                 return
             }
 
             let addedSummary = addedTerms.joined(separator: ", ")
-            logAutomaticVocabulary("terms added | addedTerms=\(addedSummary)")
+            logAutomaticVocabulary("terms added | session=\(shortSessionID(sessionID)) | addedTerms=\(addedSummary)")
 
             await MainActor.run {
                 self.overlayController.showNotice(
@@ -217,38 +263,41 @@ extension WorkflowController {
                 )
             }
         } catch {
-            logAutomaticVocabulary("analysis failed: \(error.localizedDescription)")
+            logAutomaticVocabulary("analysis failed | session=\(shortSessionID(sessionID)) | error=\(error.localizedDescription)")
             ErrorLogStore.shared.log(
                 "Automatic vocabulary evaluation failed: \(error.localizedDescription)",
             )
         }
     }
 
-    private func readInitialEditableSnapshot() async -> CurrentInputTextSnapshot? {
-        let firstSnapshot = await textInjector.currentInputTextSnapshot()
-        if firstSnapshot.isEditable {
-            return firstSnapshot
+    private func readInitialEditableSnapshot(sessionID: UUID) async -> CurrentInputTextSnapshot? {
+        var latestSnapshot = await textInjector.currentInputTextSnapshot()
+        if latestSnapshot.isEditable {
+            return latestSnapshot
+        }
+
+        for attempt in 1 ... Self.automaticVocabularyInitialSnapshotRetryCount {
+            logAutomaticVocabulary(
+                "initial snapshot not editable, retrying \(attempt)/\(Self.automaticVocabularyInitialSnapshotRetryCount) "
+                    + "| session=\(shortSessionID(sessionID)) | "
+                    + describeCurrentInputTextSnapshot(latestSnapshot),
+            )
+
+            do {
+                try await Task.sleep(for: Self.automaticVocabularyInitialSnapshotRetryDelay)
+            } catch {
+                return nil
+            }
+
+            latestSnapshot = await textInjector.currentInputTextSnapshot()
+            if latestSnapshot.isEditable {
+                return latestSnapshot
+            }
         }
 
         logAutomaticVocabulary(
-            "initial snapshot not editable, retrying | "
-                + describeCurrentInputTextSnapshot(firstSnapshot),
-        )
-
-        do {
-            try await Task.sleep(for: .milliseconds(400))
-        } catch {
-            return nil
-        }
-
-        let retrySnapshot = await textInjector.currentInputTextSnapshot()
-        if retrySnapshot.isEditable {
-            return retrySnapshot
-        }
-
-        logAutomaticVocabulary(
-            "session aborted: context is not editable after retry | "
-                + describeCurrentInputTextSnapshot(retrySnapshot),
+            "session aborted: context is not editable after retry | session=\(shortSessionID(sessionID)) | "
+                + describeCurrentInputTextSnapshot(latestSnapshot),
         )
         return nil
     }
@@ -262,7 +311,7 @@ extension WorkflowController {
             oldFragment: change.oldFragment,
             newFragment: change.newFragment,
             candidateTerms: change.candidateTerms,
-            existingTerms: VocabularyStore.activeTerms(),
+            existingTerms: VocabularyStore.allTerms(),
         )
         let response = try await llmService.completeJSON(
             systemPrompt: prompts.system,
@@ -275,7 +324,7 @@ extension WorkflowController {
 
     func addAutomaticVocabularyTerms(_ terms: [String]) -> [String] {
         let existingTerms = Set(
-            VocabularyStore.activeTerms().map {
+            VocabularyStore.allTerms().map {
                 $0.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
             },
         )
@@ -360,6 +409,10 @@ extension WorkflowController {
         NetworkDebugLogger.logMessage("[Auto Vocabulary] \(message)")
     }
 
+    func shortSessionID(_ id: UUID) -> String {
+        String(id.uuidString.prefix(8))
+    }
+
     func automaticVocabularyPreview(_ text: String, limit: Int = 80) -> String {
         let normalized = text.replacingOccurrences(of: "\n", with: "\\n")
         guard normalized.count > limit else { return normalized }
@@ -422,5 +475,60 @@ extension WorkflowController {
         let normalized = value?.trimmingCharacters(in: .whitespacesAndNewlines)
         guard let normalized, !normalized.isEmpty else { return nil }
         return normalized
+    }
+
+    // MARK: - Active session state plumbing
+
+    func updateActiveAutomaticVocabularySession(
+        sessionID: UUID,
+        mutate: (inout AutomaticVocabularyActiveSession) -> Void,
+    ) {
+        guard var session = automaticVocabularyActiveSession,
+              session.sessionID == sessionID
+        else {
+            return
+        }
+        mutate(&session)
+        automaticVocabularyActiveSession = session
+    }
+
+    func clearActiveAutomaticVocabularySession(for sessionID: UUID) {
+        guard let session = automaticVocabularyActiveSession, session.sessionID == sessionID else {
+            return
+        }
+        automaticVocabularyActiveSession = nil
+    }
+
+    /// Invoked at the top of `scheduleAutomaticVocabularyObservation`. If the
+    /// previous session already observed a meaningful edit, we launch a detached
+    /// analysis task using its last-known state instead of losing that work when
+    /// the previous observation Task is cancelled below.
+    func finalizePreviousAutomaticVocabularySessionIfNeeded() {
+        guard let session = automaticVocabularyActiveSession,
+              session.hasObservedChange,
+              let baseline = session.baselineText,
+              let latest = session.latestObservedText,
+              baseline != latest
+        else {
+            return
+        }
+
+        let insertedText = session.insertedText
+        let sessionID = session.sessionID
+        logAutomaticVocabulary(
+            "finalizing previous session before new observation "
+                + "| session=\(shortSessionID(sessionID)) "
+                + "| finalText=\(automaticVocabularyPreview(latest))",
+        )
+
+        Task.detached { [weak self] in
+            guard let self else { return }
+            await self.runAutomaticVocabularyAnalysis(
+                sessionID: sessionID,
+                insertedText: insertedText,
+                baselineText: baseline,
+                finalText: latest,
+            )
+        }
     }
 }

--- a/Sources/Typeflux/Workflow/WorkflowController+Processing.swift
+++ b/Sources/Typeflux/Workflow/WorkflowController+Processing.swift
@@ -270,6 +270,12 @@ extension WorkflowController {
             } else {
                 try textInjector.insert(text: text)
             }
+            let bumpedTerms = VocabularyStore.incrementOccurrences(in: text)
+            if !bumpedTerms.isEmpty {
+                NetworkDebugLogger.logMessage(
+                    "[Apply Text] vocabulary occurrences bumped: \(bumpedTerms.joined(separator: ", "))",
+                )
+            }
             scheduleAutomaticVocabularyObservation(for: text)
             NetworkDebugLogger.logMessage(
                 """

--- a/Sources/Typeflux/Workflow/WorkflowController.swift
+++ b/Sources/Typeflux/Workflow/WorkflowController.swift
@@ -11,11 +11,21 @@ final class WorkflowController {
     static let selectionRestoreDelayMicroseconds: useconds_t = 120_000
     static let automaticVocabularyObservationWindow: TimeInterval = 30
     static let automaticVocabularyPollInterval: Duration = .seconds(1)
-    static let automaticVocabularyStartupDelay: Duration = .milliseconds(600)
+    // Bumped from 600ms to 900ms so the paste fallback path has time for focus and
+    // pasteboard restoration before we start reading the AX baseline.
+    static let automaticVocabularyStartupDelay: Duration = .milliseconds(900)
     static let automaticVocabularyBaselineRetryDelay: Duration = .milliseconds(400)
     static let automaticVocabularyBaselineRetryCount = 6
-    static let automaticVocabularyIdleSettleDelay: TimeInterval = 8
-    static let automaticVocabularyEditRatioLimit: Double = 0.6
+    // Retry the initial editable-focus snapshot a few times — Electron/web targets
+    // frequently report non-editable roles on the first AX query after insertion.
+    static let automaticVocabularyInitialSnapshotRetryCount = 3
+    static let automaticVocabularyInitialSnapshotRetryDelay: Duration = .milliseconds(400)
+    // Dropped from 8s to 4s so real editing sessions have a realistic chance to
+    // complete before the next dictation arrives.
+    static let automaticVocabularyIdleSettleDelay: TimeInterval = 4
+    // Raised from 0.6 to 0.8 so short dictations with a delete+retype edit are
+    // still considered for analysis.
+    static let automaticVocabularyEditRatioLimit: Double = 0.8
     static let localModelPreheatDebounce: Duration = .milliseconds(180)
     static let llmTimeoutAfterTranscriptionSeconds: TimeInterval = 120
     static let recordingStartCueLeadIn: Duration = .milliseconds(60)
@@ -79,6 +89,10 @@ final class WorkflowController {
     var selectionTask: Task<TextSelectionSnapshot, Never>?
     var processingTask: Task<Void, Never>?
     var automaticVocabularyObservationTask: Task<Void, Never>?
+    /// Latest snapshot of the currently running automatic-vocabulary observation.
+    /// Kept in sync by the observation task so that an incoming `scheduleAutomatic…`
+    /// call can finalize-then-cancel instead of dropping partially-observed work.
+    var automaticVocabularyActiveSession: AutomaticVocabularyActiveSession?
     var processingSessionID = UUID()
     var activeProcessingRecordID: UUID?
     var lastRetryableFailureRecord: HistoryRecord?

--- a/Tests/TypefluxTests/AutomaticVocabularyMonitorTests.swift
+++ b/Tests/TypefluxTests/AutomaticVocabularyMonitorTests.swift
@@ -380,8 +380,9 @@ final class AutomaticVocabularyMonitorTests: XCTestCase {
         let terms = AutomaticVocabularyMonitor.parseAcceptedTerms(
             from: #"{"terms":["A","AI","UI","GPT","GPT4"]}"#,
         )
-        // A (1), AI (2), UI (2), GPT (3) all rejected; only GPT4 (4) passes.
-        XCTAssertEqual(terms, ["GPT4"])
+        // A (1), AI (2), UI (2) rejected; GPT (3) and GPT4 (4) both pass under the
+        // relaxed 3-char minimum for English/Latin acronyms.
+        XCTAssertEqual(terms, ["GPT", "GPT4"])
     }
 
     func testParseAcceptedTermsRejectsPureDigits() {

--- a/Tests/TypefluxTests/VocabularyStoreTests.swift
+++ b/Tests/TypefluxTests/VocabularyStoreTests.swift
@@ -202,4 +202,137 @@ final class VocabularyStoreExtendedTests: XCTestCase {
         XCTAssertEqual(VocabularySource.manual.rawValue, "manual")
         XCTAssertEqual(VocabularySource.automatic.rawValue, "automatic")
     }
+
+    // MARK: - occurrenceCount + ranking
+
+    func testAddInitialTermHasOccurrenceCountOne() {
+        let entries = VocabularyStore.add(term: "SeedASR", source: .manual)
+        XCTAssertEqual(entries.first?.occurrenceCount, 1)
+    }
+
+    func testAddDuplicateBumpsOccurrenceCountInsteadOfInsertingNewEntry() {
+        _ = VocabularyStore.add(term: "SeedASR", source: .manual)
+        _ = VocabularyStore.add(term: "SeedASR", source: .automatic)
+        let entries = VocabularyStore.add(term: "seedasr", source: .automatic) // case-insensitive
+        XCTAssertEqual(entries.filter { $0.term.lowercased() == "seedasr" }.count, 1)
+        XCTAssertEqual(entries.first(where: { $0.term.lowercased() == "seedasr" })?.occurrenceCount, 3)
+    }
+
+    func testAddPreservesOriginalCreatedAtAndTermWhenBumping() {
+        let initial = VocabularyStore.add(term: "Typeflux", source: .manual)
+        let originalID = initial.first?.id
+        let originalCreatedAt = initial.first?.createdAt
+
+        // Sleep a moment so createdAt would differ if the record were replaced.
+        Thread.sleep(forTimeInterval: 0.01)
+        let after = VocabularyStore.add(term: "Typeflux", source: .automatic)
+        XCTAssertEqual(after.first?.id, originalID)
+        XCTAssertEqual(after.first?.createdAt, originalCreatedAt)
+        XCTAssertEqual(after.first?.term, "Typeflux")
+    }
+
+    func testIncrementOccurrencesBumpsMatchingTerms() {
+        _ = VocabularyStore.add(term: "SeedASR", source: .manual)
+        _ = VocabularyStore.add(term: "向量", source: .manual)
+        _ = VocabularyStore.add(term: "GPT", source: .manual)
+
+        let bumped = VocabularyStore.incrementOccurrences(
+            in: "测试 SeedASR 与 向量 数据库",
+        )
+        XCTAssertEqual(Set(bumped), Set(["SeedASR", "向量"]))
+
+        let entries = VocabularyStore.load()
+        let bySeed = entries.first(where: { $0.term == "SeedASR" })
+        let byVector = entries.first(where: { $0.term == "向量" })
+        let byGPT = entries.first(where: { $0.term == "GPT" })
+        XCTAssertEqual(bySeed?.occurrenceCount, 2)
+        XCTAssertEqual(byVector?.occurrenceCount, 2)
+        XCTAssertEqual(byGPT?.occurrenceCount, 1)
+    }
+
+    func testIncrementOccurrencesEmptyTextIsNoOp() {
+        _ = VocabularyStore.add(term: "SeedASR", source: .manual)
+        let bumped = VocabularyStore.incrementOccurrences(in: "   ")
+        XCTAssertTrue(bumped.isEmpty)
+        XCTAssertEqual(VocabularyStore.load().first?.occurrenceCount, 1)
+    }
+
+    func testIncrementOccurrencesIsCaseInsensitive() {
+        _ = VocabularyStore.add(term: "Typeflux", source: .manual)
+        let bumped = VocabularyStore.incrementOccurrences(in: "I love typeflux!")
+        XCTAssertEqual(bumped, ["Typeflux"])
+        XCTAssertEqual(VocabularyStore.load().first?.occurrenceCount, 2)
+    }
+
+    func testActiveTermsSortedByCountThenCreatedAt() {
+        _ = VocabularyStore.add(term: "Oldest", source: .manual)
+        Thread.sleep(forTimeInterval: 0.01)
+        _ = VocabularyStore.add(term: "Middle", source: .manual)
+        Thread.sleep(forTimeInterval: 0.01)
+        _ = VocabularyStore.add(term: "Newest", source: .manual)
+
+        // Middle appears twice → highest count → first in ranking.
+        _ = VocabularyStore.add(term: "Middle", source: .manual)
+
+        let active = VocabularyStore.activeTerms()
+        XCTAssertEqual(active.prefix(3).map { $0 }, ["Middle", "Newest", "Oldest"])
+    }
+
+    func testActiveTermsCapsAt100Entries() {
+        var seeded: [VocabularyEntry] = []
+        let baseDate = Date(timeIntervalSince1970: 100_000)
+        for i in 0 ..< 150 {
+            seeded.append(
+                VocabularyEntry(
+                    term: "Term\(String(format: "%03d", i))",
+                    source: .manual,
+                    createdAt: baseDate.addingTimeInterval(TimeInterval(i)),
+                    occurrenceCount: 1,
+                ),
+            )
+        }
+        VocabularyStore.save(seeded)
+
+        let active = VocabularyStore.activeTerms()
+        XCTAssertEqual(active.count, 100)
+        // Latest createdAt wins the tiebreak → Term149 is first.
+        XCTAssertEqual(active.first, "Term149")
+        // Term049 is the 100th most-recent; Term048 should have been dropped.
+        XCTAssertTrue(active.contains("Term050"))
+        XCTAssertFalse(active.contains("Term049"))
+    }
+
+    func testAllTermsReturnsEverythingUnlimited() {
+        var seeded: [VocabularyEntry] = []
+        for i in 0 ..< 120 {
+            seeded.append(
+                VocabularyEntry(
+                    term: "Term\(i)",
+                    source: .manual,
+                    createdAt: Date(timeIntervalSince1970: TimeInterval(1_000 + i)),
+                    occurrenceCount: 1,
+                ),
+            )
+        }
+        VocabularyStore.save(seeded)
+        XCTAssertEqual(VocabularyStore.allTerms().count, 120)
+    }
+
+    func testVocabularyEntryDecodesWithoutOccurrenceCountFieldAsOne() throws {
+        // Legacy on-disk payload — simulates entries saved by pre-ranking builds.
+        let legacyJSON = """
+        [
+          {
+            "id": "\(UUID().uuidString)",
+            "term": "Legacy",
+            "source": "manual",
+            "createdAt": 1000
+          }
+        ]
+        """
+        let data = try XCTUnwrap(legacyJSON.data(using: .utf8))
+        let decoder = JSONDecoder()
+        let entries = try decoder.decode([VocabularyEntry].self, from: data)
+        XCTAssertEqual(entries.first?.occurrenceCount, 1)
+    }
 }

--- a/Tests/TypefluxTests/WorkflowControllerAutomaticVocabularyTests.swift
+++ b/Tests/TypefluxTests/WorkflowControllerAutomaticVocabularyTests.swift
@@ -111,6 +111,52 @@ final class WorkflowControllerAutomaticVocabularyTests: XCTestCase {
         XCTAssertEqual(llmService.completeJSONCallCount, 0)
     }
 
+    func testScheduleNewObservationFinalizesPreviousSessionWhenEditsWereObserved() async {
+        let llmService = MockWorkflowLLMService(stubbedJSON: #"{"terms":["SeedASR"]}"#)
+        let controller = makeWorkflowController(llmService: llmService)
+
+        // Simulate a previous session that observed a real user edit but never
+        // reached the end of its observation window.
+        controller.automaticVocabularyActiveSession = AutomaticVocabularyActiveSession(
+            sessionID: UUID(),
+            insertedText: "please check the seedsr config",
+            baselineText: "please check the seedsr config",
+            latestObservedText: "please check the SeedASR config",
+            hasObservedChange: true,
+        )
+
+        controller.finalizePreviousAutomaticVocabularySessionIfNeeded()
+
+        // The analysis runs on a detached Task — wait a bit for completion.
+        for _ in 0 ..< 40 {
+            if llmService.completeJSONCallCount > 0 { break }
+            try? await Task.sleep(for: .milliseconds(50))
+        }
+
+        XCTAssertEqual(llmService.completeJSONCallCount, 1)
+        if let entry = VocabularyStore.load().first(where: { $0.term == "SeedASR" }) {
+            _ = VocabularyStore.remove(id: entry.id)
+        }
+    }
+
+    func testScheduleNewObservationSkipsFinalizationWhenNoChangeWasObserved() {
+        let llmService = MockWorkflowLLMService()
+        let controller = makeWorkflowController(llmService: llmService)
+
+        // Baseline captured but no user edit ever happened — nothing to analyze.
+        controller.automaticVocabularyActiveSession = AutomaticVocabularyActiveSession(
+            sessionID: UUID(),
+            insertedText: "hello",
+            baselineText: "hello",
+            latestObservedText: "hello",
+            hasObservedChange: false,
+        )
+
+        controller.finalizePreviousAutomaticVocabularySessionIfNeeded()
+
+        XCTAssertEqual(llmService.completeJSONCallCount, 0)
+    }
+
     // MARK: - runAutomaticVocabularyAnalysis orchestration paths
 
     func testRunAnalysisSmallRewriteReachesLLM() async {

--- a/docs/AUTOMATIC_VOCABULARY.md
+++ b/docs/AUTOMATIC_VOCABULARY.md
@@ -1,0 +1,263 @@
+# 自动词库（Automatic Vocabulary Collection）设计文档
+
+本文梳理 Typeflux「自动添加词条」功能的整体设计、关键实现、当前存在的问题与修复方向。
+本文档仅描述现状分析与建议，不包含任何代码变更。
+
+---
+
+## 1. 功能目标
+
+在用户使用语音听写并将文本插入到宿主 App 后，如果用户对插入的文本做了小范围的手动修改（例如把 `type flux` 改成 `Typeflux`、把 `Open AI Realtime` 改成 `OpenAI Realtime`），Typeflux 希望：
+
+1. 观察一段时间内用户在该输入框中的最终文本变化；
+2. 通过 LLM 判断新出现的"词"是否值得加入语音识别词库；
+3. 把合格的词条写入 `VocabularyStore`，后续听写可把它作为 prompt/hints 提高识别准确率。
+
+整个链路**完全后台运行、无需用户显式操作**，由设置项 `automaticVocabularyCollectionEnabled` 总开关控制，默认开启。
+
+---
+
+## 2. 架构概览
+
+```
+applyText()
+   └── textInjector.insert / replaceSelection   (AX / 粘贴回退)
+   └── scheduleAutomaticVocabularyObservation(for: insertedText)
+            │
+            ▼
+       Task (观察会话)
+            ├── readInitialEditableSnapshot()          // 判定当前焦点可编辑
+            ├── automaticVocabularyStartupDelay (600ms)
+            ├── readAutomaticVocabularyBaselineWithRetry()   // 捕获 baseline
+            ├── polling loop（interval=1s, window=30s）
+            │     ├─ textInjector.currentInputTextSnapshot()
+            │     ├─ 校验焦点 App 未切换
+            │     ├─ observe(text, state) → 更新 latestObservedText / lastChangedAt
+            │     └─ shouldTriggerAnalysis? (idleSettleDelay = 8s)
+            ▼
+       runAutomaticVocabularyAnalysis(insertedText, baselineText, finalText)
+            ├── AutomaticVocabularyMonitor.detectChange
+            │       (oldFragment / newFragment / candidateTerms)
+            ├── changeIsJustInitialInsertion?   → 跳过
+            ├── isEditTooLarge? (ratio > 0.6)    → 跳过
+            ├── evaluateAutomaticVocabularyCandidates
+            │       → LLMRouter.completeJSON (structured JSON schema)
+            ├── parseAcceptedTerms
+            └── addAutomaticVocabularyTerms → VocabularyStore.add(source:.automatic)
+                   └── overlayController.showNotice
+```
+
+关键源文件：
+
+- [Sources/Typeflux/Workflow/AutomaticVocabularyMonitor.swift](Sources/Typeflux/Workflow/AutomaticVocabularyMonitor.swift) — 纯算法层：diff、分词、编辑比例、JSON 解析、候选/接受词合法性校验
+- [Sources/Typeflux/Workflow/WorkflowController+AutomaticVocabulary.swift](Sources/Typeflux/Workflow/WorkflowController+AutomaticVocabulary.swift) — 编排层：调度观察 Task、轮询 AX、调用 LLM、落库
+- [Sources/Typeflux/Workflow/WorkflowController+Processing.swift:273](Sources/Typeflux/Workflow/WorkflowController+Processing.swift) — `applyText` 成功后调度观察
+- [Sources/Typeflux/Settings/VocabularyStore.swift](Sources/Typeflux/Settings/VocabularyStore.swift) — 词库存储（UserDefaults + JSON）
+- [Sources/Typeflux/LLM/PromptCatalog.swift:303](Sources/Typeflux/LLM/PromptCatalog.swift) — `automaticVocabularyDecisionPrompts`
+- [Sources/Typeflux/Settings/SettingsStore.swift:475](Sources/Typeflux/Settings/SettingsStore.swift) — 开关 `automaticVocabularyCollectionEnabled`
+
+---
+
+## 3. 关键参数
+
+| 参数 | 取值 | 含义 |
+|------|------|------|
+| `automaticVocabularyObservationWindow` | 30 s | 一次会话最长观察时长 |
+| `automaticVocabularyPollInterval` | 1 s | 轮询 AX 的间隔 |
+| `automaticVocabularyStartupDelay` | 600 ms | 插入完成后、读取 baseline 前的等待时间 |
+| `automaticVocabularyBaselineRetryDelay` | 400 ms | baseline 读取重试间隔 |
+| `automaticVocabularyBaselineRetryCount` | 6 | baseline 读取重试次数（最多 ~2.4 s） |
+| `automaticVocabularyIdleSettleDelay` | 8 s | 最近一次变更后，若 ≥ 8 s 无新变更则视为"稳定"，提前结束观察 |
+| `automaticVocabularyEditRatioLimit` | 0.6 | `(Levenshtein(baseline, final)) / insertedLen > 0.6` 则判为"用户大范围重写"，跳过 |
+
+候选词与合法词的关键校验：
+
+- 拉丁/数字 token：长度 ∈ [4, 32]，必须含字母；`[A-Za-z0-9]+(?:[._+\-'][A-Za-z0-9]+)*`
+- 汉字 token：长度 ∈ [2, 12]
+- LLM 接受后进一步过滤：`^[\p{Han}A-Za-z0-9](?:[\p{Han}A-Za-z0-9 ._+\-/']{0,38}[\p{Han}A-Za-z0-9])?$`
+
+---
+
+## 4. 当前实现的若干隐含假设
+
+1. 插入完成后 ~600 ms 内，宿主 App 的 AX 值能够稳定反映已插入文本；若不能，靠 `expectedSubstring` 重试（≤ 2.4 s）兜底。
+2. 用户修改行为发生在同一焦点元素、同一 App 内；一旦焦点切换（bundleId/pid/processName 不匹配），立即放弃该会话。
+3. 用户会在修改后**静默 8 s** 让观察结束；否则最多观察 30 s 就强行结束。
+4. 修改后的文本规模与听写文本规模相当（编辑比例 ≤ 0.6），否则视为"大改写"放弃。
+5. 同一时间只有一个观察会话——新的 `scheduleAutomaticVocabularyObservation` 会 `cancel` 上一个 Task。
+6. 宿主 App 的 `focusedElement()` AX 值会随用户手动编辑而更新（否则 final == baseline，等同于没改动）。
+
+---
+
+## 5. 已排查到的潜在失效原因（按概率由高到低）
+
+### 5.1 连续听写导致上一次观察会话被提前取消 ★★★★
+
+[WorkflowController+AutomaticVocabulary.swift:12-13](Sources/Typeflux/Workflow/WorkflowController+AutomaticVocabulary.swift)
+
+```swift
+automaticVocabularyObservationTask?.cancel()
+automaticVocabularyObservationTask = nil
+```
+
+`scheduleAutomaticVocabularyObservation` 在函数开头无条件取消上一次会话。这意味着：
+
+- 用户 A 时刻听写 → 插入 → 启动观察会话 1（最长 30 s）
+- 用户在同一会话窗口内（30 s 以内）再次按热键做第二次听写 → 插入 → **会话 1 被直接 cancel，分析从未执行**
+
+对于"经常连续短句听写 + 小修改"的用户（也就是绝大多数真实用例），会话 1 几乎没有机会走完 8 s 静默期或 30 s 窗口。结果：**尽管真正修改了文本，词库始终为空**。
+
+这是与用户反馈（"长期使用，没有任何词条被自动加入"）最吻合的失效模式。
+
+### 5.2 很多宿主 App 的 AX 值读取不可用 ★★★★
+
+[AXTextInjector.swift:383-497](Sources/Typeflux/TextInjection/AXTextInjector.swift) 的 `readCurrentInputTextSnapshot` 里，以下情况都会返回 `text == nil`：
+
+- `AXIsProcessTrusted() == false`（尚未授权辅助功能）
+- 没有 `focusedElement`
+- 焦点元素不可编辑（`isEditable == false`）
+- `kAXValueAttribute` 读不到（Electron、contenteditable、Chrome 地址栏、部分富文本视图都会命中）
+- AX value 等于 placeholder 或 title
+
+一旦：
+
+- 初始快照读不到 → `readInitialEditableSnapshot` 等 400 ms 再试一次，仍不可读则整个会话放弃；
+- baseline 读不到 → `baselineText` 为 `nil`，直接 abort；
+- baseline 虽有但不含 `expectedSubstring` → 走 6 次重试后仍然以"stale baseline"返回，轮询中如果最终文本与这个 stale 基线差异过大会被 `isEditTooLarge` 跳过。
+
+常见 AX 值读取不稳定 / 不可读的典型 App：Slack、Discord、VS Code、Chrome 的 contenteditable、Logseq、Notion、Obsidian 等 Electron/自绘类 App。如果用户主要在这类 App 里做修改，**观察会话几乎每次都在 `readInitialEditableSnapshot` 或 baseline 读取阶段就已经退出**。
+
+### 5.3 粘贴回退路径带来的焦点/AX 时序问题 ★★★
+
+[AXTextInjector+Paste.swift:8](Sources/Typeflux/TextInjection/AXTextInjector+Paste.swift) 在 AX 直写失败时会走剪贴板粘贴路径。粘贴涉及：
+
+- 临时写剪贴板 → 发送 ⌘V → 等待 App 处理 → 还原剪贴板
+
+这个过程中：
+
+- `scheduleAutomaticVocabularyObservation` 被**同步**调用在 `applyText` 末尾，但 paste 路径本身异步；
+- Task 立即 `readInitialEditableSnapshot`，此时焦点可能还在瞬时的还原过程中；
+- 600 ms startup delay 对有的 App 太短，baseline 读到的仍然是插入前的状态，`expectedSubstring` 检查失败，重试完后落到"stale baseline"分支。
+
+组合起来：粘贴路径下会话启动鲁棒性较差。
+
+### 5.4 候选词被过于严格的长度阈值过滤 ★★★
+
+`isValidLatinOrNumberToken` 要求 **≥ 4 个字符**，所以 `GPT`、`API`、`iOS`、`AI`、`ASR`、`LLM`、`AST`、`AX`、`UI`、`gRPC`、`npm`、`pip`、`YAML` 等**用户最容易修正**的专业缩写全部被 diff 算法丢弃——即使用户确实把 `A.I.` 改成 `AI`、把 `api` 改成 `API`，它们也根本进不了候选列表，自然也就永远不会被加入词库。
+
+汉字要求 ≥ 2 个字符相对合理；但对英文专业术语来说，4 字符下限过于保守。
+
+### 5.5 "新片段与插入文本的归一化后相等" 判定过严 ★★
+
+[AutomaticVocabularyMonitor.swift:204-215](Sources/Typeflux/Workflow/AutomaticVocabularyMonitor.swift) 的 `changeIsJustInitialInsertion`：
+
+```swift
+if normalizedNew == normalizedInserted { return true }
+let insertedTokens = Set(tokenize(insertedText).map(normalize))
+return change.candidateTerms.allSatisfy { insertedTokens.contains(normalize($0)) }
+```
+
+- 第一条（完全相等）防止 baseline 捕获滞后、把整段新插入的文本当成"用户修改"。没问题。
+- 第二条（所有候选词都出现在 insertedText 的 token 里）更激进。场景：用户听写的就是 "OpenAI"，被误识别成 "Open AI"，插入后用户手动删除空格合并为 "OpenAI"。修改后 newFragment = "OpenAI"，候选 = ["OpenAI"]，`tokenize("Open AI")`（输入给 insertText 的是识别后的 "OpenAI"？还是 "Open AI"？）需要具体看。
+
+更常见的问题场景：用户听写 "typeflux"，识别为 "type flux"（两个词），插入文本 = "type flux"（insertedText），用户改为 "Typeflux"。这时候 insertedTokens = {"type", "flux"}（"flux" 4 字符恰好过阈值），candidateTerm = "Typeflux"，normalized = "typeflux" ∉ {"type", "flux"} → 不会被拦截。**这一条在大多数情况是安全的**，但与 §5.4 结合会显著降低召回。
+
+### 5.6 编辑比例 0.6 对"删除+重写"场景偏严 ★★
+
+如果用户的修改是"把 baseline 中的一整个片段删掉再重写"（经常发生在尝试替换比较啰嗦的表达时），Levenshtein 距离容易超过 insertedText 长度的 60%，直接走 `analysis skipped: edit too large`。对于很短的听写（<20 字符），阈值效应尤其明显。
+
+### 5.7 LLM 的 decision prompt 过于保守 ★★
+
+`automaticVocabularyDecisionPrompts` 指令包括：
+
+- "If uncertain, return an empty list."
+- "Prefer precision over recall"
+- 一大串 reject 清单
+
+在候选词本身就不多的前提下，LLM 很容易因为"不确定"直接返回 `{"terms": []}`。配合 §5.4、§5.6，端到端新增词条的概率被进一步压低。
+
+### 5.8 无观察结果时完全静默 ★
+
+整个流程只通过 `NetworkDebugLogger.logMessage("[Auto Vocabulary] ...")` 输出日志，**没有任何用户可见的状态指示**。用户完全无法区分：
+
+- 开关是否真的被打开（但默认就是 true）
+- 焦点 App 是不是在黑名单 / AX 不可读
+- 是不是会话被新的听写取消了
+- 是不是 LLM 拒绝了所有候选
+
+这是"为什么用户无法自检"的元原因。
+
+### 5.9 极小的可能：数据写入后未被读到 ★
+
+`VocabularyStore.add` → `save` → `UserDefaults.set` 是同步的；`load()` 立即回读也正常工作。从代码上看数据路径本身没问题，除非多端同时写 UserDefaults（应用本身是单进程，不会发生）。可以通过查看 `~/Library/Preferences/com.typeflux.plist` 中 `vocabulary.entries` 键验证。
+
+---
+
+## 6. 推荐的排障步骤（不改代码也能验证）
+
+1. **看日志**：Typeflux 以 `[Auto Vocabulary]` 前缀打印了完整事件流。开启 Console.app 或通过 `make dev` 终端日志抓取最近几次听写 + 修改会话，就能直接看到是在 `session scheduled / session aborted / analysis skipped / llm decision received` 哪一阶段断掉的。
+2. **检查 UserDefaults**：`defaults read com.typeflux vocabulary.entries`（或读 plist 文件）看是否有 `source: automatic` 的条目。
+3. **确认焦点 App**：重点区分两类场景 —— 原生 App（Notes、Mail、Safari 地址栏）和 Electron/Web App（Slack、Chrome、VS Code）。如果只在前者出现词条、后者从不出现，说明 §5.2 是主因。
+4. **单次测试**：刻意做一次「听写 → 停止听写 → 等 15 秒再修改 → 再等 15 秒什么都不做」，看会不会触发 `terms added` 日志。如果这种拉长间隔的单次测试有效，而平常连续使用无效，说明 §5.1 是主因。
+
+---
+
+## 7. 修复建议（待确认后再实现）
+
+按影响面和实现成本排序：
+
+### 7.1 改变"连续听写即取消"的策略（对应 §5.1）★★★★
+
+当前：新听写会立即取消上一次观察会话。
+建议：新听写到来时，对上一次会话做**即时 finalize**，而不是直接 `cancel()`。具体做法：
+
+- 把"取消"改成"立即截断观察并跑分析"：使用已收集的 `state.latestObservedText` 立刻调 `runAutomaticVocabularyAnalysis`，即便 idle 还没达到 8s；
+- 或者引入一个轻量的"快速结算"路径：只要观察期间曾有过变更（`lastChangedAt != nil`），就允许打断后分析。
+
+实现难度：低（在 `scheduleAutomaticVocabularyObservation` 入口加一段"先 finalize，再调度"的逻辑），覆盖的用户场景最广。
+
+### 7.2 放宽英文候选词的最短长度（对应 §5.4）★★★
+
+把 `isValidLatinOrNumberToken` 的下限从 4 降到 2 或 3，同时保留 LLM 端的"最小 4 字符 / 必须含字母"要求。即使 diff 阶段多放进几个短词，最终也会由 LLM 过滤掉绝大部分噪声。
+
+或者更保守：把长度判定区分"纯字母术语（3 起）"与"含数字术语（4 起）"。
+
+### 7.3 降低 idle settle delay / 引入多重触发（对应 §5.1 + §5.3）★★★
+
+8s 静默期在实际使用中偏长。建议：
+
+- 保留 8s 作为上限；
+- 当观察到的 `state.latestObservedText` 与 baseline 的差异已经"足够明显"（出现长度 ≥ N 的新 token）时，尝试触发一次**预分析**（不落库，只做前置校验），减少"刚修改完就被下一次听写打断"的概率。
+
+或者最简单：idle delay 从 8s 降到 3-4s。
+
+### 7.4 改善 AX 值读取鲁棒性（对应 §5.2 / §5.3）★★★
+
+- 把 `readInitialEditableSnapshot` 的重试次数从 1 增加到 2-3；
+- 当 `failureReason == "missing-ax-value"` 时，在开关 UI 中加"当前 App 不支持自动词库"的状态提示，帮助用户建立预期；
+- 粘贴路径下，把 `automaticVocabularyStartupDelay` 从 600 ms 提升到 900-1200 ms（或改为粘贴路径专属的延迟）。
+
+### 7.5 放宽 LLM 决策 prompt（对应 §5.7）★★
+
+- 移除 "Prefer precision over recall" / "If uncertain, return an empty list" 这一对保守指令；
+- 保留必须拒绝的负面清单，但对**正面判定**给出更明确的信号（"prefer keeping any capitalization/spacing correction that spans two or more tokens"）。
+- 可选：对 LLM 响应做"宽容模式"，把 LLM 返回的 terms 作为提名，但只入库那些同时通过确定性规则（如 `acceptedTermRegex` 且 normalizedCandidateTerms 中也存在）的词。
+
+### 7.6 可观察性（对应 §5.8）★★
+
+- 在设置页 > 词库 Tab 增加一个折叠区域"最近 10 次自动词库会话"，列出每次会话的退出原因（`session aborted (focused-element-not-editable)` / `analysis skipped (edit too large, ratio=0.72)` / `terms added`），让用户能自助排障；
+- Console log 的 `[Auto Vocabulary]` 前缀改为带 session id，便于跨行关联。
+
+### 7.7 编辑比例阈值（对应 §5.6）★
+
+把 `automaticVocabularyEditRatioLimit` 从 0.6 放宽到 0.8-1.0，或改为"插入较短时（< 20 字符）使用绝对字符上限而非比例"。保留"大规模重写直接跳过"的兜底语义。
+
+---
+
+## 8. 建议的落地顺序
+
+1. **先加日志/埋点**（§7.6），在不改语义的情况下，把端到端失败原因暴露出来，用户和我们都能确认主因。
+2. **合并 §7.1（最大效果）+ §7.2（最小侵入）两项改动**：这两项合计能覆盖预计 60%+ 的"自动词库无动于衷"场景，风险可控。
+3. 其余 §7.3 / §7.4 / §7.5 视上一步的日志结论再决定。
+
+以上改动均有对应单元测试可复用（`AutomaticVocabularyMonitorTests`, `WorkflowControllerAutomaticVocabularyTests`）。修改 §7.1 时要重点覆盖"新会话立即打断旧会话 → 旧会话已有 change → 必须 finalize 并入库"的新路径。


### PR DESCRIPTION
The automatic vocabulary collector never produced a single entry in real use because each follow-up dictation within 30s cancelled the previous observation mid-flight. Tighten the observation lifecycle and relax the filters that were dropping legitimate candidates.

- Capture observation state in AutomaticVocabularyActiveSession so a new dictation finalizes the previous session (via detached analysis) before cancelling its task, instead of silently losing observed edits.
- Tune timings: startup delay 600ms -> 900ms (paste path), idle settle 8s -> 4s, edit-ratio limit 0.6 -> 0.8, and retry the initial editable snapshot up to 3x for Electron/web targets.
- Lower English/Latin minimum term length 4 -> 3 so acronyms like GPT, API, LLM, iOS can be collected; relax the decision prompt toward recall with matching guidance.
- Track occurrenceCount per entry with legacy-safe decoding. add() bumps the counter on duplicates and incrementOccurrences(in:) lifts matches on every insert. activeTerms() now returns top-100 sorted by (count DESC, createdAt DESC); allTerms() stays unbounded for dedupe and LLM prompts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Vocabulary terms now tracked by usage frequency
  * Active vocabulary limited to top 100 most-used terms

* **Improvements**
  * Minimum term length relaxed from 4 to 3 characters
  * More lenient acceptance criteria for spelling and capitalization corrections
  * Enhanced automatic vocabulary observation with improved retry logic

* **Documentation**
  * Added comprehensive automatic vocabulary collection guide

<!-- end of auto-generated comment: release notes by coderabbit.ai -->