### PR TITLE
Add version update script

### DIFF
--- a/app/Info.plist
+++ b/app/Info.plist
@@ -19,9 +19,9 @@
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleShortVersionString</key>
-    <string>1.0.0</string>
+    <string>0.1.0</string>
     <key>CFBundleVersion</key>
-    <string>1</string>
+    <string>0.1.0</string>
 
     <key>LSUIElement</key>
     <true/>

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -254,7 +254,7 @@ If you publish a release manually, prefer attaching both:
 
 ## Release Checklist
 
-- [ ] Version updated in `app/Info.plist`
+- [ ] Version updated with `./scripts/set_version.sh <version>`
 - [ ] `CHANGELOG.md` updated
 - [ ] `swift test` passes
 - [ ] `make release-notarize` completes successfully

--- a/scripts/set_version.sh
+++ b/scripts/set_version.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+INFO_PLIST="${ROOT_DIR}/app/Info.plist"
+
+update_plist_value() {
+  local key="$1"
+  local value="$2"
+  local temp_file
+  temp_file="$(mktemp "${TMPDIR:-/tmp}/typeflux-info-plist.XXXXXX")"
+
+  if ! /usr/bin/perl -0pe '
+    BEGIN {
+      ($key, $value) = splice @ARGV, 0, 2;
+      $changed = 0;
+    }
+    $changed = s{(<key>\Q$key\E</key>\s*<string>)[^<]*(</string>)}{$1$value$2}s;
+    END {
+      exit($changed ? 0 : 2);
+    }
+  ' "$key" "$value" "$INFO_PLIST" >"$temp_file"; then
+    rm -f "$temp_file"
+    echo "Error: key not found in Info.plist: $key" >&2
+    exit 1
+  fi
+
+  mv "$temp_file" "$INFO_PLIST"
+}
+
+usage() {
+  echo "Usage: $0 <version> [build]"
+  echo
+  echo "Examples:"
+  echo "  $0 0.1.0"
+  echo "  $0 0.1.0 42"
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+if [[ $# -lt 1 || $# -gt 2 ]]; then
+  usage >&2
+  exit 1
+fi
+
+VERSION="$1"
+BUILD="${2:-$VERSION}"
+
+if [[ ! "$VERSION" =~ ^[0-9]+(\.[0-9]+){1,2}$ ]]; then
+  echo "Error: version must use numeric major.minor or major.minor.patch format." >&2
+  exit 1
+fi
+
+if [[ ! "$BUILD" =~ ^[0-9]+(\.[0-9]+){0,2}$ ]]; then
+  echo "Error: build must be a numeric value with up to three dot-separated components." >&2
+  exit 1
+fi
+
+if [[ ! -f "$INFO_PLIST" ]]; then
+  echo "Error: Info.plist not found at $INFO_PLIST" >&2
+  exit 1
+fi
+
+update_plist_value "CFBundleShortVersionString" "$VERSION"
+update_plist_value "CFBundleVersion" "$BUILD"
+
+plutil -lint "$INFO_PLIST" >/dev/null
+
+echo "Updated app/Info.plist"
+echo "CFBundleShortVersionString=$VERSION"
+echo "CFBundleVersion=$BUILD"


### PR DESCRIPTION
## Summary
- Set the app version and bundle version to 0.1.0.
- Add scripts/set_version.sh to update app/Info.plist from a version argument, with optional build override.
- Update the release checklist to use the new script.

## Tests
- swift test --skip-update

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Application version updated to 0.1.0, signaling pre-release development phase
  * Introduced automated version management tooling to streamline the release process
  * Release checklist documentation updated to align with new version management workflow

<!-- end of auto-generated comment: release notes by coderabbit.ai -->