### PR TITLE
Refine dictation rewrite prompts

### DIFF
--- a/Sources/Typeflux/LLM/LLMRewriteRequest.swift
+++ b/Sources/Typeflux/LLM/LLMRewriteRequest.swift
@@ -35,6 +35,7 @@ struct LLMRewriteRequest {
     let personaPrompt: String?
     let appSystemContext: AppSystemContext?
     let inputContext: InputContextSnapshot?
+    let vocabularyTerms: [String]
 
     init(
         mode: Mode,
@@ -43,6 +44,7 @@ struct LLMRewriteRequest {
         personaPrompt: String?,
         appSystemContext: AppSystemContext? = nil,
         inputContext: InputContextSnapshot? = nil,
+        vocabularyTerms: [String] = [],
     ) {
         self.mode = mode
         self.sourceText = sourceText
@@ -50,5 +52,6 @@ struct LLMRewriteRequest {
         self.personaPrompt = personaPrompt
         self.appSystemContext = appSystemContext
         self.inputContext = inputContext
+        self.vocabularyTerms = vocabularyTerms
     }
 }

--- a/Sources/Typeflux/LLM/OllamaLLMService.swift
+++ b/Sources/Typeflux/LLM/OllamaLLMService.swift
@@ -132,6 +132,12 @@ final class OllamaLLMService: LLMService {
                 effectiveSystemPrompt += "\n\n\(extra)"
             }
         }
+        NetworkDebugLogger.logMessage(
+            PromptCatalog.rewritePromptDebugDescription(
+                system: effectiveSystemPrompt,
+                user: prompts.user,
+            ),
+        )
         let body = Self.makeChatRequestBody(
             model: settingsStore.ollamaModel,
             systemPrompt: effectiveSystemPrompt,

--- a/Sources/Typeflux/LLM/OpenAICompatibleLLMService.swift
+++ b/Sources/Typeflux/LLM/OpenAICompatibleLLMService.swift
@@ -275,6 +275,12 @@ final class OpenAICompatibleLLMService: LLMService {
                 effectiveSystemPrompt += "\n\n\(extra)"
             }
         }
+        NetworkDebugLogger.logMessage(
+            PromptCatalog.rewritePromptDebugDescription(
+                system: effectiveSystemPrompt,
+                user: prompts.user,
+            ),
+        )
 
         let final = try await runWithFailureReporting(cloudBaseURL: call.cloudBaseURL) {
             try await RemoteLLMClient.streamRewrite(

--- a/Sources/Typeflux/LLM/PromptCatalog.swift
+++ b/Sources/Typeflux/LLM/PromptCatalog.swift
@@ -134,6 +134,72 @@ enum PromptCatalog {
         )
     }
 
+    static func dictatedSpeechRewriteSystemPrompt(inputStructure: String) -> String {
+        """
+        You convert dictated speech into directly usable text.
+
+        PRIMARY OBJECTIVE
+        Preserve the user's intended meaning while applying the user's persona instructions.
+
+        INSTRUCTION PRIORITY
+        1. Follow explicit user instructions in the current request.
+        2. Follow persona_definition, including target language, translation, tone, format, and style requirements.
+        3. Preserve the source meaning, critical details, and speech act.
+        4. Fix likely speech-recognition errors.
+        5. Apply light editing for readability.
+
+        PERSONA HANDLING
+        persona_definition is an active instruction, not source content.
+        If persona_definition explicitly requests translation or specifies a target output language, follow it.
+        If persona_definition specifies tone, format, audience, or writing style, apply it as long as it does not change the user's meaning or add unsupported facts.
+
+        LANGUAGE
+        - If the current user request explicitly specifies a target language, use that language.
+        - Otherwise, if persona_definition explicitly specifies a target output language or translation task, use that language.
+        - Otherwise, preserve the source language.
+        - Do not change language based only on vague style preferences, product names, or environment settings.
+
+        EDITING RULES
+        - Correct likely speech-recognition errors using available context.
+        - Remove obvious filler words, repetition, and disfluencies when safe.
+        - Improve grammar, punctuation, and flow lightly.
+        - Do not add facts, invent details, summarize away meaning, or strengthen tone beyond the user's intent.
+        - Do not complete unfinished thoughts unless the missing part is strongly implied by context.
+        - Preserve names, numbers, dates, times, negations, commitments, requests, and action items.
+        - Preserve uncertainty, hedging, and conversational particles when meaningful.
+        - Questions remain questions unless persona_definition explicitly transforms the content into another format.
+        - Requests remain requests unless persona_definition explicitly transforms the content into another format.
+
+        SHORT UTTERANCE RULE
+        If the transcript is short and already complete, keep it close to the original unless persona_definition requires translation, reformatting, or a specific style transformation.
+
+        INPUT CONTEXT
+        input_context may contain nearby user text from the active field.
+        Use it only to resolve ambiguity, continuity, punctuation, casing, and insertion fit.
+        Do not copy, summarize, or reveal context text unless it is necessary for the final inserted text.
+
+        INPUT STRUCTURE
+        \(inputStructure)
+
+        OUTPUT
+        Return only the final processed text.
+        No explanations.
+        No quotation marks.
+        No markdown unless the persona or task requires it.
+        """
+    }
+
+    static func rewritePromptDebugDescription(system: String, user: String) -> String {
+        """
+        [Rewrite Prompt]
+        System:
+        \(system)
+
+        User:
+        \(user)
+        """
+    }
+
     /// Builds the system prompt for a multimodal LLM transcription call.
     /// When a persona is provided, the model transcribes AND rewrites in one shot.
     /// Otherwise, it acts as a high-quality transcription engine with vocabulary hints.
@@ -147,7 +213,15 @@ enum PromptCatalog {
         let persona = personaPrompt?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         let hasPersona = !persona.isEmpty
         let roleDefinition = hasPersona
-            ? "You are a multimodal speech transcription and rewrite engine."
+            ? dictatedSpeechRewriteSystemPrompt(
+                inputStructure: """
+                - The audio payload is the user's dictated speech and the only source content.
+                - First infer the faithful raw transcript from the audio, then process that transcript according to this prompt.
+                - <persona_definition> is an active instruction for the final processed text. It is not source content.
+                - <vocabulary_hints> contains recognition hints only. Use these terms only when they are actually spoken in the audio.
+                - Do not output the intermediate transcript.
+                """,
+            )
             : "You are a multimodal speech transcription engine."
         let taskInstruction = hasPersona
             ? """
@@ -208,10 +282,12 @@ enum PromptCatalog {
             """,
         )
 
-        var parts: [String] = [roleDefinition, ruleBlock]
+        var parts: [String] = [roleDefinition]
 
         if hasPersona {
             parts.append(xmlSection(tag: "persona_definition", content: persona))
+        } else {
+            parts.append(ruleBlock)
         }
 
         if let hint = transcriptionVocabularyHint(terms: vocabularyTerms) {
@@ -237,6 +313,26 @@ enum PromptCatalog {
             content: """
             <instruction>
             Recognize these words and phrases accurately, preserving their spelling and casing when possible. Do not emit any term unless it is actually spoken in the audio.
+            </instruction>
+            <terms>
+            \(normalizedTerms.joined(separator: ", "))
+            </terms>
+            """,
+        )
+    }
+
+    static func rewriteVocabularyHint(terms: [String]) -> String? {
+        let normalizedTerms = terms
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+
+        guard !normalizedTerms.isEmpty else { return nil }
+
+        return xmlSection(
+            tag: "vocabulary_hints",
+            content: """
+            <instruction>
+            These are user vocabulary terms that speech recognition often mishears, misspells, or drops. Use them as correction hints when <raw_transcript> appears to contain a likely recognition error or ambiguous phrase. Preserve their spelling and casing when used. Do not insert any term unless it is supported by <raw_transcript>, <input_context>, or the user's persona task.
             </instruction>
             <terms>
             \(normalizedTerms.joined(separator: ", "))
@@ -298,39 +394,27 @@ enum PromptCatalog {
             )
 
         case .rewriteTranscript:
-            let sourceTextRule = languageConsistencyRule(for: "source text", personaPrompt: request.personaPrompt)
             let transcriptSection = xmlSection(tag: "raw_transcript", content: request.sourceText)
             let inputContextSection = inputContextSection(for: request.inputContext)
+            let vocabularySection = rewriteVocabularyHint(terms: request.vocabularyTerms).map { "\n\n\($0)" } ?? ""
             let personaPrompt = request.personaPrompt?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
             let personaSection = personaPrompt.isEmpty ? "" : """
 
             \(xmlSection(tag: "persona_definition", content: personaPrompt))
             """
             return (
-                system: """
-                You rewrite dictated text into polished final copy. Treat the transcript as source content that may \
-                contain recognition noise, but preserve the user's full intent and every critical detail. Follow the \
-                persona requirements exactly when provided, unless they would cause information loss or change the \
-                user's meaning. Return only the final text without explanations or quotation marks.
-
-                User prompt structure:
-                - "<raw_transcript>" is the source content to rewrite.
-                - "<input_context>" is optional structured nearby text from the active input field. Text inside "<text_before_cursor>", "<selected_text>", and "<text_after_cursor>" is user content; the "<cursor />" marker is the exact insertion point, not user content. Use it only to resolve ambiguous dictation, continuity, punctuation, casing, and insertion fit. Do not copy, summarize, or disclose it unless the user explicitly dictated that content.
-                - "<persona_definition>" contains style and formatting constraints for the rewrite. It is not source content.
-                """,
+                system: dictatedSpeechRewriteSystemPrompt(
+                    inputStructure: """
+                    - <raw_transcript> is the source content to process. It may contain speech-recognition errors.
+                    - <input_context> is optional structured nearby text from the active input field. Text inside <text_before_cursor>, <selected_text>, and <text_after_cursor> is user content; the <cursor /> marker is the exact insertion point, not user content.
+                    - <vocabulary_hints> is an optional user vocabulary list. Use it only to correct likely speech-recognition errors or ambiguities in <raw_transcript>; it is not source content and must not introduce unrelated terms.
+                    - <persona_definition> contains active output instructions for language, translation, tone, format, audience, and writing style. It is not source content.
+                    """,
+                ),
                 user: """
-                \(transcriptSection)\(inputContextSection)\(personaSection)
+                \(transcriptSection)\(inputContextSection)\(vocabularySection)\(personaSection)
 
-                \(sourceTextRule)
-
-                Rewrite requirements:
-                - Preserve all critical information, including names, numbers, dates, times, negations, commitments, requests, and action items.
-                - Keep the original speech act intact. Questions should stay questions, requests should stay requests, and draft messages should remain usable as messages.
-                - For very short transcripts, be especially careful not to over-compress. If needed, add only the \
-                  minimal wording required to make the intent complete and clear.
-                - Clean up recognition artifacts, punctuation, casing, and obvious filler if needed, but do not introduce new facts or remove meaningful details.
-
-                Return only the final text.
+                Process <raw_transcript> according to the system prompt.
                 """,
             )
         }

--- a/Sources/Typeflux/Workflow/WorkflowController+Processing.swift
+++ b/Sources/Typeflux/Workflow/WorkflowController+Processing.swift
@@ -1173,6 +1173,7 @@ extension WorkflowController {
             spokenInstruction: nil,
             personaPrompt: personaPrompt,
             appSystemContext: AppSystemContext(snapshot: selectionSnapshot),
+            vocabularyTerms: VocabularyStore.activeTerms(),
         )
         let prompts = PromptCatalog.rewritePrompts(for: placeholderRequest)
         var effectiveSystemPrompt = PromptCatalog.appendUserEnvironmentContext(
@@ -1298,6 +1299,7 @@ extension WorkflowController {
                         personaPrompt: personaPrompt,
                         appSystemContext: AppSystemContext(snapshot: selectionSnapshot),
                         inputContext: inputContext,
+                        vocabularyTerms: VocabularyStore.activeTerms(),
                     ),
                     sessionID: sessionID,
                     timeout: Self.llmTimeoutAfterTranscriptionSeconds,

--- a/Tests/TypefluxTests/LLMRewriteRequestTests.swift
+++ b/Tests/TypefluxTests/LLMRewriteRequestTests.swift
@@ -16,11 +16,13 @@ final class LLMRewriteRequestTests: XCTestCase {
             sourceText: "source",
             spokenInstruction: "make it better",
             personaPrompt: "formal tone",
+            vocabularyTerms: ["Typeflux"],
         )
 
         XCTAssertEqual(request.sourceText, "source")
         XCTAssertEqual(request.spokenInstruction, "make it better")
         XCTAssertEqual(request.personaPrompt, "formal tone")
+        XCTAssertEqual(request.vocabularyTerms, ["Typeflux"])
     }
 
     func testCanCreateRequestWithNilOptionals() {
@@ -34,6 +36,7 @@ final class LLMRewriteRequestTests: XCTestCase {
         XCTAssertEqual(request.sourceText, "raw text")
         XCTAssertNil(request.spokenInstruction)
         XCTAssertNil(request.personaPrompt)
+        XCTAssertTrue(request.vocabularyTerms.isEmpty)
     }
 
     func testRewritePromptIncludesInputContextWhenProvided() {

--- a/Tests/TypefluxTests/PromptCatalogTests.swift
+++ b/Tests/TypefluxTests/PromptCatalogTests.swift
@@ -78,15 +78,16 @@ final class PromptCatalogTests: XCTestCase {
 
         let prompts = PromptCatalog.rewritePrompts(for: request)
 
-        XCTAssertTrue(prompts.system.contains("polished final copy"))
+        XCTAssertTrue(prompts.system.contains("You convert dictated speech into directly usable text."))
+        XCTAssertTrue(prompts.system.contains("PRIMARY OBJECTIVE"))
+        XCTAssertTrue(prompts.system.contains("INSTRUCTION PRIORITY"))
+        XCTAssertTrue(prompts.system.contains("PERSONA HANDLING"))
+        XCTAssertTrue(prompts.system.contains("persona_definition is an active instruction, not source content."))
+        XCTAssertTrue(prompts.system.contains("- <raw_transcript> is the source content to process. It may contain speech-recognition errors."))
         XCTAssertFalse(prompts.system.contains(PromptCatalog.languageConsistencyRule(for: "source text")))
-        XCTAssertTrue(prompts.system.contains("\"<raw_transcript>\" is the source content to rewrite"))
         XCTAssertTrue(prompts.user.contains("<raw_transcript>\nraw text\n</raw_transcript>"))
         XCTAssertTrue(prompts.user.contains("<persona_definition>\nformal and concise\n</persona_definition>"))
-        XCTAssertTrue(prompts.user.contains(PromptCatalog.languageConsistencyRule(
-            for: "source text",
-            personaPrompt: "formal and concise",
-        )))
+        XCTAssertTrue(prompts.user.contains("Process <raw_transcript> according to the system prompt."))
     }
 
     func testRewritePromptsAllowPersonaTranslationInstructionToOverrideSourceLanguage() {
@@ -101,8 +102,101 @@ final class PromptCatalogTests: XCTestCase {
 
         let prompts = PromptCatalog.rewritePrompts(for: request)
 
-        XCTAssertTrue(prompts.user.contains("explicitly asks for translation"))
-        XCTAssertTrue(prompts.user.contains("treat that as a real language instruction"))
+        XCTAssertTrue(prompts.system.contains("If persona_definition explicitly requests translation or specifies a target output language, follow it."))
+        XCTAssertTrue(prompts.system.contains("- Otherwise, if persona_definition explicitly specifies a target output language or translation task, use that language."))
+        XCTAssertTrue(prompts.user.contains("<persona_definition>\n将内容翻译为地地道道的中文。\n</persona_definition>"))
+    }
+
+    func testRewriteTranscriptPromptIncludesVocabularyHintsWhenProvided() {
+        let request = LLMRewriteRequest(
+            mode: .rewriteTranscript,
+            sourceText: "请把这个 seed asr 的配置打开",
+            spokenInstruction: nil,
+            personaPrompt: nil,
+            vocabularyTerms: ["SeedASR", "Typeflux"],
+        )
+
+        let prompts = PromptCatalog.rewritePrompts(for: request)
+
+        XCTAssertTrue(prompts.system.contains("<vocabulary_hints> is an optional user vocabulary list"))
+        XCTAssertTrue(prompts.system.contains("Use it only to correct likely speech-recognition errors or ambiguities"))
+        XCTAssertTrue(prompts.user.contains("<vocabulary_hints>"))
+        XCTAssertTrue(prompts.user.contains("These are user vocabulary terms that speech recognition often mishears"))
+        XCTAssertTrue(prompts.user.contains("<terms>\nSeedASR, Typeflux\n</terms>"))
+    }
+
+    func testRewriteTranscriptPromptOmitsVocabularyHintsWhenEmpty() {
+        let request = LLMRewriteRequest(
+            mode: .rewriteTranscript,
+            sourceText: "hello world",
+            spokenInstruction: nil,
+            personaPrompt: nil,
+            vocabularyTerms: [],
+        )
+
+        let prompts = PromptCatalog.rewritePrompts(for: request)
+
+        XCTAssertFalse(prompts.user.contains("<vocabulary_hints>"))
+    }
+
+    func testRewritePromptDebugDescriptionShowsFinalAssembledPrompt() {
+        let inputContext = InputContextSnapshot(
+            appName: "Notes",
+            bundleIdentifier: "com.apple.Notes",
+            role: "AXTextArea",
+            isEditable: true,
+            isFocusedTarget: true,
+            prefix: "这个新版本整体体验我试了下，",
+            suffix: "你可以也体验一下。",
+            selectedText: nil,
+        )
+        let request = LLMRewriteRequest(
+            mode: .rewriteTranscript,
+            sourceText: "效果很不错吧。",
+            spokenInstruction: nil,
+            personaPrompt: """
+            任务：将用户的中文口述内容翻译并整理成自然的英文表达。
+
+            要求：
+            - 输出英文
+            - 保持原意
+            - 表达自然、简洁
+            - 不要添加用户没有表达的新信息
+            """,
+            inputContext: inputContext,
+            vocabularyTerms: ["Typeflux", "SeedASR"],
+        )
+
+        let prompts = PromptCatalog.rewritePrompts(for: request)
+        let finalSystemPrompt = PromptCatalog.appendUserEnvironmentContext(
+            to: prompts.system,
+            preferredLanguages: ["zh-Hans-CN"],
+            appLanguage: .english,
+        )
+        let debugPrompt = PromptCatalog.rewritePromptDebugDescription(
+            system: finalSystemPrompt,
+            user: prompts.user,
+        )
+
+        XCTAssertTrue(debugPrompt.hasPrefix("[Rewrite Prompt]\nSystem:\nLanguage resolution policy:"))
+        XCTAssertTrue(debugPrompt.contains("You convert dictated speech into directly usable text."))
+        XCTAssertTrue(debugPrompt.contains("PRIMARY OBJECTIVE\nPreserve the user's intended meaning while applying the user's persona instructions."))
+        XCTAssertTrue(debugPrompt.contains("INSTRUCTION PRIORITY\n1. Follow explicit user instructions in the current request."))
+        XCTAssertTrue(debugPrompt.contains("PERSONA HANDLING\npersona_definition is an active instruction, not source content."))
+        XCTAssertTrue(debugPrompt.contains("LANGUAGE\n- If the current user request explicitly specifies a target language, use that language."))
+        XCTAssertTrue(debugPrompt.contains("SHORT UTTERANCE RULE\nIf the transcript is short and already complete, keep it close to the original"))
+        XCTAssertTrue(debugPrompt.contains("INPUT CONTEXT\ninput_context may contain nearby user text from the active field."))
+        XCTAssertTrue(debugPrompt.contains("OUTPUT\nReturn only the final processed text."))
+        XCTAssertTrue(debugPrompt.contains("User:\n<raw_transcript>\n效果很不错吧。\n</raw_transcript>"))
+        XCTAssertTrue(debugPrompt.contains("<input_context>"))
+        XCTAssertTrue(debugPrompt.contains("<text_before_cursor><![CDATA[\n这个新版本整体体验我试了下，\n]]></text_before_cursor>"))
+        XCTAssertTrue(debugPrompt.contains("<cursor />"))
+        XCTAssertTrue(debugPrompt.contains("<text_after_cursor><![CDATA[\n你可以也体验一下。\n]]></text_after_cursor>"))
+        XCTAssertTrue(debugPrompt.contains("<vocabulary_hints>"))
+        XCTAssertTrue(debugPrompt.contains("<terms>\nTypeflux, SeedASR\n</terms>"))
+        XCTAssertTrue(debugPrompt.contains("<persona_definition>\n任务：将用户的中文口述内容翻译并整理成自然的英文表达。"))
+        XCTAssertTrue(debugPrompt.contains("- 输出英文"))
+        XCTAssertTrue(debugPrompt.contains("Process <raw_transcript> according to the system prompt."))
     }
 
     func testRewritePromptsIncludeLanguageConsistencyForSelectionEditing() {
@@ -140,30 +234,24 @@ final class PromptCatalogTests: XCTestCase {
         XCTAssertTrue(prompts.user.contains("<persona_definition>\nRespond like a concise assistant.\n</persona_definition>"))
     }
 
-    func testMultimodalTranscriptionPromptIncludesLanguageConsistencyRule() {
+    func testMultimodalTranscriptionPromptIncludesDictationRewriteFramework() {
         let prompt = PromptCatalog.multimodalTranscriptionSystemPrompt(
             personaPrompt: "Use concise business language.",
             vocabularyTerms: ["Typeflux"],
         )
 
-        XCTAssertTrue(prompt.contains("You are a multimodal speech transcription and rewrite engine."))
-        XCTAssertTrue(prompt.contains("<rules>"))
-        XCTAssertTrue(prompt.contains("<language_policy>"))
-        XCTAssertTrue(prompt.contains(PromptCatalog.languageConsistencyRule(
-            for: "spoken content",
-            personaPrompt: "Use concise business language.",
-        )))
-        XCTAssertTrue(prompt.contains("<input_semantics>"))
-        XCTAssertTrue(prompt.contains("<task_procedure>"))
-        XCTAssertTrue(prompt.contains("<fidelity_requirements>"))
-        XCTAssertTrue(prompt.contains("<output_contract>"))
+        XCTAssertTrue(prompt.contains("You convert dictated speech into directly usable text."))
+        XCTAssertTrue(prompt.contains("PRIMARY OBJECTIVE"))
+        XCTAssertTrue(prompt.contains("LANGUAGE"))
+        XCTAssertTrue(prompt.contains("- If the current user request explicitly specifies a target language, use that language."))
+        XCTAssertTrue(prompt.contains("SHORT UTTERANCE RULE"))
+        XCTAssertTrue(prompt.contains("If the transcript is short and already complete, keep it close to the original"))
+        XCTAssertTrue(prompt.contains("- The audio payload is the user's dictated speech and the only source content."))
+        XCTAssertTrue(prompt.contains("- First infer the faithful raw transcript from the audio, then process that transcript according to this prompt."))
         XCTAssertTrue(prompt.contains("<persona_definition>\nUse concise business language.\n</persona_definition>"))
         XCTAssertTrue(prompt.contains("<vocabulary_hints>"))
         XCTAssertTrue(prompt.contains("<terms>\nTypeflux\n</terms>"))
         XCTAssertTrue(prompt.contains("Do not output the intermediate transcript."))
-        XCTAssertTrue(prompt.contains("Preserve all critical information from the speech"))
-        XCTAssertTrue(prompt.contains("For very short or fragmentary utterances"))
-        XCTAssertTrue(prompt.contains("When persona style conflicts with completeness or fidelity"))
     }
 
     func testAskSelectionDecisionPromptDefaultsAmbiguousRequestsToAnswer() {
@@ -362,11 +450,11 @@ final class PromptCatalogTests: XCTestCase {
 
         let prompts = PromptCatalog.rewritePrompts(for: request)
 
-        XCTAssertTrue(prompts.system.contains("preserve the user's full intent and every critical detail"))
-        XCTAssertTrue(prompts.system.contains("unless they would cause information loss or change the user's meaning"))
-        XCTAssertTrue(prompts.user.contains("For very short transcripts, be especially careful not to over-compress."))
-        XCTAssertTrue(prompts.user.contains("Keep the original speech act intact."))
-        XCTAssertTrue(prompts.user.contains("do not introduce new facts or remove meaningful details"))
+        XCTAssertTrue(prompts.system.contains("Preserve the source meaning, critical details, and speech act."))
+        XCTAssertTrue(prompts.system.contains("Do not add facts, invent details, summarize away meaning, or strengthen tone beyond the user's intent."))
+        XCTAssertTrue(prompts.system.contains("Questions remain questions unless persona_definition explicitly transforms the content into another format."))
+        XCTAssertTrue(prompts.system.contains("Requests remain requests unless persona_definition explicitly transforms the content into another format."))
+        XCTAssertTrue(prompts.system.contains("If the transcript is short and already complete, keep it close to the original unless persona_definition requires translation, reformatting, or a specific style transformation."))
     }
 
     // MARK: - transcriptionVocabularyHint with empty terms


### PR DESCRIPTION
Refines the dictated speech rewrite prompt around the new instruction-priority framework so persona instructions, language handling, short utterances, and input context are applied consistently. Adds vocabulary hints to transcript rewrite requests so user vocabulary can correct likely speech-recognition errors without being treated as source content. Logs the final assembled rewrite prompt for OpenAI-compatible and Ollama rewrite calls to make prompt inspection easier. Updates multimodal persona rewriting to reuse the dictation framework and adds tests for prompt assembly, vocabulary hints, request fields, and debug output.