### PR TITLE
Fix microphone fallback after device changes

### DIFF
--- a/Sources/Typeflux/Audio/AVFoundationAudioRecorder.swift
+++ b/Sources/Typeflux/Audio/AVFoundationAudioRecorder.swift
@@ -18,7 +18,7 @@ final class AVFoundationAudioRecorder: AudioRecorder {
     private let makeAudioEngine: () -> AVAudioEngine
     private var engine: AVAudioEngine
     private let settingsStore: SettingsStore
-    private let audioDeviceManager: AudioDeviceManager
+    private let audioDeviceManager: AudioDeviceManaging
     private let outputMuter: SystemAudioOutputMuting
     private let sleep: @Sendable (Duration) async -> Void
     private let writeCoordinator = AudioBufferWriteCoordinator()
@@ -35,7 +35,7 @@ final class AVFoundationAudioRecorder: AudioRecorder {
 
     init(
         settingsStore: SettingsStore,
-        audioDeviceManager: AudioDeviceManager = AudioDeviceManager(),
+        audioDeviceManager: AudioDeviceManaging = AudioDeviceManager(),
         outputMuter: SystemAudioOutputMuting = SystemAudioOutputMuter(),
         makeAudioEngine: @escaping () -> AVAudioEngine = { AVAudioEngine() },
         sleep: @escaping @Sendable (Duration) async -> Void = { duration in
@@ -241,20 +241,32 @@ final class AVFoundationAudioRecorder: AudioRecorder {
             muteTask = nil
             outputMuter.endMutedSession()
         }
+
+        func resolvedInputDeviceIDForTesting() -> AudioDeviceID? {
+            resolveInputDeviceID()
+        }
     #endif
 
-    private func configureInputDeviceIfNeeded(for inputNode: AVAudioInputNode) throws {
+    private func resolveInputDeviceID() -> AudioDeviceID? {
         let preferredID = settingsStore.preferredMicrophoneID
-        guard !preferredID.isEmpty else { return }
-        guard let deviceID = audioDeviceManager.resolveInputDeviceID(for: preferredID) else { return }
+        if !preferredID.isEmpty {
+            if let deviceID = audioDeviceManager.resolveInputDeviceID(for: preferredID) {
+                return deviceID
+            }
 
-        inputNode.auAudioUnit.setValue(Int(deviceID), forKey: "deviceID")
+            resetUnavailablePreferredMicrophone(preferredID: preferredID)
+        }
+
+        return audioDeviceManager.defaultInputDeviceID()
     }
 
     private func configureInputDeviceAndResolveFormat(for inputNode: AVAudioInputNode) throws -> AVAudioFormat {
         let preferredID = settingsStore.preferredMicrophoneID
-        if !preferredID.isEmpty {
-            try configureInputDeviceIfNeeded(for: inputNode)
+        if let deviceID = resolveInputDeviceID() {
+            inputNode.auAudioUnit.setValue(Int(deviceID), forKey: "deviceID")
+        }
+
+        if !preferredID.isEmpty, settingsStore.preferredMicrophoneID == preferredID {
             let preferredFormat = inputNode.inputFormat(forBus: 0)
             if Self.isUsableInputFormat(preferredFormat) {
                 return preferredFormat
@@ -268,12 +280,25 @@ final class AVFoundationAudioRecorder: AudioRecorder {
                 channelCount: \(preferredFormat.channelCount)
                 """,
             )
-            inputNode.auAudioUnit.setValue(0, forKey: "deviceID")
+            resetUnavailablePreferredMicrophone(preferredID: preferredID)
+            if let defaultDeviceID = audioDeviceManager.defaultInputDeviceID() {
+                inputNode.auAudioUnit.setValue(Int(defaultDeviceID), forKey: "deviceID")
+            }
         }
 
         let automaticFormat = inputNode.inputFormat(forBus: 0)
         try Self.validateInputFormat(automaticFormat)
         return automaticFormat
+    }
+
+    private func resetUnavailablePreferredMicrophone(preferredID: String) {
+        NetworkDebugLogger.logMessage(
+            """
+            [Audio Recorder] Preferred microphone is unavailable; falling back to automatic selection.
+            preferredMicrophoneID: \(preferredID)
+            """,
+        )
+        settingsStore.preferredMicrophoneID = AudioDeviceManager.automaticDeviceID
     }
 
     private func currentRecordingState() -> Bool {

--- a/Sources/Typeflux/Audio/AudioDeviceManager.swift
+++ b/Sources/Typeflux/Audio/AudioDeviceManager.swift
@@ -6,7 +6,13 @@ struct AudioInputDevice: Identifiable, Equatable {
     let name: String
 }
 
-final class AudioDeviceManager {
+protocol AudioDeviceManaging {
+    func availableInputDevices() -> [AudioInputDevice]
+    func resolveInputDeviceID(for uniqueID: String) -> AudioDeviceID?
+    func defaultInputDeviceID() -> AudioDeviceID?
+}
+
+final class AudioDeviceManager: AudioDeviceManaging {
     static let automaticDeviceID = ""
 
     func availableInputDevices() -> [AudioInputDevice] {
@@ -39,6 +45,31 @@ final class AudioDeviceManager {
         }
 
         return nil
+    }
+
+    func defaultInputDeviceID() -> AudioDeviceID? {
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioHardwarePropertyDefaultInputDevice,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain,
+        )
+        var deviceID = AudioDeviceID(kAudioObjectUnknown)
+        var size = UInt32(MemoryLayout<AudioDeviceID>.size)
+        let status = withUnsafeMutablePointer(to: &deviceID) { pointer in
+            AudioObjectGetPropertyData(
+                AudioObjectID(kAudioObjectSystemObject),
+                &address,
+                0,
+                nil,
+                &size,
+                pointer,
+            )
+        }
+        guard status == noErr, deviceID != kAudioObjectUnknown, deviceSupportsInput(deviceID) else {
+            return nil
+        }
+
+        return deviceID
     }
 
     private func allAudioDeviceIDs() -> [AudioDeviceID] {

--- a/Tests/TypefluxTests/AVFoundationAudioRecorderTests.swift
+++ b/Tests/TypefluxTests/AVFoundationAudioRecorderTests.swift
@@ -32,6 +32,56 @@ final class AVFoundationAudioRecorderTests: XCTestCase {
         XCTAssertNotEqual(recorder.audioEngineIdentifierForTesting, originalIdentifier)
     }
 
+    func testResolvedInputDeviceUsesPreferredMicrophoneWhenAvailable() throws {
+        let suiteName = "AVFoundationAudioRecorderTests-\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let settingsStore = SettingsStore(defaults: defaults)
+        settingsStore.preferredMicrophoneID = "external-mic"
+        let recorder = AVFoundationAudioRecorder(
+            settingsStore: settingsStore,
+            audioDeviceManager: MockAudioDeviceManager(
+                resolvedInputDeviceIDs: ["external-mic": 42],
+                defaultInputDeviceID: 7,
+            ),
+        )
+
+        XCTAssertEqual(recorder.resolvedInputDeviceIDForTesting(), 42)
+        XCTAssertEqual(settingsStore.preferredMicrophoneID, "external-mic")
+    }
+
+    func testResolvedInputDeviceFallsBackToDefaultWhenPreferredMicrophoneIsUnavailable() throws {
+        let suiteName = "AVFoundationAudioRecorderTests-\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let settingsStore = SettingsStore(defaults: defaults)
+        settingsStore.preferredMicrophoneID = "disconnected-mic"
+        let recorder = AVFoundationAudioRecorder(
+            settingsStore: settingsStore,
+            audioDeviceManager: MockAudioDeviceManager(defaultInputDeviceID: 7),
+        )
+
+        XCTAssertEqual(recorder.resolvedInputDeviceIDForTesting(), 7)
+        XCTAssertEqual(settingsStore.preferredMicrophoneID, AudioDeviceManager.automaticDeviceID)
+    }
+
+    func testResolvedInputDeviceUsesDefaultMicrophoneInAutomaticMode() throws {
+        let suiteName = "AVFoundationAudioRecorderTests-\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let settingsStore = SettingsStore(defaults: defaults)
+        let recorder = AVFoundationAudioRecorder(
+            settingsStore: settingsStore,
+            audioDeviceManager: MockAudioDeviceManager(defaultInputDeviceID: 9),
+        )
+
+        XCTAssertEqual(recorder.resolvedInputDeviceIDForTesting(), 9)
+        XCTAssertEqual(settingsStore.preferredMicrophoneID, AudioDeviceManager.automaticDeviceID)
+    }
+
     func testDelayedMuteBeginsAfterConfiguredSleep() async throws {
         let suiteName = "AVFoundationAudioRecorderTests-\(UUID().uuidString)"
         let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
@@ -120,6 +170,34 @@ final class AVFoundationAudioRecorderTests: XCTestCase {
         coordinator.drain()
 
         XCTAssertEqual(recorder.values, [1, 2])
+    }
+}
+
+private final class MockAudioDeviceManager: AudioDeviceManaging {
+    private let devices: [AudioInputDevice]
+    private let resolvedInputDeviceIDs: [String: AudioDeviceID]
+    private let defaultInputDevice: AudioDeviceID?
+
+    init(
+        devices: [AudioInputDevice] = [],
+        resolvedInputDeviceIDs: [String: AudioDeviceID] = [:],
+        defaultInputDeviceID: AudioDeviceID? = nil,
+    ) {
+        self.devices = devices
+        self.resolvedInputDeviceIDs = resolvedInputDeviceIDs
+        defaultInputDevice = defaultInputDeviceID
+    }
+
+    func availableInputDevices() -> [AudioInputDevice] {
+        devices
+    }
+
+    func resolveInputDeviceID(for uniqueID: String) -> AudioDeviceID? {
+        resolvedInputDeviceIDs[uniqueID]
+    }
+
+    func defaultInputDeviceID() -> AudioDeviceID? {
+        defaultInputDevice
     }
 }
 


### PR DESCRIPTION
## Summary
- Resolve the current CoreAudio default input device for automatic microphone mode
- Clear stale preferred microphone IDs and fall back to automatic when the selected device disappears
- Bind the resolved input device before reading the AVFoundation input format, with tests for preferred/default fallback behavior

## Tests
- swift test --filter TypefluxTests.AVFoundationAudioRecorderTests
- swift test