### PR TITLE
fix: harden microphone reconnect recording state

### DIFF
--- a/Sources/Typeflux/Audio/AVFoundationAudioRecorder.swift
+++ b/Sources/Typeflux/Audio/AVFoundationAudioRecorder.swift
@@ -3,6 +3,7 @@ import Foundation
 
 final class AVFoundationAudioRecorder: AudioRecorder {
     private static let outputMuteDelay: Duration = .milliseconds(180)
+    private static let stopDrainTimeout: TimeInterval = 2.0
 
     enum RecorderError: LocalizedError, Equatable {
         case inputDeviceUnavailable
@@ -139,13 +140,11 @@ final class AVFoundationAudioRecorder: AudioRecorder {
         removeInputTapIfInstalled()
         engine.stop()
 
-        stateCondition.lock()
-        while activeBufferCallbacks > 0 {
-            stateCondition.wait()
-        }
-        stateCondition.unlock()
+        waitForActiveBufferCallbacksToFinish(context: "stop")
 
-        writeCoordinator.drain()
+        if !writeCoordinator.drain(timeout: Self.stopDrainTimeout) {
+            NetworkDebugLogger.logMessage("[Audio Recorder] Timed out waiting for queued audio writes during stop.")
+        }
 
         let duration = Date().timeIntervalSince(currentStartedAt ?? Date())
         let fileURL = currentAudioFile.url
@@ -175,13 +174,11 @@ final class AVFoundationAudioRecorder: AudioRecorder {
             engine.reset()
         }
 
-        stateCondition.lock()
-        while activeBufferCallbacks > 0 {
-            stateCondition.wait()
-        }
-        stateCondition.unlock()
+        waitForActiveBufferCallbacksToFinish(context: "internal stop")
 
-        writeCoordinator.drain()
+        if !writeCoordinator.drain(timeout: Self.stopDrainTimeout) {
+            NetworkDebugLogger.logMessage("[Audio Recorder] Timed out waiting for queued audio writes during internal stop.")
+        }
 
         stateCondition.lock()
         audioFile = nil
@@ -204,6 +201,21 @@ final class AVFoundationAudioRecorder: AudioRecorder {
         guard isTapInstalled else { return }
         engine.inputNode.removeTap(onBus: 0)
         isTapInstalled = false
+    }
+
+    private func waitForActiveBufferCallbacksToFinish(context: String) {
+        let deadline = Date().addingTimeInterval(Self.stopDrainTimeout)
+        stateCondition.lock()
+        while activeBufferCallbacks > 0 {
+            let completed = stateCondition.wait(until: deadline)
+            if !completed {
+                NetworkDebugLogger.logMessage(
+                    "[Audio Recorder] Timed out waiting for active input callbacks during \(context).",
+                )
+                break
+            }
+        }
+        stateCondition.unlock()
     }
 
     private func scheduleMutedSessionStart() {
@@ -254,7 +266,7 @@ final class AVFoundationAudioRecorder: AudioRecorder {
                 return deviceID
             }
 
-            resetUnavailablePreferredMicrophone(preferredID: preferredID)
+            logUnavailablePreferredMicrophone(preferredID: preferredID)
         }
 
         return audioDeviceManager.defaultInputDeviceID()
@@ -280,7 +292,7 @@ final class AVFoundationAudioRecorder: AudioRecorder {
                 channelCount: \(preferredFormat.channelCount)
                 """,
             )
-            resetUnavailablePreferredMicrophone(preferredID: preferredID)
+            logUnavailablePreferredMicrophone(preferredID: preferredID)
             if let defaultDeviceID = audioDeviceManager.defaultInputDeviceID() {
                 inputNode.auAudioUnit.setValue(Int(defaultDeviceID), forKey: "deviceID")
             }
@@ -291,14 +303,13 @@ final class AVFoundationAudioRecorder: AudioRecorder {
         return automaticFormat
     }
 
-    private func resetUnavailablePreferredMicrophone(preferredID: String) {
+    private func logUnavailablePreferredMicrophone(preferredID: String) {
         NetworkDebugLogger.logMessage(
             """
             [Audio Recorder] Preferred microphone is unavailable; falling back to automatic selection.
             preferredMicrophoneID: \(preferredID)
             """,
         )
-        settingsStore.preferredMicrophoneID = AudioDeviceManager.automaticDeviceID
     }
 
     private func currentRecordingState() -> Bool {
@@ -503,5 +514,9 @@ final class AudioBufferWriteCoordinator {
 
     func drain() {
         group.wait()
+    }
+
+    func drain(timeout: TimeInterval) -> Bool {
+        group.wait(timeout: .now() + timeout) == .success
     }
 }

--- a/Sources/Typeflux/Workflow/WorkflowController+Processing.swift
+++ b/Sources/Typeflux/Workflow/WorkflowController+Processing.swift
@@ -321,6 +321,7 @@ extension WorkflowController {
     func finishRecordingAndProcess(recordingStoppedAt: Date) async {
         do {
             let audioFile = try audioRecorder.stop()
+            isStoppingRecording = false
             let audioFileReadyAt = Date()
             let recordingIntent = recordingIntent
             self.recordingIntent = .dictation
@@ -426,6 +427,7 @@ extension WorkflowController {
                 }
             }
         } catch {
+            isStoppingRecording = false
             let msg = "Processing failed: \(error.localizedDescription)"
             ErrorLogStore.shared.log(msg)
 

--- a/Sources/Typeflux/Workflow/WorkflowController.swift
+++ b/Sources/Typeflux/Workflow/WorkflowController.swift
@@ -82,6 +82,7 @@ final class WorkflowController {
 
     var currentSelectedText: String?
     var isRecording = false
+    var isStoppingRecording = false
     var recordingMode: RecordingMode = .holdToTalk
     var recordingIntent: RecordingIntent = .dictation
     var hotkeyPressedAt: Date?
@@ -417,6 +418,13 @@ final class WorkflowController {
             return
         }
 
+        guard !isStoppingRecording else {
+            Task { @MainActor in
+                self.overlayController.showProcessing()
+            }
+            return
+        }
+
         hotkeyPressedAt = startLocked ? nil : Date()
 
         if isRecording {
@@ -569,6 +577,8 @@ final class WorkflowController {
     }
 
     func beginRecording(intent: RecordingIntent, startLocked: Bool) async {
+        guard !isStoppingRecording else { return }
+
         isRecording = true
         recordingMode = startLocked ? .locked : .holdToTalk
         recordingIntent = intent
@@ -719,12 +729,18 @@ final class WorkflowController {
         guard isRecording else { return }
 
         isRecording = false
+        isStoppingRecording = true
         recordingMode = .holdToTalk
         hotkeyPressedAt = nil
         recordingTimeoutTask?.cancel()
         recordingTimeoutTask = nil
         NSLog("[Workflow] Recording stopped")
         let recordingStoppedAt = Date()
+
+        Task { @MainActor in
+            self.appState.setStatus(.processing)
+            self.overlayController.showProcessing()
+        }
 
         Task { [weak self] in
             guard let self else { return }

--- a/Tests/TypefluxTests/AVFoundationAudioRecorderTests.swift
+++ b/Tests/TypefluxTests/AVFoundationAudioRecorderTests.swift
@@ -51,7 +51,7 @@ final class AVFoundationAudioRecorderTests: XCTestCase {
         XCTAssertEqual(settingsStore.preferredMicrophoneID, "external-mic")
     }
 
-    func testResolvedInputDeviceFallsBackToDefaultWhenPreferredMicrophoneIsUnavailable() throws {
+    func testResolvedInputDeviceFallsBackToDefaultWithoutClearingUnavailablePreferredMicrophone() throws {
         let suiteName = "AVFoundationAudioRecorderTests-\(UUID().uuidString)"
         let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
         defer { defaults.removePersistentDomain(forName: suiteName) }
@@ -64,7 +64,23 @@ final class AVFoundationAudioRecorderTests: XCTestCase {
         )
 
         XCTAssertEqual(recorder.resolvedInputDeviceIDForTesting(), 7)
-        XCTAssertEqual(settingsStore.preferredMicrophoneID, AudioDeviceManager.automaticDeviceID)
+        XCTAssertEqual(settingsStore.preferredMicrophoneID, "disconnected-mic")
+    }
+
+    func testResolvedInputDevicePreservesPreferredMicrophoneWhenNoFallbackIsAvailable() throws {
+        let suiteName = "AVFoundationAudioRecorderTests-\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let settingsStore = SettingsStore(defaults: defaults)
+        settingsStore.preferredMicrophoneID = "temporarily-disconnected-mic"
+        let recorder = AVFoundationAudioRecorder(
+            settingsStore: settingsStore,
+            audioDeviceManager: MockAudioDeviceManager(),
+        )
+
+        XCTAssertNil(recorder.resolvedInputDeviceIDForTesting())
+        XCTAssertEqual(settingsStore.preferredMicrophoneID, "temporarily-disconnected-mic")
     }
 
     func testResolvedInputDeviceUsesDefaultMicrophoneInAutomaticMode() throws {
@@ -170,6 +186,22 @@ final class AVFoundationAudioRecorderTests: XCTestCase {
         coordinator.drain()
 
         XCTAssertEqual(recorder.values, [1, 2])
+    }
+
+    func testAudioBufferWriteCoordinatorDrainTimeoutReturnsFalseWhenWorkIsStillRunning() async {
+        let coordinator = AudioBufferWriteCoordinator()
+        let started = expectation(description: "Queued work started")
+
+        coordinator.enqueue {
+            started.fulfill()
+            Thread.sleep(forTimeInterval: 0.08)
+        }
+
+        await fulfillment(of: [started], timeout: 1.0)
+
+        XCTAssertFalse(coordinator.drain(timeout: 0.001))
+
+        coordinator.drain()
     }
 }
 

--- a/Tests/TypefluxTests/WorkflowControllerProcessingTests.swift
+++ b/Tests/TypefluxTests/WorkflowControllerProcessingTests.swift
@@ -58,6 +58,28 @@ final class WorkflowControllerProcessingTests: XCTestCase {
         XCTAssertNil(controller.activeProcessingRecordID)
     }
 
+    func testStoppingRecordingBlocksNewRecordingUntilStopCompletes() async {
+        let audioRecorder = BlockingStopAudioRecorder()
+        let controller = makeWorkflowController(audioRecorder: audioRecorder)
+        controller.isRecording = true
+        controller.recordingMode = .locked
+
+        controller.finishRecordingFromCurrentMode()
+        await audioRecorder.waitUntilStopStarted()
+
+        XCTAssertTrue(controller.isStoppingRecording)
+
+        await controller.beginRecording(intent: .dictation, startLocked: true)
+
+        XCTAssertEqual(audioRecorder.startCallCount, 0)
+
+        audioRecorder.finishStop()
+        await waitUntil {
+            !controller.isStoppingRecording
+        }
+        XCTAssertFalse(controller.isStoppingRecording)
+    }
+
     func testAskWithoutSelectionAgentDispositionMapsAnswerToAnswer() {
         let result = WorkflowController.askWithoutSelectionAgentDisposition(
             for: .answer("Here is the answer"),
@@ -276,6 +298,7 @@ final class WorkflowControllerProcessingTests: XCTestCase {
 
     private func makeWorkflowController(
         textInjector: TextInjector = MockProcessingTextInjector(),
+        audioRecorder: AudioRecorder = MockProcessingAudioRecorder(),
         llmService: LLMService = MockProcessingLLMService(),
         configureSettings: ((SettingsStore) -> Void)? = nil,
     ) -> WorkflowController {
@@ -291,7 +314,7 @@ final class WorkflowControllerProcessingTests: XCTestCase {
             appState: appState,
             settingsStore: settingsStore,
             hotkeyService: MockProcessingHotkeyService(),
-            audioRecorder: MockProcessingAudioRecorder(),
+            audioRecorder: audioRecorder,
             sttRouter: STTRouter(
                 settingsStore: settingsStore,
                 whisper: MockProcessingTranscriber(),
@@ -323,6 +346,16 @@ final class WorkflowControllerProcessingTests: XCTestCase {
             ),
             soundEffectPlayer: SoundEffectPlayer(settingsStore: settingsStore),
         )
+    }
+}
+
+private func waitUntil(
+    timeout: TimeInterval = 1.0,
+    condition: @escaping () -> Bool,
+) async {
+    let deadline = Date().addingTimeInterval(timeout)
+    while !condition(), Date() < deadline {
+        try? await Task.sleep(for: .milliseconds(10))
     }
 }
 
@@ -408,6 +441,48 @@ private final class MockProcessingAudioRecorder: AudioRecorder {
 
     func stop() throws -> AudioFile {
         AudioFile(fileURL: URL(fileURLWithPath: "/tmp/mock.wav"), duration: 1)
+    }
+}
+
+private final class BlockingStopAudioRecorder: AudioRecorder, @unchecked Sendable {
+    private let lock = NSLock()
+    private let stopStarted = DispatchSemaphore(value: 0)
+    private let stopRelease = DispatchSemaphore(value: 0)
+    private var starts = 0
+
+    var startCallCount: Int {
+        lock.lock()
+        let count = starts
+        lock.unlock()
+        return count
+    }
+
+    func start(
+        levelHandler _: @escaping (Float) -> Void,
+        audioBufferHandler _: ((AVAudioPCMBuffer) -> Void)?,
+    ) throws {
+        lock.lock()
+        starts += 1
+        lock.unlock()
+    }
+
+    func stop() throws -> AudioFile {
+        stopStarted.signal()
+        _ = stopRelease.wait(timeout: .now() + 2)
+        return AudioFile(fileURL: URL(fileURLWithPath: "/tmp/missing.wav"), duration: 1)
+    }
+
+    func waitUntilStopStarted() async {
+        await withCheckedContinuation { continuation in
+            DispatchQueue.global().async {
+                self.stopStarted.wait()
+                continuation.resume()
+            }
+        }
+    }
+
+    func finishStop() {
+        stopRelease.signal()
     }
 }
 


### PR DESCRIPTION
## Summary

- Fixes TYP-44 by adding a stopping-recording state so hotkeys cannot start another recording while the previous recording is still stopping.
- Moves the overlay out of recording immediately when stop begins, so a slow/stale AVFoundation stop path does not leave the recording capsule looking active.
- Bounds AVFoundation callback/write-drain waits during stop so disconnected/reconnected audio devices cannot hold the recorder indefinitely.
- Preserves the selected microphone across transient disconnects while falling back to the default input for the current recording attempt.

## How to test

- `swift test --filter TypefluxTests.AVFoundationAudioRecorderTests --filter TypefluxTests.WorkflowControllerProcessingTests`
- `swift test`

## Screenshots

Not applicable; no UI layout changes.
