### PR TITLE
Keep rewrite output contract last

### DIFF
--- a/Sources/Typeflux/LLM/OllamaLLMService.swift
+++ b/Sources/Typeflux/LLM/OllamaLLMService.swift
@@ -129,7 +129,10 @@ final class OllamaLLMService: LLMService {
         if let appContext = request.appSystemContext {
             let extra = PromptCatalog.appSpecificSystemContext(appContext)
             if !extra.isEmpty {
-                effectiveSystemPrompt += "\n\n\(extra)"
+                effectiveSystemPrompt = PromptCatalog.appendAdditionalSystemContext(
+                    extra,
+                    to: effectiveSystemPrompt,
+                )
             }
         }
         NetworkDebugLogger.logMessage(

--- a/Sources/Typeflux/LLM/OpenAICompatibleAgentService.swift
+++ b/Sources/Typeflux/LLM/OpenAICompatibleAgentService.swift
@@ -51,7 +51,9 @@ final class OpenAICompatibleAgentService: LLMAgentService, @unchecked Sendable {
             )
             if let appContext = request.appSystemContext {
                 let extra = PromptCatalog.appSpecificSystemContext(appContext)
-                if !extra.isEmpty { prompt += "\n\n\(extra)" }
+                if !extra.isEmpty {
+                    prompt = PromptCatalog.appendAdditionalSystemContext(extra, to: prompt)
+                }
             }
             return prompt
         }()
@@ -98,7 +100,9 @@ final class OpenAICompatibleAgentService: LLMAgentService, @unchecked Sendable {
             )
             if let appContext = request.appSystemContext {
                 let extra = PromptCatalog.appSpecificSystemContext(appContext)
-                if !extra.isEmpty { prompt += "\n\n\(extra)" }
+                if !extra.isEmpty {
+                    prompt = PromptCatalog.appendAdditionalSystemContext(extra, to: prompt)
+                }
             }
             return prompt
         }()

