### PR TITLE
Retry GitHub update downloads via proxy

### DIFF
--- a/Sources/Typeflux/App/AutoUpdater.swift
+++ b/Sources/Typeflux/App/AutoUpdater.swift
@@ -150,7 +150,7 @@ final class AutoUpdater {
         state = .downloading
 
         do {
-            let (tempFileURL, _) = try await URLSession.shared.download(from: downloadURL)
+            let tempFileURL = try await Self.downloadUpdate(from: downloadURL)
 
             state = .installing
 
@@ -163,6 +163,32 @@ final class AutoUpdater {
             state = .idle
             showCheckFailedAlert(message: error.localizedDescription)
         }
+    }
+
+    private static func downloadUpdate(from downloadURL: URL) async throws -> URL {
+        do {
+            return try await downloadFile(from: downloadURL)
+        } catch {
+            guard let proxyURL = GitHubProxyDownloadURL.proxyURL(for: downloadURL) else {
+                throw error
+            }
+
+            NetworkDebugLogger.logError(
+                context: "Auto update download failed; retrying through GitHub proxy",
+                error: error,
+            )
+            return try await downloadFile(from: proxyURL)
+        }
+    }
+
+    private static func downloadFile(from url: URL) async throws -> URL {
+        let (tempFileURL, response) = try await URLSession.shared.download(from: url)
+        guard let httpResponse = response as? HTTPURLResponse,
+              (200..<300).contains(httpResponse.statusCode)
+        else {
+            throw UpdateError.downloadFailed
+        }
+        return tempFileURL
     }
 
     // Runs off the main actor — only does file I/O and process launching.
@@ -236,12 +262,23 @@ final class AutoUpdater {
 private enum UpdateError: LocalizedError {
     case extractionFailed
     case appNotFound
+    case downloadFailed
 
     var errorDescription: String? {
         switch self {
         case .extractionFailed: L("updater.install.extractionFailed")
         case .appNotFound: L("updater.install.appNotFound")
+        case .downloadFailed: L("updater.download.failed")
         }
+    }
+}
+
+enum GitHubProxyDownloadURL {
+    static let proxyBaseURL = URL(string: "https://gh-proxy.com")!
+
+    static func proxyURL(for url: URL) -> URL? {
+        guard url.host?.lowercased() == "github.com" else { return nil }
+        return URL(string: "\(proxyBaseURL.absoluteString)/\(url.absoluteString)")
     }
 }
 

--- a/Sources/Typeflux/Resources/en.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/en.lproj/Localizable.strings
@@ -207,6 +207,7 @@
 "updater.latest.message" = "You are running the latest version of Typeflux.";
 "updater.checkFailed.title" = "Update Check Failed";
 "updater.checkFailed.noData" = "Unable to retrieve update information.";
+"updater.download.failed" = "Failed to download the update.";
 "updater.install.extractionFailed" = "Failed to extract the update archive.";
 "updater.install.appNotFound" = "Could not find the application bundle in the update archive.";
 

--- a/Sources/Typeflux/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/ja.lproj/Localizable.strings
@@ -205,6 +205,7 @@
 "updater.latest.message" = "最新バージョンの Typeflux を実行しています。";
 "updater.checkFailed.title" = "アップデートの確認に失敗";
 "updater.checkFailed.noData" = "アップデート情報を取得できませんでした。";
+"updater.download.failed" = "アップデートのダウンロードに失敗しました。";
 "updater.install.extractionFailed" = "アップデートアーカイブの展開に失敗しました。";
 "updater.install.appNotFound" = "アップデートアーカイブ内にアプリケーションが見つかりませんでした。";
 

--- a/Sources/Typeflux/Resources/ko.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/ko.lproj/Localizable.strings
@@ -205,6 +205,7 @@
 "updater.latest.message" = "Typeflux의 최신 버전을 실행 중입니다.";
 "updater.checkFailed.title" = "업데이트 확인 실패";
 "updater.checkFailed.noData" = "업데이트 정보를 가져올 수 없습니다.";
+"updater.download.failed" = "업데이트 다운로드에 실패했습니다.";
 "updater.install.extractionFailed" = "업데이트 아카이브 압축 해제에 실패했습니다.";
 "updater.install.appNotFound" = "업데이트 아카이브에서 애플리케이션을 찾을 수 없습니다.";
 

--- a/Sources/Typeflux/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/zh-Hans.lproj/Localizable.strings
@@ -207,6 +207,7 @@
 "updater.latest.message" = "你当前运行的是最新版本的 Typeflux。";
 "updater.checkFailed.title" = "检查更新失败";
 "updater.checkFailed.noData" = "无法获取更新信息。";
+"updater.download.failed" = "下载更新失败。";
 "updater.install.extractionFailed" = "解压更新包失败。";
 "updater.install.appNotFound" = "在更新包中找不到应用程序。";
 

--- a/Sources/Typeflux/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/zh-Hant.lproj/Localizable.strings
@@ -205,6 +205,7 @@
 "updater.latest.message" = "你目前執行的是最新版本的 Typeflux。";
 "updater.checkFailed.title" = "檢查更新失敗";
 "updater.checkFailed.noData" = "無法取得更新資訊。";
+"updater.download.failed" = "下載更新失敗。";
 "updater.install.extractionFailed" = "解壓更新包失敗。";
 "updater.install.appNotFound" = "在更新包中找不到應用程式。";
 

--- a/Tests/TypefluxTests/GitHubProxyDownloadURLTests.swift
+++ b/Tests/TypefluxTests/GitHubProxyDownloadURLTests.swift
@@ -1,0 +1,36 @@
+@testable import Typeflux
+import XCTest
+
+final class GitHubProxyDownloadURLTests: XCTestCase {
+    func testBuildsProxyURLForGitHubDownload() throws {
+        let original = try XCTUnwrap(URL(
+            string: "https://github.com/mylxsw/typeflux/releases/download/pre-release-48/Typeflux-pre-release-full.dmg"
+        ))
+
+        let proxied = try XCTUnwrap(GitHubProxyDownloadURL.proxyURL(for: original))
+
+        XCTAssertEqual(
+            proxied.absoluteString,
+            "https://gh-proxy.com/https://github.com/mylxsw/typeflux/releases/download/pre-release-48/Typeflux-pre-release-full.dmg"
+        )
+    }
+
+    func testBuildsProxyURLForGitHubDownloadWithQuery() throws {
+        let original = try XCTUnwrap(URL(
+            string: "https://github.com/mylxsw/typeflux/releases/download/v1/Typeflux.zip?download=1"
+        ))
+
+        let proxied = try XCTUnwrap(GitHubProxyDownloadURL.proxyURL(for: original))
+
+        XCTAssertEqual(
+            proxied.absoluteString,
+            "https://gh-proxy.com/https://github.com/mylxsw/typeflux/releases/download/v1/Typeflux.zip?download=1"
+        )
+    }
+
+    func testReturnsNilForNonGitHubDownload() throws {
+        let original = try XCTUnwrap(URL(string: "https://example.com/typeflux.zip"))
+
+        XCTAssertNil(GitHubProxyDownloadURL.proxyURL(for: original))
+    }
+}


### PR DESCRIPTION
Adds a fallback for automatic update downloads hosted on github.com: the updater now retries once through https://gh-proxy.com after the original download fails. It also validates HTTP 2xx responses before installing so error pages are not treated as update archives. Localized download failure messages were added for all existing locales, with unit coverage for GitHub proxy URL construction. Tests: swift test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced update download reliability with automatic retry capability for improved robustness when downloads encounter failures.

* **Localization**
  * Added "Failed to download the update" error message across five supported languages: English, Japanese, Korean, Simplified Chinese, and Traditional Chinese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->