### PR TITLE
fix: use automatic SenseVoice language detection

### DIFF
--- a/Sources/Typeflux/STT/SherpaOnnxSupport.swift
+++ b/Sources/Typeflux/STT/SherpaOnnxSupport.swift
@@ -624,7 +624,7 @@ final class SherpaOnnxCommandLineDecoder {
                 "--print-args=false",
                 "--tokens=\(modelDirectory.appendingPathComponent("tokens.txt").path)",
                 "--sense-voice-model=\(modelDirectory.appendingPathComponent("model.int8.onnx").path)",
-                "--sense-voice-language=\(AppLocalization.shared.language.whisperKitLanguageCode)",
+                "--sense-voice-language=auto",
                 "--sense-voice-use-itn=true",
                 "--provider=cpu",
                 audioURL.path,

--- a/Tests/TypefluxTests/LocalModelTranscriberTests.swift
+++ b/Tests/TypefluxTests/LocalModelTranscriberTests.swift
@@ -2,7 +2,7 @@
 import XCTest
 
 final class LocalModelTranscriberTests: XCTestCase {
-    func testSenseVoiceTranscriberUsesChineseLanguageHintAndParsesTranscript() async throws {
+    func testSenseVoiceTranscriberUsesAutomaticLanguageDetectionAndParsesTranscript() async throws {
         let originalLanguage = AppLocalization.shared.language
         AppLocalization.shared.setLanguage(.simplifiedChinese)
         defer { AppLocalization.shared.setLanguage(originalLanguage) }
@@ -21,14 +21,14 @@ final class LocalModelTranscriberTests: XCTestCase {
         XCTAssertEqual(text, "你好 Typeflux")
         XCTAssertEqual(runner.lastExecutablePath, modelFolder.appendingPathComponent("sherpa-onnx-v1.12.35-osx-universal2-shared-no-tts/bin/sherpa-onnx-offline").path)
         XCTAssertEqual(runner.lastEnvironment?["DYLD_LIBRARY_PATH"], modelFolder.appendingPathComponent("sherpa-onnx-v1.12.35-osx-universal2-shared-no-tts/lib").path)
-        XCTAssertTrue(runner.lastArguments.contains("--sense-voice-language=zh"))
+        XCTAssertTrue(runner.lastArguments.contains("--sense-voice-language=auto"))
         XCTAssertTrue(runner.lastArguments.contains("--sense-voice-use-itn=true"))
         XCTAssertTrue(runner.lastArguments.contains(where: { $0.hasPrefix("--sense-voice-model=") }))
         XCTAssertTrue(runner.lastArguments.contains(where: { $0.hasPrefix("--tokens=") }))
         XCTAssertEqual(runner.lastArguments.last, audioFile.fileURL.path)
     }
 
-    func testSenseVoiceTranscriberUsesEnglishLanguageHint() async throws {
+    func testSenseVoiceTranscriberUsesAutomaticLanguageDetectionForEnglishUI() async throws {
         let originalLanguage = AppLocalization.shared.language
         AppLocalization.shared.setLanguage(.english)
         defer { AppLocalization.shared.setLanguage(originalLanguage) }
@@ -43,7 +43,7 @@ final class LocalModelTranscriberTests: XCTestCase {
 
         _ = try await transcriber.transcribe(audioFile: makeTestWAVFile())
 
-        XCTAssertTrue(runner.lastArguments.contains("--sense-voice-language=en"))
+        XCTAssertTrue(runner.lastArguments.contains("--sense-voice-language=auto"))
     }
 
     func testQwen3ASRTranscriberUsesQwen3ModelArguments() async throws {


### PR DESCRIPTION
References TYP-39

## Summary
- Force local SenseVoice transcription to pass `--sense-voice-language=auto` instead of deriving the ASR language from the app UI language.
- Update LocalModelTranscriber tests to verify Chinese and English UI settings both use automatic SenseVoice language detection while preserving ITN and transcript parsing behavior.

## How to test
- `swift test --filter TypefluxTests.LocalModelTranscriberTests`
- `swift test`

## Screenshots
- Not applicable; no UI changes.