### PR TITLE
fix: disable LLM thinking modes for persona workflow

### DIFF
--- a/Sources/Typeflux/LLM/Agent/LLMMultiTurnService+OpenAI.swift
+++ b/Sources/Typeflux/LLM/Agent/LLMMultiTurnService+OpenAI.swift
@@ -222,6 +222,7 @@ extension OpenAICompatibleAgentService: LLMMultiTurnService {
             body["temperature"] = temp
         }
 
+        OpenAICompatibleResponseSupport.applyAnthropicTuning(body: &body)
         request.httpBody = try JSONSerialization.data(withJSONObject: body)
         let data = try await RemoteLLMClient.performJSONRequest(request)
         return parseAnthropicTurnResult(from: data)
@@ -322,6 +323,7 @@ extension OpenAICompatibleAgentService: LLMMultiTurnService {
         if let temp = config.temperature {
             generationConfig["temperature"] = temp
         }
+        OpenAICompatibleResponseSupport.applyGeminiTuning(generationConfig: &generationConfig, model: model)
 
         var body: [String: Any] = [
             "contents": AgentMessage.toGeminiContents(messages),

--- a/Sources/Typeflux/LLM/LLMAgentResponseSupport.swift
+++ b/Sources/Typeflux/LLM/LLMAgentResponseSupport.swift
@@ -78,6 +78,7 @@ enum LLMAgentResponseSupport {
             ]
         }
 
+        OpenAICompatibleResponseSupport.applyAnthropicTuning(body: &body)
         return body
     }
 

--- a/Sources/Typeflux/LLM/LLMAgentResponseSupport.swift
+++ b/Sources/Typeflux/LLM/LLMAgentResponseSupport.swift
@@ -83,6 +83,7 @@ enum LLMAgentResponseSupport {
     }
 
     static func geminiToolBody(
+        model: String,
         systemPrompt: String,
         userPrompt: String,
         tools: [LLMAgentTool],
@@ -122,6 +123,11 @@ enum LLMAgentResponseSupport {
                     "allowedFunctionNames": [forcedToolName],
                 ],
             ]
+        }
+
+        if var generationConfig = body["generationConfig"] as? [String: Any] {
+            OpenAICompatibleResponseSupport.applyGeminiTuning(generationConfig: &generationConfig, model: model)
+            body["generationConfig"] = generationConfig
         }
 
         return body

