### PR TITLE
fix: show localized system persona prompts in UI

### DIFF
--- a/Sources/Typeflux/Settings/SettingsView.swift
+++ b/Sources/Typeflux/Settings/SettingsView.swift
@@ -466,7 +466,7 @@ struct StudioView: View {
                     ForEach(viewModel.filteredPersonas) { persona in
                         personaRosterCard(
                             title: persona.name,
-                            subtitle: persona.prompt,
+                            subtitle: viewModel.personaDisplayPrompt(for: persona),
                             initials: String(
                                 persona.name.prefix(StudioTheme.Count.personaInitials),
                             ).uppercased(),

--- a/Sources/Typeflux/Settings/SettingsViewModel.swift
+++ b/Sources/Typeflux/Settings/SettingsViewModel.swift
@@ -298,7 +298,7 @@ final class StudioViewModel: ObservableObject {
         activePersonaID = settingsStore.activePersonaID
         let initialPersona = currentPersonas.first(where: { $0.id == initialSelectedPersonaID })
         personaDraftName = initialPersona?.name ?? ""
-        personaDraftPrompt = initialPersona?.prompt ?? ""
+        personaDraftPrompt = initialPersona.map { settingsStore.resolvedPersonaPrompt(for: $0) } ?? ""
         isCreatingPersonaDraft = false
         vocabularyEntries = VocabularyStore.load()
         launchAtLogin = LaunchAtLoginManager.isEnabled
@@ -478,8 +478,12 @@ final class StudioViewModel: ObservableObject {
         guard !searchQuery.isEmpty else { return personas }
         return personas.filter {
             $0.name.localizedCaseInsensitiveContains(searchQuery) ||
-                $0.prompt.localizedCaseInsensitiveContains(searchQuery)
+                personaDisplayPrompt(for: $0).localizedCaseInsensitiveContains(searchQuery)
         }
+    }
+
+    func personaDisplayPrompt(for persona: PersonaProfile) -> String {
+        settingsStore.resolvedPersonaPrompt(for: persona)
     }
 
     var filteredVocabularyEntries: [VocabularyEntry] {
@@ -774,6 +778,9 @@ final class StudioViewModel: ObservableObject {
         appLanguage = language
         settingsStore.appLanguage = language
         AppLocalization.shared.setLanguage(language)
+        if selectedPersonaIsSystem {
+            loadPersonaDraft()
+        }
         refreshPermissionRows()
     }
 
@@ -2162,7 +2169,7 @@ final class StudioViewModel: ObservableObject {
     private func loadPersonaDraft() {
         if let selectedPersona {
             personaDraftName = selectedPersona.name
-            personaDraftPrompt = selectedPersona.prompt
+            personaDraftPrompt = settingsStore.resolvedPersonaPrompt(for: selectedPersona)
         } else {
             personaDraftName = ""
             personaDraftPrompt = ""

--- a/Sources/Typeflux/Workflow/WorkflowController+Persona.swift
+++ b/Sources/Typeflux/Workflow/WorkflowController+Persona.swift
@@ -32,7 +32,11 @@ extension WorkflowController {
         }
         items.append(
             contentsOf: settingsStore.personas.map {
-                PersonaPickerEntry(id: $0.id, title: $0.name, subtitle: $0.prompt)
+                PersonaPickerEntry(
+                    id: $0.id,
+                    title: $0.name,
+                    subtitle: settingsStore.resolvedPersonaPrompt(for: $0),
+                )
             },
         )
         return items

--- a/Tests/TypefluxTests/SettingsViewModelPersonaTests.swift
+++ b/Tests/TypefluxTests/SettingsViewModelPersonaTests.swift
@@ -56,6 +56,63 @@ final class SettingsViewModelPersonaTests: XCTestCase {
         XCTAssertFalse(viewModel.personaRewriteEnabled)
     }
 
+    func testSelectingSystemPersonaShowsResolvedLocalizedPrompt() throws {
+        let suiteName = "SettingsViewModelPersonaTests.localizedPrompt.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        let settingsStore = SettingsStore(defaults: defaults)
+        settingsStore.appLanguage = .simplifiedChinese
+        let historyStore = InMemoryHistoryStore()
+        let viewModel = StudioViewModel(
+            settingsStore: settingsStore,
+            historyStore: historyStore,
+            initialSection: .personas,
+        )
+
+        let persona = try XCTUnwrap(viewModel.personas.first(where: { $0.id == SettingsStore.defaultPersonaID }))
+        viewModel.selectPersona(persona.id)
+
+        XCTAssertTrue(viewModel.personaDraftPrompt.contains("人设语言模式：继承。"))
+        XCTAssertTrue(viewModel.personaDisplayPrompt(for: persona).contains("把原始口述内容整理成可直接使用的文字"))
+        XCTAssertFalse(viewModel.personaDraftPrompt.contains("You are Typeflux AI"))
+    }
+
+    func testSystemPersonaSearchUsesResolvedLocalizedPrompt() throws {
+        let suiteName = "SettingsViewModelPersonaTests.localizedSearch.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        let settingsStore = SettingsStore(defaults: defaults)
+        settingsStore.appLanguage = .simplifiedChinese
+        let historyStore = InMemoryHistoryStore()
+        let viewModel = StudioViewModel(
+            settingsStore: settingsStore,
+            historyStore: historyStore,
+            initialSection: .personas,
+        )
+
+        viewModel.searchQuery = "原始口述内容"
+
+        XCTAssertTrue(viewModel.filteredPersonas.contains(where: { $0.id == SettingsStore.defaultPersonaID }))
+    }
+
+    func testChangingAppLanguageRefreshesSelectedSystemPersonaPrompt() throws {
+        let suiteName = "SettingsViewModelPersonaTests.languageRefresh.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        let settingsStore = SettingsStore(defaults: defaults)
+        let historyStore = InMemoryHistoryStore()
+        let viewModel = StudioViewModel(
+            settingsStore: settingsStore,
+            historyStore: historyStore,
+            initialSection: .personas,
+        )
+
+        viewModel.selectPersona(SettingsStore.defaultPersonaID)
+        XCTAssertTrue(viewModel.personaDraftPrompt.contains("You are Typeflux AI"))
+
+        viewModel.setAppLanguage(.simplifiedChinese)
+
+        XCTAssertTrue(viewModel.personaDraftPrompt.contains("人设语言模式：继承。"))
+        XCTAssertFalse(viewModel.personaDraftPrompt.contains("You are Typeflux AI"))
+    }
+
     func testDeactivatePersonaRewriteKeepsNonePersonaSelected() {
         let suiteName = "SettingsViewModelPersonaTests.\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suiteName)!


### PR DESCRIPTION
## Summary

- Fixes the persona management UI so built-in system personas display the resolved prompt text instead of the stored English fallback
- Updates persona search, selected system persona draft display, app-language refresh, and overlay persona picker subtitles to use the same resolved prompt logic as request execution
- Keeps custom persona storage/editing unchanged

## How to test

- swift test --filter TypefluxTests.SettingsViewModelPersonaTests
- swift test --filter TypefluxTests.SettingsStorePersonaTests
- swift test

## Screenshots

Not attached; UI text behavior covered by unit tests.