### PR TITLE
feat(hotkey): support single-key shortcuts for right modifier keys

### DIFF
--- a/Sources/Typeflux/Hotkey/HotkeyBinding.swift
+++ b/Sources/Typeflux/Hotkey/HotkeyBinding.swift
@@ -2,6 +2,8 @@ import AppKit
 import Foundation
 
 struct HotkeyBinding: Codable, Equatable, Identifiable {
+    static let rightCommandKeyCode = 54
+    static let rightOptionKeyCode = 61
     static let functionKeyCode = 63
 
     var id: UUID
@@ -19,7 +21,13 @@ struct HotkeyBinding: Codable, Equatable, Identifiable {
     }
 
     var isRightCommandTrigger: Bool {
-        keyCode == 54 && modifierFlags == 1_048_576
+        keyCode == Self.rightCommandKeyCode
+            && modifierFlags == UInt(NSEvent.ModifierFlags.command.rawValue)
+    }
+
+    var isRightOptionTrigger: Bool {
+        keyCode == Self.rightOptionKeyCode
+            && modifierFlags == UInt(NSEvent.ModifierFlags.option.rawValue)
     }
 
     var isFunctionTrigger: Bool {
@@ -28,7 +36,7 @@ struct HotkeyBinding: Codable, Equatable, Identifiable {
     }
 
     var isModifierOnlyTrigger: Bool {
-        isRightCommandTrigger || isFunctionTrigger
+        isRightCommandTrigger || isRightOptionTrigger || isFunctionTrigger
     }
 
     func matches(keyCode: Int, modifierFlags: UInt) -> Bool {

--- a/Sources/Typeflux/Hotkey/HotkeyFormat.swift
+++ b/Sources/Typeflux/Hotkey/HotkeyFormat.swift
@@ -10,6 +10,9 @@ enum HotkeyFormat {
         if binding.isRightCommandTrigger {
             return ["Right Command"]
         }
+        if binding.isRightOptionTrigger {
+            return ["Right Option"]
+        }
         if binding.isFunctionTrigger {
             return ["Fn"]
         }

--- a/Sources/Typeflux/Resources/en.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/en.lproj/Localizable.strings
@@ -500,9 +500,9 @@
 "settings.advanced.personaHotkeyApply.subtitle" = "When enabled, the persona shortcut checks for selected text first and uses the picker to rewrite that selection instead of only switching the default persona.";
 "settings.shortcuts.recording" = "Recording a new shortcut";
 "settings.shortcuts.recordingActivation" = "Press the new voice input key or key combination now.";
-"settings.shortcuts.recordingAsk" = "Press the new Ask Anything combination now. Include at least one modifier key.";
-"settings.shortcuts.recordingPersona" = "Press the shortcut that should open the persona picker. Include at least one modifier key.";
-"settings.shortcuts.recordingGeneric" = "Press the full key combination you want to use. Include at least one modifier key.";
+"settings.shortcuts.recordingAsk" = "Press the new Ask Anything key or key combination now.";
+"settings.shortcuts.recordingPersona" = "Press the shortcut that should open the persona picker.";
+"settings.shortcuts.recordingGeneric" = "Press the key or key combination you want to use.";
 "settings.shortcuts.record" = "Record";
 "settings.shortcuts.stopRecording" = "Stop Recording";
 "settings.shortcuts.activationConflict" = "Voice input shortcut cannot match the Ask Anything or persona shortcut.";

--- a/Sources/Typeflux/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/ja.lproj/Localizable.strings
@@ -498,9 +498,9 @@
 "settings.advanced.personaHotkeyApply.subtitle" = "有効にすると、ペルソナ ショートカットは最初に選択されたテキストを確認し、デフォルトのペルソナを切り替えるだけでなく、ピッカーを使用してその選択を書き換えます。";
 "settings.shortcuts.recording" = "新しいショートカットを記録する";
 "settings.shortcuts.recordingActivation" = "新しい音声入力キーまたはキーの組み合わせを今すぐ押してください。";
-"settings.shortcuts.recordingAsk" = "新しい「何でも質問」の組み合わせを今すぐ押してください。少なくとも 1 つの修飾キーを含めます。";
-"settings.shortcuts.recordingPersona" = "ペルソナピッカーを開くショートカットを押します。少なくとも 1 つの修飾キーを含めます。";
-"settings.shortcuts.recordingGeneric" = "使用するキーの組み合わせをすべて押します。少なくとも 1 つの修飾キーを含めます。";
+"settings.shortcuts.recordingAsk" = "新しい「何でも質問」のキーまたはキーの組み合わせを今すぐ押してください。";
+"settings.shortcuts.recordingPersona" = "ペルソナピッカーを開くショートカットを押してください。";
+"settings.shortcuts.recordingGeneric" = "使用するキーまたはキーの組み合わせを押してください。";
 "settings.shortcuts.record" = "記録";
 "settings.shortcuts.stopRecording" = "録音を停止する";
 "settings.shortcuts.activationConflict" = "音声入力ショートカットは、「何でも質問」またはペルソナのショートカットと一致することはできません。";

--- a/Sources/Typeflux/Resources/ko.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/ko.lproj/Localizable.strings
@@ -498,9 +498,9 @@
 "settings.advanced.personaHotkeyApply.subtitle" = "활성화되면 페르소나 단축키는 선택한 텍스트를 먼저 확인하고 기본 페르소나만 전환하는 대신 선택기를 사용하여 해당 선택 항목을 다시 작성합니다.";
 "settings.shortcuts.recording" = "새 바로가기 녹음";
 "settings.shortcuts.recordingActivation" = "지금 새로운 음성 입력 키나 키 조합을 누르세요.";
-"settings.shortcuts.recordingAsk" = "지금 새로운 무엇이든 물어보세요 조합을 누르세요. 최소한 하나의 수정자 키를 포함하세요.";
-"settings.shortcuts.recordingPersona" = "페르소나 선택기를 여는 바로가기를 누릅니다. 최소한 하나의 수정자 키를 포함하세요.";
-"settings.shortcuts.recordingGeneric" = "사용하려는 전체 키 조합을 누르세요. 최소한 하나의 수정자 키를 포함하세요.";
+"settings.shortcuts.recordingAsk" = "지금 새로운 무엇이든 물어보세요 키나 키 조합을 누르세요.";
+"settings.shortcuts.recordingPersona" = "페르소나 선택기를 여는 바로가기를 누르세요.";
+"settings.shortcuts.recordingGeneric" = "사용하려는 키나 키 조합을 누르세요.";
 "settings.shortcuts.record" = "기록";
 "settings.shortcuts.stopRecording" = "녹음 중지";
 "settings.shortcuts.activationConflict" = "음성 입력 바로가기는 무엇이든 물어보세요 또는 페르소나 바로가기와 일치할 수 없습니다.";

--- a/Sources/Typeflux/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/zh-Hans.lproj/Localizable.strings
@@ -500,9 +500,9 @@
 "settings.advanced.personaHotkeyApply.subtitle" = "开启后，人设快捷键会先检查是否有选中文本；如果有，就用所选人设直接改写该文本，而不只是切换默认人设。";
 "settings.shortcuts.recording" = "正在录制新的快捷键";
 "settings.shortcuts.recordingActivation" = "现在按下新的语音输入按键或组合键。";
-"settings.shortcuts.recordingAsk" = "现在按下新的“随便问”组合键，至少包含一个修饰键。";
-"settings.shortcuts.recordingPersona" = "现在按下用于打开人设选择器的快捷键，至少包含一个修饰键。";
-"settings.shortcuts.recordingGeneric" = "按下你想使用的完整组合键，至少包含一个修饰键。";
+"settings.shortcuts.recordingAsk" = "现在按下新的“随便问”按键或组合键。";
+"settings.shortcuts.recordingPersona" = "现在按下用于打开人设选择器的快捷键。";
+"settings.shortcuts.recordingGeneric" = "按下你想使用的按键或组合键。";
 "settings.shortcuts.record" = "录制";
 "settings.shortcuts.stopRecording" = "停止录制";
 "settings.shortcuts.activationConflict" = "语音输入快捷键不能与“随便问”或人设快捷键相同。";

--- a/Sources/Typeflux/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/zh-Hant.lproj/Localizable.strings
@@ -498,9 +498,9 @@
 "settings.advanced.personaHotkeyApply.subtitle" = "開啟後，人設快捷鍵會先檢查是否有選取文字；如果有，就用所選人設直接改寫該文字，而不只是切換預設人設。";
 "settings.shortcuts.recording" = "正在錄製新的快捷鍵";
 "settings.shortcuts.recordingActivation" = "現在按下新的語音輸入按鍵或組合鍵。";
-"settings.shortcuts.recordingAsk" = "現在按下新的「隨便問」組合鍵，至少包含一個修飾鍵。";
-"settings.shortcuts.recordingPersona" = "現在按下用於打開人設選擇器的快捷鍵，至少包含一個修飾鍵。";
-"settings.shortcuts.recordingGeneric" = "按下你想使用的完整組合鍵，至少包含一個修飾鍵。";
+"settings.shortcuts.recordingAsk" = "現在按下新的「隨便問」按鍵或組合鍵。";
+"settings.shortcuts.recordingPersona" = "現在按下用於打開人設選擇器的快捷鍵。";
+"settings.shortcuts.recordingGeneric" = "按下你想使用的按鍵或組合鍵。";
 "settings.shortcuts.record" = "錄製";
 "settings.shortcuts.stopRecording" = "停止錄製";
 "settings.shortcuts.activationConflict" = "語音輸入快捷鍵不能與「隨便問」或人設快捷鍵相同。";

--- a/Sources/Typeflux/Settings/HotkeyRecorder.swift
+++ b/Sources/Typeflux/Settings/HotkeyRecorder.swift
@@ -16,21 +16,14 @@ final class HotkeyRecorder: ObservableObject {
             let keyCode = Int(event.keyCode)
             let flags = event.modifierFlags.intersection([.command, .option, .control, .shift, .function])
 
-            let binding = HotkeyBinding(keyCode: keyCode, modifierFlags: UInt(flags.rawValue))
-
-            if event.type == .flagsChanged {
-                guard binding.isRightCommandTrigger || binding.isFunctionTrigger else { return event }
-                onRecorded(binding)
-                stop()
-                return nil
+            guard let binding = Self.recordedBinding(
+                eventType: event.type,
+                keyCode: keyCode,
+                modifierFlags: UInt(flags.rawValue),
+                isRepeat: event.isARepeat,
+            ) else {
+                return event.type == .keyDown && event.isARepeat ? nil : event
             }
-
-            // Ignore repeats
-            if event.isARepeat { return nil }
-
-            // Require at least one modifier to reduce collisions.
-            if flags.isEmpty { return nil }
-
             onRecorded(binding)
             stop()
             return nil
@@ -43,5 +36,21 @@ final class HotkeyRecorder: ObservableObject {
         }
         monitor = nil
         isRecording = false
+    }
+
+    static func recordedBinding(
+        eventType: NSEvent.EventType,
+        keyCode: Int,
+        modifierFlags: UInt,
+        isRepeat: Bool,
+    ) -> HotkeyBinding? {
+        let binding = HotkeyBinding(keyCode: keyCode, modifierFlags: modifierFlags)
+
+        if eventType == .flagsChanged {
+            return binding.isModifierOnlyTrigger ? binding : nil
+        }
+
+        guard eventType == .keyDown, !isRepeat, modifierFlags != 0 else { return nil }
+        return binding
     }
 }

--- a/Tests/TypefluxTests/HotkeyBindingTests.swift
+++ b/Tests/TypefluxTests/HotkeyBindingTests.swift
@@ -29,13 +29,37 @@ final class HotkeyBindingTests: XCTestCase {
     // MARK: - isRightCommandTrigger
 
     func testIsRightCommandTrigger() {
-        let binding = HotkeyBinding(keyCode: 54, modifierFlags: 1_048_576)
+        let binding = HotkeyBinding(
+            keyCode: HotkeyBinding.rightCommandKeyCode,
+            modifierFlags: UInt(NSEvent.ModifierFlags.command.rawValue),
+        )
         XCTAssertTrue(binding.isRightCommandTrigger)
     }
 
     func testIsNotRightCommandTriggerWrongKeyCode() {
-        let binding = HotkeyBinding(keyCode: 55, modifierFlags: 1_048_576)
+        let binding = HotkeyBinding(
+            keyCode: HotkeyBinding.rightCommandKeyCode + 1,
+            modifierFlags: UInt(NSEvent.ModifierFlags.command.rawValue),
+        )
         XCTAssertFalse(binding.isRightCommandTrigger)
+    }
+
+    // MARK: - isRightOptionTrigger
+
+    func testIsRightOptionTrigger() {
+        let binding = HotkeyBinding(
+            keyCode: HotkeyBinding.rightOptionKeyCode,
+            modifierFlags: UInt(NSEvent.ModifierFlags.option.rawValue),
+        )
+        XCTAssertTrue(binding.isRightOptionTrigger)
+    }
+
+    func testIsNotRightOptionTriggerWrongKeyCode() {
+        let binding = HotkeyBinding(
+            keyCode: HotkeyBinding.rightOptionKeyCode + 1,
+            modifierFlags: UInt(NSEvent.ModifierFlags.option.rawValue),
+        )
+        XCTAssertFalse(binding.isRightOptionTrigger)
     }
 
     // MARK: - isFunctionTrigger
@@ -57,7 +81,18 @@ final class HotkeyBindingTests: XCTestCase {
     }
 
     func testModifierOnlyForRightCommand() {
-        let binding = HotkeyBinding(keyCode: 54, modifierFlags: 1_048_576)
+        let binding = HotkeyBinding(
+            keyCode: HotkeyBinding.rightCommandKeyCode,
+            modifierFlags: UInt(NSEvent.ModifierFlags.command.rawValue),
+        )
+        XCTAssertTrue(binding.isModifierOnlyTrigger)
+    }
+
+    func testModifierOnlyForRightOption() {
+        let binding = HotkeyBinding(
+            keyCode: HotkeyBinding.rightOptionKeyCode,
+            modifierFlags: UInt(NSEvent.ModifierFlags.option.rawValue),
+        )
         XCTAssertTrue(binding.isModifierOnlyTrigger)
     }
 

--- a/Tests/TypefluxTests/HotkeyFormatTests.swift
+++ b/Tests/TypefluxTests/HotkeyFormatTests.swift
@@ -5,8 +5,19 @@ final class HotkeyFormatTests: XCTestCase {
     // MARK: - Special triggers
 
     func testDisplayRightCommandTrigger() {
-        let binding = HotkeyBinding(keyCode: 54, modifierFlags: 1_048_576)
+        let binding = HotkeyBinding(
+            keyCode: HotkeyBinding.rightCommandKeyCode,
+            modifierFlags: UInt(NSEvent.ModifierFlags.command.rawValue),
+        )
         XCTAssertEqual(HotkeyFormat.display(binding), "Right Command")
+    }
+
+    func testDisplayRightOptionTrigger() {
+        let binding = HotkeyBinding(
+            keyCode: HotkeyBinding.rightOptionKeyCode,
+            modifierFlags: UInt(NSEvent.ModifierFlags.option.rawValue),
+        )
+        XCTAssertEqual(HotkeyFormat.display(binding), "Right Option")
     }
 
     func testDisplayFnTrigger() {

--- a/Tests/TypefluxTests/HotkeyGestureArbiterTests.swift
+++ b/Tests/TypefluxTests/HotkeyGestureArbiterTests.swift
@@ -188,6 +188,34 @@ final class HotkeyGestureArbiterTests: XCTestCase {
 
         XCTAssertEqual(events, [.activationTapped])
     }
+
+    func testRightOptionModifierOnlyActivationBeginsAndEnds() {
+        var arbiter = HotkeyGestureArbiter()
+        let rightOptionActivation = HotkeyBinding(
+            keyCode: HotkeyBinding.rightOptionKeyCode,
+            modifierFlags: UInt(NSEvent.ModifierFlags.option.rawValue),
+        )
+
+        let beginEvents = arbiter.handleFlagsChanged(
+            keyCode: HotkeyBinding.rightOptionKeyCode,
+            modifierFlags: UInt(NSEvent.ModifierFlags.option.rawValue),
+            activationHotkey: rightOptionActivation,
+            askHotkey: nil,
+        )
+
+        XCTAssertEqual(beginEvents, [.begin(.activation)])
+        XCTAssertEqual(arbiter.phase, .active(.activation))
+
+        let endEvents = arbiter.handleFlagsChanged(
+            keyCode: HotkeyBinding.rightOptionKeyCode,
+            modifierFlags: 0,
+            activationHotkey: rightOptionActivation,
+            askHotkey: nil,
+        )
+
+        XCTAssertEqual(endEvents, [.end(.activation)])
+        XCTAssertEqual(arbiter.phase, .idle)
+    }
 }
 
 // MARK: - Extended HotkeyGestureArbiter tests

--- a/Tests/TypefluxTests/HotkeyRecorderTests.swift
+++ b/Tests/TypefluxTests/HotkeyRecorderTests.swift
@@ -1,0 +1,76 @@
+import AppKit
+@testable import Typeflux
+import XCTest
+
+final class HotkeyRecorderTests: XCTestCase {
+    func testIgnoresSingleNonModifierKeyDownWithoutModifiers() {
+        let binding = HotkeyRecorder.recordedBinding(
+            eventType: .keyDown,
+            keyCode: 49,
+            modifierFlags: 0,
+            isRepeat: false,
+        )
+
+        XCTAssertNil(binding)
+    }
+
+    func testRecordsKeyDownWithModifiers() {
+        let flags = UInt(NSEvent.ModifierFlags.command.rawValue)
+
+        let binding = HotkeyRecorder.recordedBinding(
+            eventType: .keyDown,
+            keyCode: 35,
+            modifierFlags: flags,
+            isRepeat: false,
+        )
+
+        XCTAssertEqual(binding?.keyCode, 35)
+        XCTAssertEqual(binding?.modifierFlags, flags)
+    }
+
+    func testIgnoresRepeatedKeyDown() {
+        let binding = HotkeyRecorder.recordedBinding(
+            eventType: .keyDown,
+            keyCode: 49,
+            modifierFlags: 0,
+            isRepeat: true,
+        )
+
+        XCTAssertNil(binding)
+    }
+
+    func testRecordsSupportedModifierOnlyTriggerFromFlagsChanged() {
+        let binding = HotkeyRecorder.recordedBinding(
+            eventType: .flagsChanged,
+            keyCode: HotkeyBinding.functionKeyCode,
+            modifierFlags: UInt(NSEvent.ModifierFlags.function.rawValue),
+            isRepeat: false,
+        )
+
+        XCTAssertEqual(binding?.keyCode, HotkeyBinding.defaultActivation.keyCode)
+        XCTAssertEqual(binding?.modifierFlags, HotkeyBinding.defaultActivation.modifierFlags)
+    }
+
+    func testRecordsRightOptionModifierOnlyTriggerFromFlagsChanged() {
+        let binding = HotkeyRecorder.recordedBinding(
+            eventType: .flagsChanged,
+            keyCode: HotkeyBinding.rightOptionKeyCode,
+            modifierFlags: UInt(NSEvent.ModifierFlags.option.rawValue),
+            isRepeat: false,
+        )
+
+        XCTAssertEqual(binding?.keyCode, HotkeyBinding.rightOptionKeyCode)
+        XCTAssertEqual(binding?.modifierFlags, UInt(NSEvent.ModifierFlags.option.rawValue))
+    }
+
+    func testIgnoresUnsupportedModifierOnlyTriggerFromFlagsChanged() {
+        let binding = HotkeyRecorder.recordedBinding(
+            eventType: .flagsChanged,
+            keyCode: 56,
+            modifierFlags: UInt(NSEvent.ModifierFlags.shift.rawValue),
+            isRepeat: false,
+        )
+
+        XCTAssertNil(binding)
+    }
+}


### PR DESCRIPTION
## Summary

支持单一按键（Fn、右侧 Command、右侧 Option）作为快捷键触发语音输入。

## Changes

- `HotkeyBinding`: 新增 `rightOptionKeyCode` (61) 和 `isRightOptionTrigger`，将 Right Option 纳入 `isModifierOnlyTrigger`
- `HotkeyFormat`: 新增 Right Option 的显示格式 "Right Option"
- `HotkeyRecorder`: 重构录制逻辑，提取 `recordedBinding` 静态方法
  - `flagsChanged` 事件可录制 modifier-only 单键（Fn / Right Command / Right Option）
  - 普通无修饰键 `keyDown` 被阻止，防止误录
- `Localizable.strings` (5 种语言): 移除"至少包含一个修饰键"的限制文案

## Test Plan

- [x] `HotkeyRecorderTests` (6 tests) — 覆盖录制边界
- [x] `HotkeyGestureArbiterTests` — 新增 Right Option begin/end 测试
- [x] `HotkeyBindingTests` / `HotkeyFormatTests` — 新增 Right Option 相关测试
- [x] 全部 66 个 hotkey 相关测试通过，0 失败