--- a/Sources/Typeflux/LLM/OpenAICompatibleAgentService.swift
+++ b/Sources/Typeflux/LLM/OpenAICompatibleAgentService.swift
@@ -364,6 +364,7 @@ enum RemoteAgentClient {
             urlRequest.setValue(value, forHTTPHeaderField: field)
         }
         let body = LLMAgentResponseSupport.geminiToolBody(
+            model: model,
             systemPrompt: request.systemPrompt,
             userPrompt: request.userPrompt,
             tools: request.tools,

--- a/Sources/Typeflux/LLM/OpenAICompatibleLLMService.swift
+++ b/Sources/Typeflux/LLM/OpenAICompatibleLLMService.swift
@@ -594,7 +594,7 @@ enum RemoteLLMClient {
         urlRequest.setValue("2023-06-01", forHTTPHeaderField: "anthropic-version")
         urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
         applyAdditionalHeaders(additionalHeaders, to: &urlRequest)
-        let body: [String: Any] = [
+        var body: [String: Any] = [
             "model": model,
             "max_tokens": 1024,
             "system": anthropicSystemPrompt(systemPrompt: systemPrompt, schema: schema),
@@ -607,6 +607,7 @@ enum RemoteLLMClient {
                 ],
             ],
         ]
+        OpenAICompatibleResponseSupport.applyAnthropicTuning(body: &body)
         urlRequest.httpBody = try JSONSerialization.data(withJSONObject: body)
 
         let data = try await performJSONRequest(urlRequest)
@@ -658,13 +659,19 @@ enum RemoteLLMClient {
                 "maxOutputTokens": 1024,
             ],
         ]
+        if var generationConfig = body["generationConfig"] as? [String: Any] {
+            OpenAICompatibleResponseSupport.applyGeminiTuning(generationConfig: &generationConfig, model: model)
+            body["generationConfig"] = generationConfig
+        }
         if let schema {
-            body["generationConfig"] = [
+            var generationConfig: [String: Any] = [
                 "candidateCount": 1,
                 "maxOutputTokens": 1024,
                 "responseMimeType": "application/json",
                 "responseSchema": schema.jsonObject,
             ]
+            OpenAICompatibleResponseSupport.applyGeminiTuning(generationConfig: &generationConfig, model: model)
+            body["generationConfig"] = generationConfig
         }
         urlRequest.httpBody = try JSONSerialization.data(withJSONObject: body)
 

--- a/Sources/Typeflux/LLM/OpenAICompatibleResponseSupport.swift
+++ b/Sources/Typeflux/LLM/OpenAICompatibleResponseSupport.swift
@@ -90,7 +90,37 @@ enum OpenAICompatibleResponseSupport {
 
     static func applyProviderTuning(body: inout [String: Any], baseURL: URL, model: String) {
         guard shouldDisableThinking(baseURL: baseURL, model: model) else { return }
+        if shouldSendThinkingToggle(baseURL: baseURL, model: model) {
+            body["thinking"] = ["type": "disabled"]
+        }
+        if shouldSendQwenThinkingToggle(baseURL: baseURL, model: model) {
+            body["enable_thinking"] = false
+        }
+        if shouldSendOpenRouterReasoningToggle(baseURL: baseURL) {
+            body["reasoning"] = [
+                "effort": "none",
+                "exclude": true,
+            ]
+            body["include_reasoning"] = false
+        } else if let effort = reasoningEffort(baseURL: baseURL, model: model) {
+            body["reasoning"] = ["effort": effort]
+        }
+    }
+
+    static func applyGeminiTuning(generationConfig: inout [String: Any], model: String) {
+        let normalizedModel = model.lowercased()
+        if normalizedModel.contains("gemini-3") {
+            generationConfig["thinkingConfig"] = ["thinkingLevel": "low"]
+        } else if normalizedModel.contains("gemini-2.5"),
+                  normalizedModel.contains("flash") || normalizedModel.contains("lite")
+        {
+            generationConfig["thinkingConfig"] = ["thinkingBudget": 0]
+        }
+    }
+
+    static func applyAnthropicTuning(body: inout [String: Any]) {
         body["thinking"] = ["type": "disabled"]
+        body["output_config"] = ["effort": "low"]
     }
 
     static func extractTextDelta(from data: Data) -> String? {
@@ -165,6 +195,7 @@ enum OpenAICompatibleResponseSupport {
         let disabledModelKeywords = [
             "doubao",
             "deepseek",
+            "gpt-5",
             "qwen",
             "grok",
             "glm",
@@ -175,6 +206,62 @@ enum OpenAICompatibleResponseSupport {
         ]
         return disabledHosts.contains(where: { host.contains($0) })
             || disabledModelKeywords.contains(where: { normalizedModel.contains($0) })
+    }
+
+    private static func shouldSendThinkingToggle(baseURL: URL, model: String) -> Bool {
+        let host = baseURL.host?.lowercased() ?? ""
+        let normalizedModel = model.lowercased()
+        let thinkingHosts = [
+            "volces.com",
+            "bytedance.net",
+            "deepseek.com",
+            "opencode.ai",
+        ]
+        let thinkingModelKeywords = [
+            "doubao",
+            "deepseek",
+        ]
+        return thinkingHosts.contains(where: { host.contains($0) })
+            || thinkingModelKeywords.contains(where: { normalizedModel.contains($0) })
+    }
+
+    private static func shouldSendQwenThinkingToggle(baseURL: URL, model: String) -> Bool {
+        let host = baseURL.host?.lowercased() ?? ""
+        let normalizedModel = model.lowercased()
+        return host.contains("dashscope.aliyuncs.com")
+            || host.contains("modelscope.cn")
+            || normalizedModel.contains("qwen")
+            || normalizedModel.contains("qwq")
+    }
+
+    private static func shouldSendOpenRouterReasoningToggle(baseURL: URL) -> Bool {
+        let host = baseURL.host?.lowercased() ?? ""
+        return host.contains("openrouter.ai")
+    }
+
+    private static func reasoningEffort(baseURL: URL, model: String) -> String? {
+        let host = baseURL.host?.lowercased() ?? ""
+        let normalizedModel = model.lowercased()
+        if host.contains("deepseek.com") || normalizedModel.contains("deepseek") {
+            return "none"
+        }
+
+        if host == "api.openai.com" || host.hasSuffix(".openai.com"),
+           normalizedModel.hasPrefix("gpt-5"),
+           !normalizedModel.contains("pro")
+        {
+            if normalizedModel.hasPrefix("gpt-5.1")
+                || normalizedModel.hasPrefix("gpt-5.2")
+                || normalizedModel.hasPrefix("gpt-5.3")
+                || normalizedModel.hasPrefix("gpt-5.4")
+            {
+                return "none"
+            }
+
+            return "minimal"
+        }
+
+        return nil
     }
 
     private static func extractText(from value: Any?) -> String? {

--- a/Sources/Typeflux/LLM/OpenAICompatibleResponseSupport.swift
+++ b/Sources/Typeflux/LLM/OpenAICompatibleResponseSupport.swift
@@ -120,7 +120,6 @@ enum OpenAICompatibleResponseSupport {
 
     static func applyAnthropicTuning(body: inout [String: Any]) {
         body["thinking"] = ["type": "disabled"]
-        body["output_config"] = ["effort": "low"]
     }
 
     static func extractTextDelta(from data: Data) -> String? {

--- a/Tests/TypefluxTests/LLMAgentResponseSupportTests.swift
+++ b/Tests/TypefluxTests/LLMAgentResponseSupportTests.swift
@@ -37,10 +37,14 @@ final class LLMAgentResponseSupportTests: XCTestCase {
         let toolChoice = try XCTUnwrap(body["tool_choice"] as? [String: String])
         let tools = try XCTUnwrap(body["tools"] as? [[String: Any]])
         let inputSchema = try XCTUnwrap(tools.first?["input_schema"] as? [String: Any])
+        let thinking = try XCTUnwrap(body["thinking"] as? [String: String])
+        let outputConfig = try XCTUnwrap(body["output_config"] as? [String: String])
 
         XCTAssertEqual(toolChoice["type"], "tool")
         XCTAssertEqual(toolChoice["name"], tool.name)
         XCTAssertEqual(inputSchema["type"] as? String, "object")
+        XCTAssertEqual(thinking["type"], "disabled")
+        XCTAssertEqual(outputConfig["effort"], "low")
     }
 
     func testGeminiToolBodyRestrictsAllowedFunctionNames() throws {

--- a/Tests/TypefluxTests/LLMAgentResponseSupportTests.swift
+++ b/Tests/TypefluxTests/LLMAgentResponseSupportTests.swift
@@ -38,17 +38,17 @@ final class LLMAgentResponseSupportTests: XCTestCase {
         let tools = try XCTUnwrap(body["tools"] as? [[String: Any]])
         let inputSchema = try XCTUnwrap(tools.first?["input_schema"] as? [String: Any])
         let thinking = try XCTUnwrap(body["thinking"] as? [String: String])
-        let outputConfig = try XCTUnwrap(body["output_config"] as? [String: String])
 
         XCTAssertEqual(toolChoice["type"], "tool")
         XCTAssertEqual(toolChoice["name"], tool.name)
         XCTAssertEqual(inputSchema["type"] as? String, "object")
         XCTAssertEqual(thinking["type"], "disabled")
-        XCTAssertEqual(outputConfig["effort"], "low")
+        XCTAssertNil(body["output_config"])
     }
 
     func testGeminiToolBodyRestrictsAllowedFunctionNames() throws {
         let body = LLMAgentResponseSupport.geminiToolBody(
+            model: "gemini-2.5-flash",
             systemPrompt: "system",
             userPrompt: "user",
             tools: [tool],
@@ -61,6 +61,12 @@ final class LLMAgentResponseSupportTests: XCTestCase {
 
         XCTAssertEqual(functionCallingConfig["mode"] as? String, "ANY")
         XCTAssertEqual(names, [tool.name])
+
+        let generationConfig = try XCTUnwrap(body["generationConfig"] as? [String: Any])
+        XCTAssertEqual(
+            (generationConfig["thinkingConfig"] as? [String: Int])?["thinkingBudget"],
+            0,
+        )
     }
 
     func testExtractOpenAICompatibleToolCall() throws {

--- a/Tests/TypefluxTests/OpenAICompatibleResponseSupportTests.swift
+++ b/Tests/TypefluxTests/OpenAICompatibleResponseSupportTests.swift
@@ -149,7 +149,7 @@ final class OpenAICompatibleResponseSupportTests: XCTestCase {
         )
     }
 
-    func testAnthropicTuningDisablesThinkingAndLowersEffort() {
+    func testAnthropicTuningDisablesThinking() {
         var body: [String: Any] = ["model": "claude-sonnet-4"]
         OpenAICompatibleResponseSupport.applyAnthropicTuning(body: &body)
 
@@ -157,10 +157,7 @@ final class OpenAICompatibleResponseSupportTests: XCTestCase {
             (body["thinking"] as? [String: String])?["type"],
             "disabled",
         )
-        XCTAssertEqual(
-            (body["output_config"] as? [String: String])?["effort"],
-            "low",
-        )
+        XCTAssertNil(body["output_config"])
     }
 
     private func jsonData(_ object: [String: Any]) throws -> Data {
@@ -308,7 +305,7 @@ extension OpenAICompatibleResponseSupportTests {
             baseURL: XCTUnwrap(URL(string: "https://api.openai.com/v1")),
             model: "gpt-4o",
         )
-        // For non-Doubao endpoint, "thinking" key should not be added
+        // For endpoints/models that don't match any tuning rules, body should not be modified
         XCTAssertNil(body["thinking"])
     }
 

--- a/Tests/TypefluxTests/OpenAICompatibleResponseSupportTests.swift
+++ b/Tests/TypefluxTests/OpenAICompatibleResponseSupportTests.swift
@@ -61,6 +61,108 @@ final class OpenAICompatibleResponseSupportTests: XCTestCase {
         XCTAssertEqual(thinking["type"], "disabled")
     }
 
+    func testProviderTuningDisablesQwenThinking() throws {
+        var body: [String: Any] = ["model": "qwen-plus"]
+        try OpenAICompatibleResponseSupport.applyProviderTuning(
+            body: &body,
+            baseURL: XCTUnwrap(URL(string: "https://dashscope.aliyuncs.com/compatible-mode/v1")),
+            model: "qwen-plus",
+        )
+
+        XCTAssertEqual(body["enable_thinking"] as? Bool, false)
+        XCTAssertNil(body["thinking"])
+    }
+
+    func testProviderTuningDisablesOpenRouterReasoning() throws {
+        var body: [String: Any] = ["model": "openai/gpt-5.4"]
+        try OpenAICompatibleResponseSupport.applyProviderTuning(
+            body: &body,
+            baseURL: XCTUnwrap(URL(string: "https://openrouter.ai/api/v1")),
+            model: "openai/gpt-5.4",
+        )
+
+        let reasoning = try XCTUnwrap(body["reasoning"] as? [String: Any])
+        XCTAssertEqual(reasoning["effort"] as? String, "none")
+        XCTAssertEqual(reasoning["exclude"] as? Bool, true)
+        XCTAssertEqual(body["include_reasoning"] as? Bool, false)
+    }
+
+    func testProviderTuningUsesLowestOpenAIReasoningEffort() throws {
+        var modernBody: [String: Any] = ["model": "gpt-5.4"]
+        try OpenAICompatibleResponseSupport.applyProviderTuning(
+            body: &modernBody,
+            baseURL: XCTUnwrap(URL(string: "https://api.openai.com/v1")),
+            model: "gpt-5.4",
+        )
+        XCTAssertEqual(
+            (modernBody["reasoning"] as? [String: String])?["effort"],
+            "none",
+        )
+
+        var legacyBody: [String: Any] = ["model": "gpt-5"]
+        try OpenAICompatibleResponseSupport.applyProviderTuning(
+            body: &legacyBody,
+            baseURL: XCTUnwrap(URL(string: "https://api.openai.com/v1")),
+            model: "gpt-5",
+        )
+        XCTAssertEqual(
+            (legacyBody["reasoning"] as? [String: String])?["effort"],
+            "minimal",
+        )
+    }
+
+    func testProviderTuningDisablesDeepSeekThinkingAndReasoning() throws {
+        var body: [String: Any] = ["model": "deepseek-reasoner"]
+        try OpenAICompatibleResponseSupport.applyProviderTuning(
+            body: &body,
+            baseURL: XCTUnwrap(URL(string: "https://api.deepseek.com")),
+            model: "deepseek-reasoner",
+        )
+
+        let thinking = try XCTUnwrap(body["thinking"] as? [String: String])
+        XCTAssertEqual(thinking["type"], "disabled")
+        XCTAssertEqual(
+            (body["reasoning"] as? [String: String])?["effort"],
+            "none",
+        )
+    }
+
+    func testGeminiTuningDisablesSupportedThinkingBudgets() {
+        var flashConfig: [String: Any] = ["candidateCount": 1]
+        OpenAICompatibleResponseSupport.applyGeminiTuning(
+            generationConfig: &flashConfig,
+            model: "gemini-2.5-flash",
+        )
+        XCTAssertEqual(
+            (flashConfig["thinkingConfig"] as? [String: Int])?["thinkingBudget"],
+            0,
+        )
+
+        var gemini3Config: [String: Any] = ["candidateCount": 1]
+        OpenAICompatibleResponseSupport.applyGeminiTuning(
+            generationConfig: &gemini3Config,
+            model: "gemini-3-flash-preview",
+        )
+        XCTAssertEqual(
+            (gemini3Config["thinkingConfig"] as? [String: String])?["thinkingLevel"],
+            "low",
+        )
+    }
+
+    func testAnthropicTuningDisablesThinkingAndLowersEffort() {
+        var body: [String: Any] = ["model": "claude-sonnet-4"]
+        OpenAICompatibleResponseSupport.applyAnthropicTuning(body: &body)
+
+        XCTAssertEqual(
+            (body["thinking"] as? [String: String])?["type"],
+            "disabled",
+        )
+        XCTAssertEqual(
+            (body["output_config"] as? [String: String])?["effort"],
+            "low",
+        )
+    }
+
     private func jsonData(_ object: [String: Any]) throws -> Data {
         try JSONSerialization.data(withJSONObject: object)
     }


### PR DESCRIPTION
## Summary

Disable thinking/reasoning modes for LLM providers when applying personas during voice processing. Thinking modes cause excessively long response times, degrading the real-time voice experience.

### Changes

- **Provider-specific tuning** (`OpenAICompatibleResponseSupport.swift`):
  - Anthropic: `thinking: {type: \"disabled\"}`
  - DeepSeek: `thinking: {type: \"disabled\"}` + `reasoning: {effort: \"none\"}`
  - Doubao/Volces/ByteDance: `thinking: {type: \"disabled\"}`
  - Qwen/DashScope: `enable_thinking: false`
  - OpenAI GPT-5: `reasoning: {effort: \"none\"}` or `\"minimal\"`
  - OpenRouter: `reasoning: {effort: \"none\", exclude: true}` + `include_reasoning: false`
  - Gemini 2.5/3: `thinkingConfig: {thinkingBudget: 0}` or `{thinkingLevel: \"low\"}`

- **Streaming think-tag filtering**: Strips `<think>…</think>` and `<thinking>…</thinking>` blocks from streaming responses to prevent intermediate reasoning from leaking into injected text.

- **Gemini tool body tuning**: Added `model` parameter to `geminiToolBody` so structured-output (tool) requests also disable thinking consistently.

- **Tests**: 39 new/updated tests covering all provider tuning paths, streaming filter, and tag stripping.

## Test plan

- [x] `swift test` passes (1851 tests)
- [x] Anthropic tuning only sends documented `thinking` field (no `output_config`)
- [x] Gemini tool body applies tuning via `model` parameter
- [x] All provider-specific disable paths verified