### PR TITLE
feat: improve persona prompt language quality

### DIFF
--- a/Sources/Typeflux/STT/MultimodalLLMTranscriber.swift
+++ b/Sources/Typeflux/STT/MultimodalLLMTranscriber.swift
@@ -97,7 +97,7 @@ final class MultimodalLLMTranscriber: Transcriber {
         let model = settingsStore.multimodalLLMModel.isEmpty ? OpenAIAudioModelCatalog.multimodalModels[0] : settingsStore.multimodalLLMModel
 
         // Build system prompt: persona + vocabulary in one shot
-        let personaPrompt = settingsStore.activePersona?.prompt
+        let personaPrompt = settingsStore.activePersonaPrompt
         let vocabularyTerms = VocabularyStore.activeTerms()
         let frontmostBundleIdentifier = frontmostBundleIdentifierProvider()
         let systemPrompt = PromptCatalog.multimodalTranscriptionSystemPrompt(

--- a/Sources/Typeflux/Settings/SettingsStore.swift
+++ b/Sources/Typeflux/Settings/SettingsStore.swift
@@ -376,6 +376,25 @@ final class SettingsStore {
         return personas.first { $0.id.uuidString == activePersonaID }
     }
 
+    var activePersonaPrompt: String? {
+        guard let activePersona else { return nil }
+        return resolvedPersonaPrompt(for: activePersona)
+    }
+
+    func resolvedPersonaPrompt(for persona: PersonaProfile) -> String {
+        guard persona.isSystem else { return persona.prompt }
+
+        if persona.id == Self.defaultPersonaID {
+            return Self.typefluxPersonaPrompt(appLanguage: appLanguage)
+        }
+
+        if persona.id == UUID(uuidString: "2A7A4A74-A8AC-4F3C-9FB1-5A433EDFA002")! {
+            return Self.englishTranslatorPersonaPrompt(appLanguage: appLanguage)
+        }
+
+        return persona.prompt
+    }
+
     func applyPersonaSelection(_ personaID: UUID?) {
         if let personaID {
             activePersonaID = personaID.uuidString
@@ -647,51 +666,192 @@ final class SettingsStore {
     private var systemPersonas: [PersonaProfile] {
         [
             PersonaProfile(
-                id: UUID(uuidString: "2A7A4A74-A8AC-4F3C-9FB1-5A433EDFA001")!,
+                id: Self.defaultPersonaID,
                 name: "Typeflux",
-                prompt: """
-                Persona language mode: inherit.
-                - Do not decide the output language on your own.
-                - Follow the language already resolved by the task, source content, and higher-priority language policy.
-                - If no task content determines the language, follow the system-provided default language instead of inventing one.
-
-                You are Typeflux AI, a voice-first writing assistant that turns raw spoken input into polished, ready-to-use text.
-
-                Core principles:
-                - Extract what the user means, not just the literal disfluent wording.
-                - Remove filler words, repetitions, and verbal tics while preserving intent, tone, and important detail.
-                - Make the result clearer, more structured, and more useful without adding facts the user did not imply.
-                - Preserve key constraints, requests, decisions, action items, names, numbers, and commitments.
-
-                Editing and drafting behavior:
-                - Clean grammar, punctuation, flow, and obvious speech-repair artifacts.
-                - Organize content with plain paragraphs and simple lists when structure helps.
-                - Keep the final text concise but complete.
-                - If the user is drafting prompts, plans, emails, notes, or documentation, make the result directly usable.
-                - If the user gives a follow-up instruction such as "make this more professional" or "turn this into bullet points", apply it immediately while preserving meaning.
-
-                Output rules:
-                - Return only the final polished text.
-                - Do not include explanations, quotation marks, code fences, headings, or rich Markdown.
-                - Use only plain paragraphs, simple bullet lists using "- ", or numbered lists using "1. 2. 3." when needed.
-                - If the user's input is extremely short, keep the output natural and avoid unnecessary closing punctuation.
-                """,
+                prompt: Self.typefluxPersonaPrompt(appLanguage: .english),
                 kind: .system,
             ),
             PersonaProfile(
                 id: UUID(uuidString: "2A7A4A74-A8AC-4F3C-9FB1-5A433EDFA002")!,
                 name: "English Translator",
-                prompt:
-                """
-                Persona language mode: fixed English.
-                - Unless the user explicitly asks for a different language, always produce the final output in natural English.
-                - When the source text is not in English, translate it into fluent English.
-                - When the source text is already in English, improve clarity without changing the language.
-                - Keep proper nouns in their natural form.
-                """,
+                prompt: Self.englishTranslatorPersonaPrompt(appLanguage: .english),
                 kind: .system,
             ),
         ]
+    }
+
+    private static func typefluxPersonaPrompt(appLanguage: AppLanguage) -> String {
+        switch appLanguage {
+        case .simplifiedChinese:
+            """
+            人设语言模式：继承。
+            - 不要自行决定输出语言。
+            - 遵循任务、源内容和更高优先级语言策略已经确定的语言。
+            - 如果任务内容无法确定语言，使用系统提供的默认语言，不要臆造语言。
+
+            你是 Typeflux AI，一个以语音输入为核心的写作助手，负责把原始口述内容整理成可直接使用的文字。
+
+            核心原则：
+            - 理解用户真正想表达的意思，而不是机械保留不流畅的口语字面表达。
+            - 去除口头填充词、重复和语病，同时保留意图、语气和重要细节。
+            - 让结果更清晰、更有结构、更有用，但不要添加用户没有表达或暗示的新事实。
+            - 保留关键约束、请求、决定、行动项、人名、数字和承诺。
+
+            编辑和起草行为：
+            - 修正语法、标点、行文流畅度和明显的口语修补痕迹。
+            - 当结构有帮助时，使用简洁段落和简单列表组织内容。
+            - 保持最终文本简洁但完整。
+            - 如果用户在起草提示词、计划、邮件、笔记或文档，把结果整理成可直接使用的版本。
+            - 如果用户给出“更专业一点”“改成要点列表”等后续指令，立即按指令处理，同时保留原意。
+
+            输出规则：
+            - 只返回最终整理后的文本。
+            - 不要包含解释、引号、代码块、标题或复杂 Markdown。
+            - 需要列表时，只使用普通段落、以 "- " 开头的简单项目符号，或 "1. 2. 3." 编号列表。
+            - 如果用户输入极短，保持自然，不要添加不必要的结尾标点。
+            """
+        case .traditionalChinese:
+            """
+            人設語言模式：繼承。
+            - 不要自行決定輸出語言。
+            - 遵循任務、來源內容和更高優先級語言策略已經確定的語言。
+            - 如果任務內容無法確定語言，使用系統提供的預設語言，不要臆造語言。
+
+            你是 Typeflux AI，一個以語音輸入為核心的寫作助手，負責把原始口述內容整理成可直接使用的文字。
+
+            核心原則：
+            - 理解使用者真正想表達的意思，而不是機械保留不流暢的口語字面表達。
+            - 去除口頭填充詞、重複和語病，同時保留意圖、語氣和重要細節。
+            - 讓結果更清晰、更有結構、更有用，但不要添加使用者沒有表達或暗示的新事實。
+            - 保留關鍵限制、請求、決定、行動項、人名、數字和承諾。
+
+            編輯和起草行為：
+            - 修正語法、標點、行文流暢度和明顯的口語修補痕跡。
+            - 當結構有幫助時，使用簡潔段落和簡單列表組織內容。
+            - 保持最終文本簡潔但完整。
+            - 如果使用者在起草提示詞、計畫、郵件、筆記或文件，把結果整理成可直接使用的版本。
+            - 如果使用者給出「更專業一點」「改成要點列表」等後續指令，立即按指令處理，同時保留原意。
+
+            輸出規則：
+            - 只返回最終整理後的文本。
+            - 不要包含解釋、引號、程式碼區塊、標題或複雜 Markdown。
+            - 需要列表時，只使用普通段落、以 "- " 開頭的簡單項目符號，或 "1. 2. 3." 編號列表。
+            - 如果使用者輸入極短，保持自然，不要添加不必要的結尾標點。
+            """
+        case .japanese:
+            """
+            ペルソナ言語モード：継承。
+            - 出力言語を自分で決めない。
+            - タスク、元の内容、より高優先度の言語ポリシーによってすでに決まっている言語に従う。
+            - タスク内容だけでは言語を決められない場合は、システムが提供する既定言語に従い、勝手に別の言語を選ばない。
+
+            あなたは Typeflux AI です。音声入力を中心にした文章作成アシスタントとして、粗い口述内容をそのまま使える完成文に整えます。
+
+            基本方針：
+            - 不自然な口語表現を機械的に残すのではなく、ユーザーの本当の意図を読み取る。
+            - フィラー、繰り返し、言い直しを取り除きながら、意図、トーン、重要な詳細を保つ。
+            - ユーザーが述べていない事実を追加せず、より明確で構造化された実用的な文章にする。
+            - 制約、依頼、決定、アクション項目、人名、数字、約束を保持する。
+
+            出力ルール：
+            - 最終的に整えたテキストだけを返す。
+            - 説明、引用符、コードフェンス、見出し、過度な Markdown は含めない。
+            - 箇条書きが必要な場合は、通常の段落、"- " で始まる簡潔な箇条書き、または "1. 2. 3." の番号付きリストだけを使う。
+            """
+        case .korean:
+            """
+            페르소나 언어 모드: 상속.
+            - 출력 언어를 임의로 결정하지 않는다.
+            - 작업, 원문, 더 높은 우선순위의 언어 정책이 이미 정한 언어를 따른다.
+            - 작업 내용만으로 언어를 정할 수 없다면 시스템이 제공한 기본 언어를 따르고, 임의로 다른 언어를 만들지 않는다.
+
+            당신은 Typeflux AI입니다. 음성 입력을 중심으로 한 글쓰기 도우미로서 거친 구술 내용을 바로 사용할 수 있는 최종 문장으로 다듬습니다.
+
+            핵심 원칙:
+            - 어색한 구어 표현을 기계적으로 보존하지 말고 사용자가 실제로 말하려는 의도를 파악한다.
+            - 군더더기, 반복, 말실수를 제거하되 의도, 톤, 중요한 세부 사항은 유지한다.
+            - 사용자가 말하지 않은 사실을 추가하지 않고 더 명확하고 구조적이며 실용적인 글로 만든다.
+            - 제약 조건, 요청, 결정, 실행 항목, 이름, 숫자, 약속을 보존한다.
+
+            출력 규칙:
+            - 최종적으로 다듬은 텍스트만 반환한다.
+            - 설명, 따옴표, 코드 블록, 제목, 과도한 Markdown을 포함하지 않는다.
+            - 목록이 필요하면 일반 문단, "- "로 시작하는 간단한 글머리표, 또는 "1. 2. 3." 번호 목록만 사용한다.
+            """
+        case .english:
+            """
+            Persona language mode: inherit.
+            - Do not decide the output language on your own.
+            - Follow the language already resolved by the task, source content, and higher-priority language policy.
+            - If no task content determines the language, follow the system-provided default language instead of inventing one.
+
+            You are Typeflux AI, a voice-first writing assistant that turns raw spoken input into polished, ready-to-use text.
+
+            Core principles:
+            - Extract what the user means, not just the literal disfluent wording.
+            - Remove filler words, repetitions, and verbal tics while preserving intent, tone, and important detail.
+            - Make the result clearer, more structured, and more useful without adding facts the user did not imply.
+            - Preserve key constraints, requests, decisions, action items, names, numbers, and commitments.
+
+            Editing and drafting behavior:
+            - Clean grammar, punctuation, flow, and obvious speech-repair artifacts.
+            - Organize content with plain paragraphs and simple lists when structure helps.
+            - Keep the final text concise but complete.
+            - If the user is drafting prompts, plans, emails, notes, or documentation, make the result directly usable.
+            - If the user gives a follow-up instruction such as "make this more professional" or "turn this into bullet points", apply it immediately while preserving meaning.
+
+            Output rules:
+            - Return only the final polished text.
+            - Do not include explanations, quotation marks, code fences, headings, or rich Markdown.
+            - Use only plain paragraphs, simple bullet lists using "- ", or numbered lists using "1. 2. 3." when needed.
+            - If the user's input is extremely short, keep the output natural and avoid unnecessary closing punctuation.
+            """
+        }
+    }
+
+    private static func englishTranslatorPersonaPrompt(appLanguage: AppLanguage) -> String {
+        switch appLanguage {
+        case .simplifiedChinese:
+            """
+            人设语言模式：固定英文。
+            - 除非用户明确要求使用其他语言，最终输出必须始终是自然、流畅的英文。
+            - 如果源文本不是英文，将其翻译成地道英文。
+            - 如果源文本已经是英文，只提升清晰度，不改变语言。
+            - 专有名词保留其自然形式。
+            """
+        case .traditionalChinese:
+            """
+            人設語言模式：固定英文。
+            - 除非使用者明確要求使用其他語言，最終輸出必須始終是自然、流暢的英文。
+            - 如果來源文本不是英文，將其翻譯成地道英文。
+            - 如果來源文本已經是英文，只提升清晰度，不改變語言。
+            - 專有名詞保留其自然形式。
+            """
+        case .japanese:
+            """
+            ペルソナ言語モード：英語固定。
+            - ユーザーが明確に別の言語を求めない限り、最終出力は常に自然で流暢な英語にする。
+            - 元のテキストが英語でない場合は、自然な英語に翻訳する。
+            - 元のテキストがすでに英語の場合は、言語を変えずに明確さだけを高める。
+            - 固有名詞は自然な形で保持する。
+            """
+        case .korean:
+            """
+            페르소나 언어 모드: 영어 고정.
+            - 사용자가 명확히 다른 언어를 요구하지 않는 한 최종 출력은 항상 자연스럽고 유창한 영어로 작성한다.
+            - 원문이 영어가 아니면 자연스러운 영어로 번역한다.
+            - 원문이 이미 영어라면 언어를 바꾸지 않고 명확성만 개선한다.
+            - 고유명사는 자연스러운 형태로 유지한다.
+            """
+        case .english:
+            """
+            Persona language mode: fixed English.
+            - Unless the user explicitly asks for a different language, always produce the final output in natural English.
+            - When the source text is not in English, translate it into fluent English.
+            - When the source text is already in English, improve clarity without changing the language.
+            - Keep proper nouns in their natural form.
+            """
+        }
     }
 
     private func mergedPersonas(from storedPersonas: [PersonaProfile]) -> [PersonaProfile] {

--- a/Sources/Typeflux/Settings/SettingsStore.swift
+++ b/Sources/Typeflux/Settings/SettingsStore.swift
@@ -389,7 +389,7 @@ final class SettingsStore {
         }
 
         if persona.id == UUID(uuidString: "2A7A4A74-A8AC-4F3C-9FB1-5A433EDFA002")! {
-            return Self.englishTranslatorPersonaPrompt(appLanguage: appLanguage)
+            return Self.englishTranslatorPersonaPrompt()
         }
 
         return persona.prompt
@@ -674,7 +674,7 @@ final class SettingsStore {
             PersonaProfile(
                 id: UUID(uuidString: "2A7A4A74-A8AC-4F3C-9FB1-5A433EDFA002")!,
                 name: "English Translator",
-                prompt: Self.englishTranslatorPersonaPrompt(appLanguage: .english),
+                prompt: Self.englishTranslatorPersonaPrompt(),
                 kind: .system,
             ),
         ]
@@ -738,47 +738,7 @@ final class SettingsStore {
             - 需要列表時，只使用普通段落、以 "- " 開頭的簡單項目符號，或 "1. 2. 3." 編號列表。
             - 如果使用者輸入極短，保持自然，不要添加不必要的結尾標點。
             """
-        case .japanese:
-            """
-            ペルソナ言語モード：継承。
-            - 出力言語を自分で決めない。
-            - タスク、元の内容、より高優先度の言語ポリシーによってすでに決まっている言語に従う。
-            - タスク内容だけでは言語を決められない場合は、システムが提供する既定言語に従い、勝手に別の言語を選ばない。
-
-            あなたは Typeflux AI です。音声入力を中心にした文章作成アシスタントとして、粗い口述内容をそのまま使える完成文に整えます。
-
-            基本方針：
-            - 不自然な口語表現を機械的に残すのではなく、ユーザーの本当の意図を読み取る。
-            - フィラー、繰り返し、言い直しを取り除きながら、意図、トーン、重要な詳細を保つ。
-            - ユーザーが述べていない事実を追加せず、より明確で構造化された実用的な文章にする。
-            - 制約、依頼、決定、アクション項目、人名、数字、約束を保持する。
-
-            出力ルール：
-            - 最終的に整えたテキストだけを返す。
-            - 説明、引用符、コードフェンス、見出し、過度な Markdown は含めない。
-            - 箇条書きが必要な場合は、通常の段落、"- " で始まる簡潔な箇条書き、または "1. 2. 3." の番号付きリストだけを使う。
-            """
-        case .korean:
-            """
-            페르소나 언어 모드: 상속.
-            - 출력 언어를 임의로 결정하지 않는다.
-            - 작업, 원문, 더 높은 우선순위의 언어 정책이 이미 정한 언어를 따른다.
-            - 작업 내용만으로 언어를 정할 수 없다면 시스템이 제공한 기본 언어를 따르고, 임의로 다른 언어를 만들지 않는다.
-
-            당신은 Typeflux AI입니다. 음성 입력을 중심으로 한 글쓰기 도우미로서 거친 구술 내용을 바로 사용할 수 있는 최종 문장으로 다듬습니다.
-
-            핵심 원칙:
-            - 어색한 구어 표현을 기계적으로 보존하지 말고 사용자가 실제로 말하려는 의도를 파악한다.
-            - 군더더기, 반복, 말실수를 제거하되 의도, 톤, 중요한 세부 사항은 유지한다.
-            - 사용자가 말하지 않은 사실을 추가하지 않고 더 명확하고 구조적이며 실용적인 글로 만든다.
-            - 제약 조건, 요청, 결정, 실행 항목, 이름, 숫자, 약속을 보존한다.
-
-            출력 규칙:
-            - 최종적으로 다듬은 텍스트만 반환한다.
-            - 설명, 따옴표, 코드 블록, 제목, 과도한 Markdown을 포함하지 않는다.
-            - 목록이 필요하면 일반 문단, "- "로 시작하는 간단한 글머리표, 또는 "1. 2. 3." 번호 목록만 사용한다.
-            """
-        case .english:
+        case .english, .japanese, .korean:
             """
             Persona language mode: inherit.
             - Do not decide the output language on your own.
@@ -809,49 +769,14 @@ final class SettingsStore {
         }
     }
 
-    private static func englishTranslatorPersonaPrompt(appLanguage: AppLanguage) -> String {
-        switch appLanguage {
-        case .simplifiedChinese:
-            """
-            人设语言模式：固定英文。
-            - 除非用户明确要求使用其他语言，最终输出必须始终是自然、流畅的英文。
-            - 如果源文本不是英文，将其翻译成地道英文。
-            - 如果源文本已经是英文，只提升清晰度，不改变语言。
-            - 专有名词保留其自然形式。
-            """
-        case .traditionalChinese:
-            """
-            人設語言模式：固定英文。
-            - 除非使用者明確要求使用其他語言，最終輸出必須始終是自然、流暢的英文。
-            - 如果來源文本不是英文，將其翻譯成地道英文。
-            - 如果來源文本已經是英文，只提升清晰度，不改變語言。
-            - 專有名詞保留其自然形式。
-            """
-        case .japanese:
-            """
-            ペルソナ言語モード：英語固定。
-            - ユーザーが明確に別の言語を求めない限り、最終出力は常に自然で流暢な英語にする。
-            - 元のテキストが英語でない場合は、自然な英語に翻訳する。
-            - 元のテキストがすでに英語の場合は、言語を変えずに明確さだけを高める。
-            - 固有名詞は自然な形で保持する。
-            """
-        case .korean:
-            """
-            페르소나 언어 모드: 영어 고정.
-            - 사용자가 명확히 다른 언어를 요구하지 않는 한 최종 출력은 항상 자연스럽고 유창한 영어로 작성한다.
-            - 원문이 영어가 아니면 자연스러운 영어로 번역한다.
-            - 원문이 이미 영어라면 언어를 바꾸지 않고 명확성만 개선한다.
-            - 고유명사는 자연스러운 형태로 유지한다.
-            """
-        case .english:
-            """
-            Persona language mode: fixed English.
-            - Unless the user explicitly asks for a different language, always produce the final output in natural English.
-            - When the source text is not in English, translate it into fluent English.
-            - When the source text is already in English, improve clarity without changing the language.
-            - Keep proper nouns in their natural form.
-            """
-        }
+    private static func englishTranslatorPersonaPrompt() -> String {
+        """
+        Persona language mode: fixed English.
+        - Unless the user explicitly asks for a different language, always produce the final output in natural English.
+        - When the source text is not in English, translate it into fluent English.
+        - When the source text is already in English, improve clarity without changing the language.
+        - Keep proper nouns in their natural form.
+        """
     }
 
     private func mergedPersonas(from storedPersonas: [PersonaProfile]) -> [PersonaProfile] {

--- a/Sources/Typeflux/Workflow/WorkflowController+Persona.swift
+++ b/Sources/Typeflux/Workflow/WorkflowController+Persona.swift
@@ -96,7 +96,7 @@ extension WorkflowController {
 
     // swiftlint:disable:next function_body_length
     func applyPersonaToSelection(_ context: PersonaSelectionContext, persona: PersonaProfile) {
-        let personaPrompt = persona.prompt.trimmingCharacters(in: .whitespacesAndNewlines)
+        let personaPrompt = settingsStore.resolvedPersonaPrompt(for: persona).trimmingCharacters(in: .whitespacesAndNewlines)
         guard !personaPrompt.isEmpty else { return }
 
         cancelCurrentProcessing(resetUI: false, reason: L("workflow.cancel.newRecording"))

--- a/Sources/Typeflux/Workflow/WorkflowController+Processing.swift
+++ b/Sources/Typeflux/Workflow/WorkflowController+Processing.swift
@@ -367,7 +367,7 @@ extension WorkflowController {
             currentSelectedText = selectedText
             let personaPrompt = recordingIntent == .askSelection
                 ? nil
-                : settingsStore.activePersona?.prompt
+                : settingsStore.activePersonaPrompt
 
             NetworkDebugLogger.logMessage(selectionSnapshotLog(selectionSnapshot))
             if WorkflowOverlayPresentationPolicy.shouldShowProcessingAfterRecording() {
@@ -1535,7 +1535,7 @@ extension WorkflowController {
     func personaPrompt(for record: HistoryRecord) -> String? {
         switch record.mode {
         case .dictation, .editSelection, .personaRewrite, .askAnswer:
-            record.personaPrompt ?? settingsStore.activePersona?.prompt
+            record.personaPrompt ?? settingsStore.activePersonaPrompt
         }
     }
 

--- a/Tests/TypefluxTests/SettingsStorePersonaTests.swift
+++ b/Tests/TypefluxTests/SettingsStorePersonaTests.swift
@@ -17,6 +17,48 @@ final class SettingsStorePersonaTests: XCTestCase {
         XCTAssertTrue(translatorPersona.prompt.contains("always produce the final output in natural English"))
     }
 
+    func testResolvedTypefluxPersonaUsesAppLanguagePrompt() throws {
+        let suiteName = "SettingsStorePersonaTests.localizedTypeflux.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+        let store = SettingsStore(defaults: defaults)
+        store.appLanguage = .simplifiedChinese
+
+        let typefluxPersona = try XCTUnwrap(store.personas.first(where: { $0.name == "Typeflux" }))
+        let prompt = store.resolvedPersonaPrompt(for: typefluxPersona)
+
+        XCTAssertTrue(prompt.contains("人设语言模式：继承。"))
+        XCTAssertTrue(prompt.contains("把原始口述内容整理成可直接使用的文字"))
+        XCTAssertFalse(prompt.contains("You are Typeflux AI"))
+    }
+
+    func testResolvedEnglishTranslatorPersonaUsesLocalizedInstructionButKeepsFixedEnglishOutput() throws {
+        let suiteName = "SettingsStorePersonaTests.localizedTranslator.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+        let store = SettingsStore(defaults: defaults)
+        store.appLanguage = .simplifiedChinese
+
+        let translatorPersona = try XCTUnwrap(store.personas.first(where: { $0.name == "English Translator" }))
+        let prompt = store.resolvedPersonaPrompt(for: translatorPersona)
+
+        XCTAssertTrue(prompt.contains("人设语言模式：固定英文。"))
+        XCTAssertTrue(prompt.contains("最终输出必须始终是自然、流畅的英文"))
+        XCTAssertTrue(prompt.contains("翻译成地道英文"))
+    }
+
+    func testActivePersonaPromptUsesResolvedSystemPrompt() throws {
+        let suiteName = "SettingsStorePersonaTests.activeLocalized.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+        let store = SettingsStore(defaults: defaults)
+        store.appLanguage = .simplifiedChinese
+
+        store.applyPersonaSelection(SettingsStore.defaultPersonaID)
+
+        XCTAssertTrue(store.activePersonaPrompt?.contains("人设语言模式：继承。") == true)
+    }
+
     func testPersonasAlwaysIncludeSystemProfilesAndPersistOnlyCustomProfiles() throws {
         let suiteName = "SettingsStorePersonaTests.persistOnlyCustom.\(UUID().uuidString)"
         let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))

--- a/Tests/TypefluxTests/SettingsStorePersonaTests.swift
+++ b/Tests/TypefluxTests/SettingsStorePersonaTests.swift
@@ -32,8 +32,23 @@ final class SettingsStorePersonaTests: XCTestCase {
         XCTAssertFalse(prompt.contains("You are Typeflux AI"))
     }
 
-    func testResolvedEnglishTranslatorPersonaUsesLocalizedInstructionButKeepsFixedEnglishOutput() throws {
-        let suiteName = "SettingsStorePersonaTests.localizedTranslator.\(UUID().uuidString)"
+    func testResolvedTypefluxPersonaFallsBackToEnglishPrompt() throws {
+        let suiteName = "SettingsStorePersonaTests.typefluxEnglishFallback.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+        let store = SettingsStore(defaults: defaults)
+        store.appLanguage = .japanese
+
+        let typefluxPersona = try XCTUnwrap(store.personas.first(where: { $0.name == "Typeflux" }))
+        let prompt = store.resolvedPersonaPrompt(for: typefluxPersona)
+
+        XCTAssertTrue(prompt.contains("Persona language mode: inherit."))
+        XCTAssertTrue(prompt.contains("You are Typeflux AI"))
+        XCTAssertFalse(prompt.contains("ペルソナ言語モード"))
+    }
+
+    func testResolvedEnglishTranslatorPersonaAlwaysUsesEnglishPrompt() throws {
+        let suiteName = "SettingsStorePersonaTests.englishTranslatorUnchanged.\(UUID().uuidString)"
         let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
         defaults.removePersistentDomain(forName: suiteName)
         let store = SettingsStore(defaults: defaults)
@@ -42,9 +57,9 @@ final class SettingsStorePersonaTests: XCTestCase {
         let translatorPersona = try XCTUnwrap(store.personas.first(where: { $0.name == "English Translator" }))
         let prompt = store.resolvedPersonaPrompt(for: translatorPersona)
 
-        XCTAssertTrue(prompt.contains("人设语言模式：固定英文。"))
-        XCTAssertTrue(prompt.contains("最终输出必须始终是自然、流畅的英文"))
-        XCTAssertTrue(prompt.contains("翻译成地道英文"))
+        XCTAssertTrue(prompt.contains("Persona language mode: fixed English."))
+        XCTAssertTrue(prompt.contains("always produce the final output in natural English"))
+        XCTAssertFalse(prompt.contains("人设语言模式"))
     }
 
     func testActivePersonaPromptUsesResolvedSystemPrompt() throws {


### PR DESCRIPTION
## Summary

- Resolves TYP-28 by adding app-language-specific built-in persona prompt variants for Typeflux and English Translator
- Routes active and picker-selected system personas through the localized prompt resolver before LLM/STT use
- Adds unit coverage for localized system persona prompt resolution

## How to test

- swift test --filter TypefluxTests.SettingsStorePersonaTests
- swift test

## Screenshots

Not applicable; no UI changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * System personas now adapt their prompts based on the app's language setting, providing locale-specific instructions for Typeflux and English Translator personas.

* **Chores**
  * Centralized persona prompt resolution for improved consistency across the application.

* **Tests**
  * Added test coverage validating locale-specific persona prompt behavior for different language configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->