### PR TITLE
fix(release): prevent crash on end-user machines from Bundle.module

### DIFF
--- a/Sources/Typeflux/App/AppLocalization.swift
+++ b/Sources/Typeflux/App/AppLocalization.swift
@@ -132,7 +132,7 @@ final class AppLocalization: ObservableObject {
             }
 
             guard
-                let tableURL = Bundle.module.url(
+                let tableURL = Bundle.appResources.url(
                     forResource: "Localizable",
                     withExtension: "strings",
                     subdirectory: nil,
@@ -154,14 +154,14 @@ final class AppLocalization: ObservableObject {
 
     private func bundle(for language: AppLanguage) -> Bundle {
         for localizationName in language.bundleLocalizationCandidates {
-            if let path = Bundle.module.path(forResource: localizationName, ofType: "lproj"),
+            if let path = Bundle.appResources.path(forResource: localizationName, ofType: "lproj"),
                let bundle = Bundle(path: path)
             {
                 return bundle
             }
         }
 
-        return Bundle.module
+        return Bundle.appResources
     }
 }
 

--- a/Sources/Typeflux/App/AppResourceBundle.swift
+++ b/Sources/Typeflux/App/AppResourceBundle.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+extension Bundle {
+    /// Resource bundle for the Typeflux module.
+    ///
+    /// SwiftPM's generated `Bundle.module` accessor for executable targets only
+    /// checks `Bundle.main.bundleURL` (which resolves to the `.app` root) and a
+    /// hard-coded developer-machine `.build` path. Neither exists in a
+    /// codesigned `.app` installed on an end user's machine, where resources
+    /// must live under `Contents/Resources/`. This accessor searches the
+    /// standard `.app` resource location first and falls back to
+    /// `Bundle.module` so dev builds keep working.
+    static let appResources: Bundle = {
+        let bundleName = "Typeflux_Typeflux.bundle"
+        var candidates: [URL] = []
+        if let resourceURL = Bundle.main.resourceURL {
+            candidates.append(resourceURL.appendingPathComponent(bundleName))
+        }
+        candidates.append(Bundle.main.bundleURL.appendingPathComponent(bundleName))
+        candidates.append(
+            Bundle.main.bundleURL
+                .appendingPathComponent("Contents/Resources")
+                .appendingPathComponent(bundleName)
+        )
+        for url in candidates {
+            if let bundle = Bundle(url: url) {
+                return bundle
+            }
+        }
+        return .module
+    }()
+}

--- a/Sources/Typeflux/Audio/SoundEffectPlayer.swift
+++ b/Sources/Typeflux/Audio/SoundEffectPlayer.swift
@@ -98,7 +98,7 @@ final class SoundEffectPlayer {
     }
 
     private func resourceURL(for effect: Effect) -> URL? {
-        Bundle.module.url(forResource: effect.rawValue, withExtension: "mp3", subdirectory: "Resources")
-            ?? Bundle.module.url(forResource: effect.rawValue, withExtension: "mp3")
+        Bundle.appResources.url(forResource: effect.rawValue, withExtension: "mp3", subdirectory: "Resources")
+            ?? Bundle.appResources.url(forResource: effect.rawValue, withExtension: "mp3")
     }
 }

--- a/Sources/Typeflux/Auth/LoginView.swift
+++ b/Sources/Typeflux/Auth/LoginView.swift
@@ -1448,8 +1448,8 @@ private struct SocialProviderLogoMark: View {
     }
 
     private var logoImage: NSImage? {
-        guard let url = Bundle.module.url(forResource: resourceName, withExtension: "svg", subdirectory: "Resources")
-            ?? Bundle.module.url(forResource: resourceName, withExtension: "svg")
+        guard let url = Bundle.appResources.url(forResource: resourceName, withExtension: "svg", subdirectory: "Resources")
+            ?? Bundle.appResources.url(forResource: resourceName, withExtension: "svg")
         else {
             return nil
         }

--- a/Sources/Typeflux/Onboarding/OnboardingView.swift
+++ b/Sources/Typeflux/Onboarding/OnboardingView.swift
@@ -1145,15 +1145,15 @@ struct OnboardingView: View {
 
     private func loadProviderLogo(for providerID: StudioModelProviderID) -> NSImage? {
         guard let name = providerLogoResourceName(for: providerID) else { return nil }
-        let url = Bundle.module.url(
+        let url = Bundle.appResources.url(
             forResource: name,
             withExtension: "png",
             subdirectory: "Resources/Providers",
         )
-            ?? Bundle.module.url(forResource: name, withExtension: "png", subdirectory: "Providers")
-            ?? Bundle.module.url(forResource: name, withExtension: "png")
-            ?? Bundle.module.url(forResource: name, withExtension: "svg", subdirectory: "Resources")
-            ?? Bundle.module.url(forResource: name, withExtension: "svg")
+            ?? Bundle.appResources.url(forResource: name, withExtension: "png", subdirectory: "Providers")
+            ?? Bundle.appResources.url(forResource: name, withExtension: "png")
+            ?? Bundle.appResources.url(forResource: name, withExtension: "svg", subdirectory: "Resources")
+            ?? Bundle.appResources.url(forResource: name, withExtension: "svg")
         guard let url else { return nil }
         return NSImage(contentsOf: url)
     }

--- a/Sources/Typeflux/Settings/SettingsView.swift
+++ b/Sources/Typeflux/Settings/SettingsView.swift
@@ -4009,15 +4009,15 @@ struct StudioView: View {
         guard let resourceName = providerLogoResourceName(for: provider) else { return nil }
 
         let url =
-            Bundle.module.url(
+            Bundle.appResources.url(
                 forResource: resourceName, withExtension: "png", subdirectory: "Resources/Providers",
             )
-            ?? Bundle.module.url(
+            ?? Bundle.appResources.url(
                 forResource: resourceName, withExtension: "png", subdirectory: "Providers",
             )
-            ?? Bundle.module.url(forResource: resourceName, withExtension: "png")
-            ?? Bundle.module.url(forResource: resourceName, withExtension: "svg", subdirectory: "Resources")
-            ?? Bundle.module.url(forResource: resourceName, withExtension: "svg")
+            ?? Bundle.appResources.url(forResource: resourceName, withExtension: "png")
+            ?? Bundle.appResources.url(forResource: resourceName, withExtension: "svg", subdirectory: "Resources")
+            ?? Bundle.appResources.url(forResource: resourceName, withExtension: "svg")
 
         guard let url else { return nil }
         return NSImage(contentsOf: url)


### PR DESCRIPTION
SwiftPM's generated resource_bundle_accessor.swift for executable targets only checks Bundle.main.bundleURL (the .app root) and a hard-coded developer-machine .build path. Neither is valid in a codesigned .app installed on an end user's machine, where resources must live under Contents/Resources. Moving the bundle to the .app root is blocked by codesign's "unsealed contents present in the bundle root" rule, so first access of Bundle.module hit fatalError and the app crashed on launch.

Introduce Bundle.appResources that searches Bundle.main.resourceURL first (the standard Contents/Resources location) and replace the five call sites that previously used Bundle.module. Dev builds keep working via the same accessor.