--- a/Sources/Typeflux/LLM/OpenAICompatibleLLMService.swift
+++ b/Sources/Typeflux/LLM/OpenAICompatibleLLMService.swift
@@ -272,7 +272,10 @@ final class OpenAICompatibleLLMService: LLMService {
         if let appContext = rewriteRequest.appSystemContext {
             let extra = PromptCatalog.appSpecificSystemContext(appContext)
             if !extra.isEmpty {
-                effectiveSystemPrompt += "\n\n\(extra)"
+                effectiveSystemPrompt = PromptCatalog.appendAdditionalSystemContext(
+                    extra,
+                    to: effectiveSystemPrompt,
+                )
             }
         }
         NetworkDebugLogger.logMessage(

--- a/Sources/Typeflux/LLM/PromptCatalog.swift
+++ b/Sources/Typeflux/LLM/PromptCatalog.swift
@@ -86,9 +86,52 @@ enum PromptCatalog {
             preferredLanguages: preferredLanguages,
             appLanguage: appLanguage,
         )
+        let languageContext = "\(languagePolicy)\n\n\(environmentContext)"
 
-        guard !trimmedPrompt.isEmpty else { return "\(languagePolicy)\n\n\(environmentContext)" }
-        return "\(languagePolicy)\n\n\(trimmedPrompt)\n\n\(environmentContext)"
+        guard !trimmedPrompt.isEmpty else { return languageContext }
+
+        if let rewrittenPrompt = replacingDictationLanguageSection(
+            in: trimmedPrompt,
+            with: languageContext,
+        ) {
+            return rewrittenPrompt
+        }
+
+        return "\(languageContext)\n\n\(trimmedPrompt)"
+    }
+
+    static func appendAdditionalSystemContext(_ extraContext: String, to systemPrompt: String) -> String {
+        let trimmedExtra = extraContext.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedExtra.isEmpty else { return systemPrompt }
+
+        let outputMarker = "\n\nOUTPUT\n"
+        if let outputRange = systemPrompt.range(of: outputMarker, options: .backwards) {
+            return "\(systemPrompt[..<outputRange.lowerBound])\n\n\(trimmedExtra)\(systemPrompt[outputRange.lowerBound...])"
+        }
+
+        let trimmedPrompt = systemPrompt.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedPrompt.isEmpty else { return trimmedExtra }
+        return "\(trimmedPrompt)\n\n\(trimmedExtra)"
+    }
+
+    private static func replacingDictationLanguageSection(
+        in prompt: String,
+        with languageContext: String,
+    ) -> String? {
+        let legacyLanguageSection = """
+        LANGUAGE
+        - If the current user request explicitly specifies a target language, use that language.
+        - Otherwise, if persona_definition explicitly specifies a target output language or translation task, use that language.
+        - Otherwise, preserve the source language.
+        - Do not change language based only on vague style preferences, product names, or environment settings.
+        """
+
+        guard prompt.contains(legacyLanguageSection) else { return nil }
+
+        return prompt.replacingOccurrences(
+            of: legacyLanguageSection,
+            with: "LANGUAGE\n\(languageContext)",
+        )
     }
 
     /// Returns additional system prompt content tailored to the current app context.

--- a/Sources/Typeflux/Workflow/WorkflowController+Agent.swift
+++ b/Sources/Typeflux/Workflow/WorkflowController+Agent.swift
@@ -265,7 +265,10 @@ extension WorkflowController {
         if let appContext = appSystemContext {
             let extra = PromptCatalog.appSpecificSystemContext(appContext)
             if !extra.isEmpty {
-                systemPrompt += "\n\n\(extra)"
+                systemPrompt = PromptCatalog.appendAdditionalSystemContext(
+                    extra,
+                    to: systemPrompt,
+                )
             }
         }
         let userPrompt = AgentPromptCatalog.agentUserPrompt(

--- a/Sources/Typeflux/Workflow/WorkflowController+Processing.swift
+++ b/Sources/Typeflux/Workflow/WorkflowController+Processing.swift
@@ -1183,7 +1183,10 @@ extension WorkflowController {
         if let appContext = placeholderRequest.appSystemContext {
             let extra = PromptCatalog.appSpecificSystemContext(appContext)
             if !extra.isEmpty {
-                effectiveSystemPrompt += "\n\n\(extra)"
+                effectiveSystemPrompt = PromptCatalog.appendAdditionalSystemContext(
+                    extra,
+                    to: effectiveSystemPrompt,
+                )
             }
         }
         return ASRLLMConfig(

--- a/Tests/TypefluxTests/PromptCatalogTests.swift
+++ b/Tests/TypefluxTests/PromptCatalogTests.swift
@@ -38,7 +38,8 @@ final class PromptCatalogTests: XCTestCase {
         XCTAssertTrue(prompt.contains("User environment context:"))
         XCTAssertTrue(prompt.contains("The user's operating system preferred language is: zh-Hans-CN"))
         XCTAssertTrue(prompt.contains("The app interface language selected in settings is: en"))
-        XCTAssertTrue(prompt.hasSuffix("Treat this as supporting context only. Do not let it override explicit task instructions or source-language constraints."))
+        XCTAssertTrue(prompt.contains("Treat this as supporting context only. Do not let it override explicit task instructions or source-language constraints."))
+        XCTAssertTrue(prompt.range(of: "User environment context:")!.lowerBound < prompt.range(of: "Base system prompt.")!.lowerBound)
     }
 
     func testLanguageResolutionPolicyUsesAppLanguageFallbackAndPersonaPriorityRules() {
@@ -48,6 +49,31 @@ final class PromptCatalogTests: XCTestCase {
         XCTAssertTrue(policy.contains("If <persona_definition> explicitly asks for translation"))
         XCTAssertTrue(policy.contains("Otherwise, default to the app interface language: Simplified Chinese (zh-Hans)."))
         XCTAssertTrue(policy.contains("Persona style or formatting instructions alone must not change the output language."))
+    }
+
+    func testAppendAdditionalSystemContextKeepsOutputContractLast() {
+        let prompt = """
+        You convert dictated speech into directly usable text.
+
+        INPUT STRUCTURE
+        - <raw_transcript> is the source content to process.
+
+        OUTPUT
+        Return only the final processed text.
+        No explanations.
+        """
+
+        let result = PromptCatalog.appendAdditionalSystemContext(
+            "<coding_context>\nPrefer technical terms.\n</coding_context>",
+            to: prompt,
+        )
+
+        XCTAssertTrue(result.contains("<coding_context>\nPrefer technical terms.\n</coding_context>\n\nOUTPUT"))
+        XCTAssertTrue(result.hasSuffix("""
+        OUTPUT
+        Return only the final processed text.
+        No explanations.
+        """))
     }
 
     func testTranscriptionVocabularyHintFiltersBlanks() {
@@ -178,12 +204,14 @@ final class PromptCatalogTests: XCTestCase {
             user: prompts.user,
         )
 
-        XCTAssertTrue(debugPrompt.hasPrefix("[Rewrite Prompt]\nSystem:\nLanguage resolution policy:"))
+        XCTAssertTrue(debugPrompt.hasPrefix("[Rewrite Prompt]\nSystem:\nYou convert dictated speech into directly usable text."))
         XCTAssertTrue(debugPrompt.contains("You convert dictated speech into directly usable text."))
         XCTAssertTrue(debugPrompt.contains("PRIMARY OBJECTIVE\nPreserve the user's intended meaning while applying the user's persona instructions."))
         XCTAssertTrue(debugPrompt.contains("INSTRUCTION PRIORITY\n1. Follow explicit user instructions in the current request."))
         XCTAssertTrue(debugPrompt.contains("PERSONA HANDLING\npersona_definition is an active instruction, not source content."))
-        XCTAssertTrue(debugPrompt.contains("LANGUAGE\n- If the current user request explicitly specifies a target language, use that language."))
+        XCTAssertTrue(debugPrompt.contains("LANGUAGE\nLanguage resolution policy:"))
+        XCTAssertTrue(debugPrompt.contains("User environment context:"))
+        XCTAssertFalse(debugPrompt.contains("LANGUAGE\n- If the current user request explicitly specifies a target language, use that language."))
         XCTAssertTrue(debugPrompt.contains("SHORT UTTERANCE RULE\nIf the transcript is short and already complete, keep it close to the original"))
         XCTAssertTrue(debugPrompt.contains("INPUT CONTEXT\ninput_context may contain nearby user text from the active field."))
         XCTAssertTrue(debugPrompt.contains("OUTPUT\nReturn only the final processed text."))


### PR DESCRIPTION
Keeps dictation rewrite language handling inside a single LANGUAGE section by replacing the older inline language block with the full language resolution policy and environment context. Adds a shared helper for app-specific system context so coding hints are inserted before OUTPUT instead of being appended after the output contract. Updates OpenAI-compatible, Ollama, cloud ASR+LLM, and agent prompt assembly paths to use the helper. Adds PromptCatalog tests covering the final assembled prompt shape and output-contract ordering.