### PR TITLE
fix: optimize model provider sorting (TYP-35)

### DIFF
--- a/Sources/Typeflux/LLM/LLMRemoteProvider.swift
+++ b/Sources/Typeflux/LLM/LLMRemoteProvider.swift
@@ -32,27 +32,20 @@ enum LLMRemoteProvider: String, CaseIterable, Codable {
 
     static let defaultProvider: LLMRemoteProvider = .openAI
 
-    static let settingsDisplayOrder: [LLMRemoteProvider] = [
-        .typefluxCloud,
-        .freeModel,
-        .openCodeZen,
-        .openCodeGo,
-        .openRouter,
-        .openAI,
-        .anthropic,
-        .gemini,
-        .grok,
-        .deepSeek,
-        .kimi,
-        .qwen,
-        .zhipu,
-        .minimax,
-        .xiaomi,
-        .custom,
-    ]
+    static var settingsDisplayOrder: [LLMRemoteProvider] {
+        let standardProviders = allCases
+            .filter { $0 != .typefluxCloud && $0 != .custom }
+            .sorted { lhs, rhs in
+                lhs.displayName.localizedCaseInsensitiveCompare(rhs.displayName) == .orderedAscending
+            }
 
-    static let onboardingDisplayOrder: [LLMRemoteProvider] = settingsDisplayOrder.filter {
-        $0 != .freeModel && $0 != .typefluxCloud
+        return [.typefluxCloud] + standardProviders + [.custom]
+    }
+
+    static var onboardingDisplayOrder: [LLMRemoteProvider] {
+        settingsDisplayOrder.filter {
+            $0 != .freeModel && $0 != .typefluxCloud
+        }
     }
 
     var displayName: String {

--- a/Sources/Typeflux/Onboarding/OnboardingView.swift
+++ b/Sources/Typeflux/Onboarding/OnboardingView.swift
@@ -434,59 +434,60 @@ struct OnboardingView: View {
 
             HStack(alignment: .top, spacing: 18) {
                 VStack(spacing: 10) {
-                    if !FreeLLMModelRegistry.suggestedModelNames.isEmpty {
-                        ForEach(
-                            LLMRemoteProvider.settingsDisplayOrder
-                                .filter { $0 == .freeModel }
-                                .prefix(1),
-                            id: \.self,
-                        ) { provider in
+                    let standardOptions = (
+                        LLMRemoteProvider.settingsDisplayOrder
+                            .filter { $0 != .typefluxCloud && $0 != .custom }
+                            .filter { $0 != .freeModel || !FreeLLMModelRegistry.suggestedModelNames.isEmpty }
+                            .map { provider in
+                                (
+                                    title: provider.displayName,
+                                    providerID: provider.studioProviderID,
+                                    remoteProvider: Optional(provider),
+                                )
+                            } + [
+                                (
+                                    title: LLMProvider.ollama.displayName,
+                                    providerID: StudioModelProviderID.ollama,
+                                    remoteProvider: nil,
+                                ),
+                            ]
+                    ).sorted { lhs, rhs in
+                        lhs.title.localizedCaseInsensitiveCompare(rhs.title) == .orderedAscending
+                    }
+
+                    ForEach(standardOptions, id: \.providerID) { option in
+                        if let provider = option.remoteProvider {
                             let isSelected = viewModel.llmProvider == .openAICompatible
                                 && viewModel.llmRemoteProvider == provider
                             modelProviderCard(
                                 providerID: provider.studioProviderID,
                                 title: provider.displayName,
                                 description: L("settings.models.card.\(provider.rawValue).summary"),
-                                badge: L("settings.models.badge.free"),
+                                badge: provider == .freeModel
+                                    ? L("settings.models.badge.free")
+                                    : (
+                                        provider.apiStyle == .openAICompatible
+                                            ? L("settings.models.badge.api")
+                                            : L("settings.models.badge.native")
+                                    ),
                                 isSelected: isSelected,
                             ) {
                                 withAnimation(.easeOut(duration: 0.18)) {
                                     viewModel.selectLLMRemoteProvider(provider)
                                 }
                             }
-                        }
-                    }
-
-                    ForEach(
-                        LLMRemoteProvider.onboardingDisplayOrder.filter { $0 != .custom },
-                        id: \.self
-                    ) { provider in
-                        let isSelected = viewModel.llmProvider == .openAICompatible
-                            && viewModel.llmRemoteProvider == provider
-                        modelProviderCard(
-                            providerID: provider.studioProviderID,
-                            title: provider.displayName,
-                            description: L("settings.models.card.\(provider.rawValue).summary"),
-                            badge: provider.apiStyle == .openAICompatible
-                                ? L("settings.models.badge.api")
-                                : L("settings.models.badge.native"),
-                            isSelected: isSelected,
-                        ) {
-                            withAnimation(.easeOut(duration: 0.18)) {
-                                viewModel.selectLLMRemoteProvider(provider)
+                        } else {
+                            modelProviderCard(
+                                providerID: .ollama,
+                                title: L("provider.llm.ollama"),
+                                description: L("settings.models.card.ollama.summary"),
+                                badge: L("settings.models.badge.local"),
+                                isSelected: viewModel.llmProvider == .ollama,
+                            ) {
+                                withAnimation(.easeOut(duration: 0.18)) {
+                                    viewModel.selectOllama()
+                                }
                             }
-                        }
-                    }
-
-                    modelProviderCard(
-                        providerID: .ollama,
-                        title: L("provider.llm.ollama"),
-                        description: L("settings.models.card.ollama.summary"),
-                        badge: L("settings.models.badge.local"),
-                        isSelected: viewModel.llmProvider == .ollama,
-                    ) {
-                        withAnimation(.easeOut(duration: 0.18)) {
-                            viewModel.selectOllama()
                         }
                     }
 

--- a/Sources/Typeflux/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/zh-Hans.lproj/Localizable.strings
@@ -225,7 +225,7 @@
 "provider.llm.custom" = "自定义";
 "provider.llm.freeModel" = "免费模型";
 "provider.llm.openRouter" = "OpenRouter";
-"provider.llm.ollama" = "本地 Ollama";
+"provider.llm.ollama" = "Ollama 本地";
 "provider.llm.typefluxCloud" = "Typeflux Cloud";
 
 "downloadSource.modelScope" = "ModelScope";
@@ -708,7 +708,7 @@
 "onboarding.models.stt.local.hint" = "所选模型将在首次使用时自动下载。";
 "onboarding.models.llm.openai.title" = "OpenAI 兼容接口";
 "onboarding.models.llm.openai.description" = "任意远程聊天 API — OpenAI、Claude、DeepSeek…";
-"onboarding.models.llm.ollama.title" = "本地 Ollama";
+"onboarding.models.llm.ollama.title" = "Ollama 本地";
 "onboarding.models.llm.ollama.description" = "完全在你的 Mac 上本地运行，保护隐私";
 "onboarding.models.badge.noSetup" = "免配置";
 "onboarding.models.badge.apiKey" = "需要密钥";

--- a/Sources/Typeflux/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/zh-Hant.lproj/Localizable.strings
@@ -223,7 +223,7 @@
 "provider.llm.custom" = "自訂";
 "provider.llm.freeModel" = "免費模型";
 "provider.llm.openRouter" = "OpenRouter";
-"provider.llm.ollama" = "本地 Ollama";
+"provider.llm.ollama" = "Ollama 本地";
 "provider.llm.typefluxCloud" = "Typeflux Cloud";
 
 "downloadSource.modelScope" = "ModelScope";
@@ -704,7 +704,7 @@
 "onboarding.models.stt.local.hint" = "所選模型將在首次使用時自動下載。";
 "onboarding.models.llm.openai.title" = "OpenAI 相容介面";
 "onboarding.models.llm.openai.description" = "任意遠端聊天 API — OpenAI、Claude、DeepSeek…";
-"onboarding.models.llm.ollama.title" = "本機 Ollama";
+"onboarding.models.llm.ollama.title" = "Ollama 本地";
 "onboarding.models.llm.ollama.description" = "完全在你的 Mac 上本機執行，保護隱私";
 "onboarding.models.badge.noSetup" = "免設定";
 "onboarding.models.badge.apiKey" = "需要金鑰";

--- a/Sources/Typeflux/Settings/SettingsView.swift
+++ b/Sources/Typeflux/Settings/SettingsView.swift
@@ -680,9 +680,10 @@ struct StudioView: View {
     }
 
     private var personaLLMProviderOptions: [(label: String, value: StudioModelProviderID)] {
-        let remoteOptions = LLMRemoteProvider.settingsDisplayOrder
+        var remoteOptions = LLMRemoteProvider.settingsDisplayOrder
             .filter { $0 != .freeModel || !FreeLLMModelRegistry.suggestedModelNames.isEmpty }
             .filter { $0 != .custom }
+            .filter { $0 != .typefluxCloud }
             .map { provider in
                 (label: provider.displayName, value: provider.studioProviderID)
             }
@@ -692,7 +693,12 @@ struct StudioView: View {
                 (label: provider.displayName, value: provider.studioProviderID)
             }
 
-        return remoteOptions + [(label: LLMProvider.ollama.displayName, value: .ollama)] + customOptions
+        remoteOptions.append((label: LLMProvider.ollama.displayName, value: .ollama))
+        remoteOptions.sort { lhs, rhs in
+            lhs.label.localizedCaseInsensitiveCompare(rhs.label) == .orderedAscending
+        }
+
+        return [(label: LLMRemoteProvider.typefluxCloud.displayName, value: .typefluxCloud)] + remoteOptions + customOptions
     }
 
     private func personaRosterCard(
@@ -3122,17 +3128,22 @@ struct StudioView: View {
             ),
         ]
 
-        if !FreeLLMModelRegistry.suggestedModelNames.isEmpty {
-            cards.append(makeLLMRemoteProviderCard(.freeModel, badge: L("settings.models.badge.free")))
-        }
+        var standardCards = LLMRemoteProvider.settingsDisplayOrder
+            .filter { $0 != .typefluxCloud && $0 != .custom }
+            .filter { $0 != .freeModel || !FreeLLMModelRegistry.suggestedModelNames.isEmpty }
+            .map { provider in
+                (
+                    name: provider.displayName,
+                    card: makeLLMRemoteProviderCard(
+                        provider,
+                        badge: provider == .freeModel ? L("settings.models.badge.free") : nil,
+                    ),
+                )
+            }
 
-        let primaryRemoteProviders = LLMRemoteProvider.settingsDisplayOrder.filter {
-            $0 != .freeModel && $0 != .typefluxCloud && $0 != .custom
-        }
-        cards.append(contentsOf: primaryRemoteProviders.map { makeLLMRemoteProviderCard($0) })
-
-        cards.append(
-            StudioModelCard(
+        standardCards.append((
+            name: LLMProvider.ollama.displayName,
+            card: StudioModelCard(
                 id: StudioModelProviderID.ollama.rawValue,
                 name: LLMProvider.ollama.displayName,
                 summary: L("settings.models.card.ollama.summary"),
@@ -3142,8 +3153,12 @@ struct StudioView: View {
                 isSelected: viewModel.llmProvider == .ollama,
                 isMuted: false,
                 actionTitle: L("settings.models.useLocal"),
-            ),
-        )
+            )
+        ))
+        standardCards.sort { lhs, rhs in
+            lhs.name.localizedCaseInsensitiveCompare(rhs.name) == .orderedAscending
+        }
+        cards.append(contentsOf: standardCards.map(\.card))
 
         let customRemoteProviders = LLMRemoteProvider.settingsDisplayOrder.filter { $0 == .custom }
         cards.append(contentsOf: customRemoteProviders.map { makeLLMRemoteProviderCard($0) })

--- a/Tests/TypefluxTests/LLMRemoteProviderTests.swift
+++ b/Tests/TypefluxTests/LLMRemoteProviderTests.swift
@@ -121,22 +121,38 @@ final class LLMRemoteProviderTests: XCTestCase {
             LLMRemoteProvider.settingsDisplayOrder,
             [
                 .typefluxCloud,
-                .freeModel,
-                .openCodeZen,
-                .openCodeGo,
-                .openRouter,
-                .openAI,
                 .anthropic,
-                .gemini,
-                .grok,
                 .deepSeek,
+                .freeModel,
+                .gemini,
+                .groq,
                 .kimi,
-                .qwen,
-                .zhipu,
                 .minimax,
+                .openAI,
+                .openCodeGo,
+                .openCodeZen,
+                .openRouter,
+                .qwen,
+                .grok,
                 .xiaomi,
+                .zhipu,
                 .custom,
             ],
+        )
+    }
+
+    func testSettingsDisplayOrderPinsCloudAndCustomAroundAlphabetizedProviders() {
+        let order = LLMRemoteProvider.settingsDisplayOrder
+
+        XCTAssertEqual(order.first, .typefluxCloud)
+        XCTAssertEqual(order.last, .custom)
+
+        let standardProviders = Array(order.dropFirst().dropLast())
+        XCTAssertEqual(
+            standardProviders.map(\.displayName),
+            standardProviders.map(\.displayName).sorted {
+                $0.localizedCaseInsensitiveCompare($1) == .orderedAscending
+            },
         )
     }
 

--- a/Tests/TypefluxTests/LocalizationResourceTests.swift
+++ b/Tests/TypefluxTests/LocalizationResourceTests.swift
@@ -29,6 +29,15 @@ final class LocalizationResourceTests: XCTestCase {
         }
     }
 
+    func testChineseOllamaProviderNameUsesRequestedWordOrder() throws {
+        for language in [AppLanguage.simplifiedChinese, .traditionalChinese] {
+            let bundle = try localizationBundle(for: language)
+            let localized = bundle.localizedString(forKey: "provider.llm.ollama", value: nil, table: nil)
+
+            XCTAssertEqual(localized, "Ollama 本地")
+        }
+    }
+
     func testOverlayProcessingPhaseKeysExistForAllSupportedLanguages() throws {
         let keys = [
             "overlay.processing.transcribing",


### PR DESCRIPTION
## Summary
- Pins Typeflux Cloud first and Custom last in LLM provider ordering.
- Sorts standard LLM providers alphabetically by display name across settings, persona provider options, and onboarding selection.
- Moves Ollama into the alphabetized provider group and updates Chinese labels to `Ollama 本地`.
- Adds tests for provider ordering and Chinese Ollama localization.

## How to test
- `swift test --filter TypefluxTests.LLMRemoteProviderTests --filter TypefluxTests.LocalizationResourceTests`
- `swift test`

## Screenshots
Not applicable; provider list behavior and localization are covered by tests.

Refs TYP-35
