### PR TITLE
fix: preserve selected microphone across reconnects

### DIFF
--- a/Sources/Typeflux/Audio/AVFoundationAudioRecorder.swift
+++ b/Sources/Typeflux/Audio/AVFoundationAudioRecorder.swift
@@ -254,7 +254,7 @@ final class AVFoundationAudioRecorder: AudioRecorder {
                 return deviceID
             }
 
-            resetUnavailablePreferredMicrophone(preferredID: preferredID)
+            logUnavailablePreferredMicrophone(preferredID: preferredID)
         }
 
         return audioDeviceManager.defaultInputDeviceID()
@@ -280,7 +280,7 @@ final class AVFoundationAudioRecorder: AudioRecorder {
                 channelCount: \(preferredFormat.channelCount)
                 """,
             )
-            resetUnavailablePreferredMicrophone(preferredID: preferredID)
+            logUnavailablePreferredMicrophone(preferredID: preferredID)
             if let defaultDeviceID = audioDeviceManager.defaultInputDeviceID() {
                 inputNode.auAudioUnit.setValue(Int(defaultDeviceID), forKey: "deviceID")
             }
@@ -291,14 +291,13 @@ final class AVFoundationAudioRecorder: AudioRecorder {
         return automaticFormat
     }
 
-    private func resetUnavailablePreferredMicrophone(preferredID: String) {
+    private func logUnavailablePreferredMicrophone(preferredID: String) {
         NetworkDebugLogger.logMessage(
             """
             [Audio Recorder] Preferred microphone is unavailable; falling back to automatic selection.
             preferredMicrophoneID: \(preferredID)
             """,
         )
-        settingsStore.preferredMicrophoneID = AudioDeviceManager.automaticDeviceID
     }
 
     private func currentRecordingState() -> Bool {

--- a/Tests/TypefluxTests/AVFoundationAudioRecorderTests.swift
+++ b/Tests/TypefluxTests/AVFoundationAudioRecorderTests.swift
@@ -51,7 +51,7 @@ final class AVFoundationAudioRecorderTests: XCTestCase {
         XCTAssertEqual(settingsStore.preferredMicrophoneID, "external-mic")
     }
 
-    func testResolvedInputDeviceFallsBackToDefaultWhenPreferredMicrophoneIsUnavailable() throws {
+    func testResolvedInputDeviceFallsBackToDefaultWithoutClearingUnavailablePreferredMicrophone() throws {
         let suiteName = "AVFoundationAudioRecorderTests-\(UUID().uuidString)"
         let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
         defer { defaults.removePersistentDomain(forName: suiteName) }
@@ -64,7 +64,23 @@ final class AVFoundationAudioRecorderTests: XCTestCase {
         )
 
         XCTAssertEqual(recorder.resolvedInputDeviceIDForTesting(), 7)
-        XCTAssertEqual(settingsStore.preferredMicrophoneID, AudioDeviceManager.automaticDeviceID)
+        XCTAssertEqual(settingsStore.preferredMicrophoneID, "disconnected-mic")
+    }
+
+    func testResolvedInputDevicePreservesPreferredMicrophoneWhenNoFallbackIsAvailable() throws {
+        let suiteName = "AVFoundationAudioRecorderTests-\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let settingsStore = SettingsStore(defaults: defaults)
+        settingsStore.preferredMicrophoneID = "temporarily-disconnected-mic"
+        let recorder = AVFoundationAudioRecorder(
+            settingsStore: settingsStore,
+            audioDeviceManager: MockAudioDeviceManager(),
+        )
+
+        XCTAssertNil(recorder.resolvedInputDeviceIDForTesting())
+        XCTAssertEqual(settingsStore.preferredMicrophoneID, "temporarily-disconnected-mic")
     }
 
     func testResolvedInputDeviceUsesDefaultMicrophoneInAutomaticMode() throws {


### PR DESCRIPTION
## Summary

- Fixes TYP-44 by keeping the user-selected microphone ID when the device is temporarily unavailable.
- Falls back to the current default input only for the active recording attempt instead of overwriting microphone settings.
- Adds recorder tests covering unavailable preferred microphones with and without a fallback device.

## How to test

- `swift test --filter TypefluxTests.AVFoundationAudioRecorderTests`
- `swift test`

## Screenshots

Not applicable; no UI changes.
