### PR TITLE
TYP-22 Log input context capture

### DIFF
--- a/Sources/Typeflux/Workflow/InputContextSnapshot.swift
+++ b/Sources/Typeflux/Workflow/InputContextSnapshot.swift
@@ -25,7 +25,7 @@ struct InputContextSnapshot: Equatable {
         suffixLimit: Int = defaultSuffixLimit,
         selectionLimit: Int = defaultSelectionLimit,
     ) -> InputContextSnapshot? {
-        guard inputSnapshot.isEditable, inputSnapshot.isFocusedTarget else { return nil }
+        guard inputSnapshot.isEditable else { return nil }
         guard let text = inputSnapshot.text, !text.isEmpty else { return nil }
         guard
             let selectedRange = inputSnapshot.selectedRange,
@@ -47,12 +47,63 @@ struct InputContextSnapshot: Equatable {
             bundleIdentifier: inputSnapshot.bundleIdentifier ?? selectionSnapshot.bundleIdentifier,
             role: inputSnapshot.role ?? selectionSnapshot.role,
             isEditable: inputSnapshot.isEditable,
-            isFocusedTarget: inputSnapshot.isFocusedTarget,
+            isFocusedTarget: inputSnapshot.isFocusedTarget || selectionSnapshot.isFocusedTarget,
             prefix: prefix,
             suffix: suffix,
             selectedText: selected,
         )
         return snapshot.hasContent ? snapshot : nil
+    }
+
+    static func logCapture(
+        inputSnapshot: CurrentInputTextSnapshot,
+        selectionSnapshot: TextSelectionSnapshot,
+        context: InputContextSnapshot?,
+    ) {
+        let selectedRangeDescription = inputSnapshot.selectedRange.map {
+            "location=\($0.location), length=\($0.length)"
+        } ?? "<nil>"
+        let status = context == nil ? "skipped" : "captured"
+        let skipReason = context == nil
+            ? inputContextSkipReason(inputSnapshot: inputSnapshot)
+            : "<none>"
+
+        NetworkDebugLogger.logMessage(
+            """
+            [InputContext]
+            status: \(status)
+            skipReason: \(skipReason)
+            inputFailureReason: \(inputSnapshot.failureReason ?? "<nil>")
+            appName: \(inputSnapshot.processName ?? selectionSnapshot.processName ?? "<nil>")
+            bundleIdentifier: \(inputSnapshot.bundleIdentifier ?? selectionSnapshot.bundleIdentifier ?? "<nil>")
+            role: \(inputSnapshot.role ?? selectionSnapshot.role ?? "<nil>")
+            inputIsEditable: \(inputSnapshot.isEditable)
+            inputIsFocusedTarget: \(inputSnapshot.isFocusedTarget)
+            selectionIsFocusedTarget: \(selectionSnapshot.isFocusedTarget)
+            selectedRange: \(selectedRangeDescription)
+            inputTextLength: \(inputSnapshot.text?.count ?? 0)
+            selectedTextLength: \(context?.selectedText?.count ?? 0)
+            prefix(\(context?.prefix.count ?? 0)):
+            \(context?.prefix ?? "")
+            selectedText(\(context?.selectedText?.count ?? 0)):
+            \(context?.selectedText ?? "")
+            suffix(\(context?.suffix.count ?? 0)):
+            \(context?.suffix ?? "")
+            """,
+        )
+    }
+
+    private static func inputContextSkipReason(inputSnapshot: CurrentInputTextSnapshot) -> String {
+        if !inputSnapshot.isEditable {
+            return inputSnapshot.failureReason ?? "focused-element-not-editable"
+        }
+        guard let text = inputSnapshot.text, !text.isEmpty else {
+            return inputSnapshot.failureReason ?? "missing-input-text"
+        }
+        guard inputSnapshot.selectedRange != nil else {
+            return "missing-selected-range"
+        }
+        return "invalid-selected-range-or-empty-context"
     }
 
     private static func stringRange(from cfRange: CFRange, in text: String) -> Range<String.Index>? {

--- a/Sources/Typeflux/Workflow/WorkflowController.swift
+++ b/Sources/Typeflux/Workflow/WorkflowController.swift
@@ -547,10 +547,16 @@ final class WorkflowController {
                 guard let self else { return nil }
                 let inputSnapshot = await textInjector.currentInputTextSnapshot()
                 let selectionSnapshot = await selectionTask?.value ?? TextSelectionSnapshot()
-                return InputContextSnapshot.make(
+                let context = InputContextSnapshot.make(
                     inputSnapshot: inputSnapshot,
                     selectionSnapshot: selectionSnapshot,
                 )
+                InputContextSnapshot.logCapture(
+                    inputSnapshot: inputSnapshot,
+                    selectionSnapshot: selectionSnapshot,
+                    context: context,
+                )
+                return context
             }
         } else {
             inputContextTask = nil

--- a/Tests/TypefluxTests/InputContextSnapshotTests.swift
+++ b/Tests/TypefluxTests/InputContextSnapshotTests.swift
@@ -2,7 +2,19 @@
 import XCTest
 
 final class InputContextSnapshotTests: XCTestCase {
-    func testMakeReturnsNilWhenFeatureCannotReadFocusedEditableText() {
+    func testMakeReturnsNilWhenInputIsNotEditable() {
+        let snapshot = CurrentInputTextSnapshot(
+            processName: "Notes",
+            text: "Hello world",
+            selectedRange: CFRange(location: 5, length: 0),
+            isEditable: false,
+            isFocusedTarget: false,
+        )
+
+        XCTAssertNil(InputContextSnapshot.make(inputSnapshot: snapshot, selectionSnapshot: TextSelectionSnapshot()))
+    }
+
+    func testMakeAllowsFocusedElementWhenFocusedAttributeIsFalse() {
         let snapshot = CurrentInputTextSnapshot(
             processName: "Notes",
             text: "Hello world",
@@ -11,7 +23,14 @@ final class InputContextSnapshotTests: XCTestCase {
             isFocusedTarget: false,
         )
 
-        XCTAssertNil(InputContextSnapshot.make(inputSnapshot: snapshot, selectionSnapshot: TextSelectionSnapshot()))
+        let context = InputContextSnapshot.make(
+            inputSnapshot: snapshot,
+            selectionSnapshot: TextSelectionSnapshot(),
+        )
+
+        XCTAssertEqual(context?.prefix, "Hello")
+        XCTAssertEqual(context?.suffix, " world")
+        XCTAssertFalse(context?.isFocusedTarget ?? true)
     }
 
     func testMakeSplitsTextAroundCursorAndAppliesLimits() {


### PR DESCRIPTION
## Summary
- Add local debug logging for input-context capture, including capture status, skip reason, app metadata, selected range, and raw prefix/selected/suffix context.
- Relax the fragile focused-target guard so readable editable text can be used even when the app reports `kAXFocusedAttribute` as false or nil.
- Add regression coverage for the relaxed focus behavior.

## How to test
- `swift test --filter TypefluxTests.InputContextSnapshotTests`
- `swift test --filter TypefluxTests.LLMRewriteRequestTests`
- `swift test --filter TypefluxTests.SettingsStoreFeatureFlagTests`
- `swift test`

## Screenshots
Not applicable; logging and workflow behavior only.

Refs TYP-22