### PR TITLE
feat: add SenseVoice decoding experiments

### DIFF
--- a/Sources/Typeflux/Audio/AudioFileTranscoder.swift
+++ b/Sources/Typeflux/Audio/AudioFileTranscoder.swift
@@ -2,8 +2,17 @@ import AVFoundation
 import Foundation
 
 enum AudioFileTranscoder {
-    static func wavFileURL(for audioFile: AudioFile) throws -> URL {
-        if audioFile.fileURL.pathExtension.lowercased() == "wav" {
+    enum OutputFormat {
+        case sourceSampleRateAndChannels
+        case mono16k
+    }
+
+    static func wavFileURL(
+        for audioFile: AudioFile,
+        outputFormat: OutputFormat = .sourceSampleRateAndChannels,
+        forceTranscode: Bool = false,
+    ) throws -> URL {
+        if !forceTranscode, audioFile.fileURL.pathExtension.lowercased() == "wav" {
             return audioFile.fileURL
         }
 
@@ -21,12 +30,32 @@ enum AudioFileTranscoder {
             try FileManager.default.removeItem(at: outputURL)
         }
 
+        if outputFormat == .mono16k,
+           audioFile.fileURL.pathExtension.lowercased() == "wav",
+           let normalizedWAV = try manuallyNormalizedPCM16MonoWAV(inputURL: audioFile.fileURL)
+        {
+            try normalizedWAV.write(to: outputURL)
+            return outputURL
+        }
+
         let inputFile = try AVAudioFile(forReading: audioFile.fileURL)
+        let outputSampleRate: Double
+        let outputChannelCount: AVAudioChannelCount
+        switch outputFormat {
+        case .sourceSampleRateAndChannels:
+            outputSampleRate = inputFile.processingFormat.sampleRate
+            outputChannelCount = inputFile.processingFormat.channelCount
+        case .mono16k:
+            outputSampleRate = 16_000
+            outputChannelCount = 1
+        }
+        let commonFormat: AVAudioCommonFormat = outputFormat == .mono16k ? .pcmFormatFloat32 : .pcmFormatInt16
+        let isInterleaved = outputFormat == .mono16k ? false : true
         let format = AVAudioFormat(
-            commonFormat: .pcmFormatInt16,
-            sampleRate: inputFile.processingFormat.sampleRate,
-            channels: inputFile.processingFormat.channelCount,
-            interleaved: true,
+            commonFormat: commonFormat,
+            sampleRate: outputSampleRate,
+            channels: outputChannelCount,
+            interleaved: isInterleaved,
         )
 
         guard let format else {
@@ -37,12 +66,7 @@ enum AudioFileTranscoder {
             )
         }
 
-        let outputFile = try AVAudioFile(
-            forWriting: outputURL,
-            settings: format.settings,
-            commonFormat: format.commonFormat,
-            interleaved: format.isInterleaved,
-        )
+        let outputFile = try AVAudioFile(forWriting: outputURL, settings: format.settings)
 
         guard let converter = AVAudioConverter(from: inputFile.processingFormat, to: format) else {
             throw NSError(
@@ -66,7 +90,8 @@ enum AudioFileTranscoder {
         }
 
         let ratio = format.sampleRate / inputFile.processingFormat.sampleRate
-        let outputCapacity = AVAudioFrameCount(Double(inputBuffer.frameCapacity) * ratio) + 1
+        let convertedFrameCapacity = AVAudioFrameCount(Double(inputBuffer.frameCapacity) * ratio) + 1
+        let outputCapacity = max(inputBuffer.frameCapacity, convertedFrameCapacity)
         guard let outputBuffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: outputCapacity) else {
             throw NSError(
                 domain: "AudioFileTranscoder",
@@ -87,7 +112,7 @@ enum AudioFileTranscoder {
 
             let status = converter.convert(to: outputBuffer, error: &conversionError) { _, outStatus in
                 if didProvideInput {
-                    outStatus.pointee = .noDataNow
+                    outStatus.pointee = .endOfStream
                     return nil
                 }
 
@@ -114,5 +139,108 @@ enum AudioFileTranscoder {
         }
 
         return outputURL
+    }
+
+    private static func manuallyNormalizedPCM16MonoWAV(inputURL: URL) throws -> Data? {
+        let data = try Data(contentsOf: inputURL)
+        guard data.count >= 44,
+              String(data: data[0..<4], encoding: .ascii) == "RIFF",
+              String(data: data[8..<12], encoding: .ascii) == "WAVE"
+        else {
+            return nil
+        }
+
+        var offset = 12
+        var sampleRate: UInt32?
+        var channels: UInt16?
+        var bitsPerSample: UInt16?
+        var pcmRange: Range<Int>?
+        while offset + 8 <= data.count {
+            let chunkID = String(data: data[offset..<offset + 4], encoding: .ascii)
+            let chunkSize = Int(littleEndianUInt32(data, offset: offset + 4))
+            let chunkStart = offset + 8
+            let chunkEnd = min(chunkStart + chunkSize, data.count)
+            if chunkID == "fmt ", chunkSize >= 16 {
+                let audioFormat = littleEndianUInt16(data, offset: chunkStart)
+                guard audioFormat == 1 else { return nil }
+                channels = littleEndianUInt16(data, offset: chunkStart + 2)
+                sampleRate = littleEndianUInt32(data, offset: chunkStart + 4)
+                bitsPerSample = littleEndianUInt16(data, offset: chunkStart + 14)
+            } else if chunkID == "data" {
+                pcmRange = chunkStart..<chunkEnd
+            }
+            offset = chunkEnd + (chunkSize % 2)
+        }
+
+        guard sampleRate != nil,
+              channels == 1,
+              bitsPerSample == 16,
+              let pcmRange
+        else {
+            return nil
+        }
+
+        let inputPCM = data[pcmRange]
+        let inputFrameCount = inputPCM.count / MemoryLayout<Int16>.size
+        guard inputFrameCount > 0 else {
+            return wavFile(fromPCM16Mono: Data(), sampleRate: 16_000)
+        }
+
+        let outputFrameCount = max(1, Int((Double(inputFrameCount) * 16_000 / Double(sampleRate ?? 16_000)).rounded()))
+        var outputPCM = Data(count: outputFrameCount * MemoryLayout<Int16>.size)
+        outputPCM.withUnsafeMutableBytes { outputBytes in
+            inputPCM.withUnsafeBytes { inputBytes in
+                let inputSamples = inputBytes.bindMemory(to: Int16.self)
+                let outputSamples = outputBytes.bindMemory(to: Int16.self)
+                for outputIndex in 0..<outputFrameCount {
+                    let inputIndex = min(inputFrameCount - 1, Int(Double(outputIndex) * Double(inputFrameCount) / Double(outputFrameCount)))
+                    outputSamples[outputIndex] = inputSamples[inputIndex]
+                }
+            }
+        }
+        return wavFile(fromPCM16Mono: outputPCM, sampleRate: 16_000)
+    }
+
+    private static func wavFile(fromPCM16Mono pcmData: Data, sampleRate: Int) -> Data {
+        let channels: UInt16 = 1
+        let bitsPerSample: UInt16 = 16
+        let byteRate = UInt32(sampleRate) * UInt32(channels) * UInt32(bitsPerSample / 8)
+        let blockAlign = channels * (bitsPerSample / 8)
+        let subchunk2Size = UInt32(pcmData.count)
+        let chunkSize = UInt32(36) + subchunk2Size
+
+        var data = Data()
+        data.append("RIFF".data(using: .ascii)!)
+        data.append(littleEndianData(chunkSize))
+        data.append("WAVE".data(using: .ascii)!)
+        data.append("fmt ".data(using: .ascii)!)
+        data.append(littleEndianData(UInt32(16)))
+        data.append(littleEndianData(UInt16(1)))
+        data.append(littleEndianData(channels))
+        data.append(littleEndianData(UInt32(sampleRate)))
+        data.append(littleEndianData(byteRate))
+        data.append(littleEndianData(blockAlign))
+        data.append(littleEndianData(bitsPerSample))
+        data.append("data".data(using: .ascii)!)
+        data.append(littleEndianData(subchunk2Size))
+        data.append(pcmData)
+        return data
+    }
+
+    private static func littleEndianUInt16(_ data: Data, offset: Int) -> UInt16 {
+        data.withUnsafeBytes { bytes in
+            bytes.loadUnaligned(fromByteOffset: offset, as: UInt16.self).littleEndian
+        }
+    }
+
+    private static func littleEndianUInt32(_ data: Data, offset: Int) -> UInt32 {
+        data.withUnsafeBytes { bytes in
+            bytes.loadUnaligned(fromByteOffset: offset, as: UInt32.self).littleEndian
+        }
+    }
+
+    private static func littleEndianData<T: FixedWidthInteger>(_ value: T) -> Data {
+        var littleEndian = value.littleEndian
+        return Data(bytes: &littleEndian, count: MemoryLayout<T>.size)
     }
 }

--- a/Sources/Typeflux/Batch/TypefluxBatchCommand.swift
+++ b/Sources/Typeflux/Batch/TypefluxBatchCommand.swift
@@ -36,6 +36,7 @@ private struct BatchConfiguration {
     let retryFailed: Bool
     let sttProviderOverride: STTProvider?
     let localSTTModelOverride: LocalSTTModel?
+    let senseVoiceDecodingConfiguration: SenseVoiceDecodingConfiguration
     let personaSelector: PersonaSelector?
     let noPersona: Bool
 
@@ -75,6 +76,21 @@ private struct BatchConfiguration {
         } else {
             localSTTModelOverride = nil
         }
+
+        var senseVoiceConfig = SenseVoiceDecodingConfiguration.default
+        if let raw = parser.consumeValue("--sense-voice-language") {
+            guard let language = SenseVoiceDecodingConfiguration.Language(rawValue: raw) else {
+                throw BatchCommandError(message: "Unsupported --sense-voice-language value: \(raw)")
+            }
+            senseVoiceConfig.language = language
+        }
+        if parser.consumeFlag("--sense-voice-no-itn") {
+            senseVoiceConfig.useITN = false
+        }
+        if parser.consumeFlag("--sense-voice-normalize-16k-mono") {
+            senseVoiceConfig.audioNormalization = .mono16k
+        }
+        senseVoiceDecodingConfiguration = senseVoiceConfig
 
         let personaID = parser.consumeValue("--persona-id")
         let personaName = parser.consumeValue("--persona-name")
@@ -164,6 +180,9 @@ private struct BatchConfiguration {
       --state <path>                   Override the default state path. Defaults to <output>.state.json.
       --stt-provider <provider>        Optional STT provider override. See table below.
       --local-stt-model <model>        Optional local STT model override. See table below.
+      --sense-voice-language <value>   SenseVoice language override for local experiments: auto, zh, en.
+      --sense-voice-no-itn             Disable SenseVoice inverse text normalization for local experiments.
+      --sense-voice-normalize-16k-mono Convert SenseVoice input to 16 kHz mono WAV before decoding.
       --persona-id <uuid>              Optional saved persona selector by ID.
       --persona-name <name>            Optional saved persona selector by name.
       --persona-prompt-file <path>     Optional prompt file selector instead of a saved persona.
@@ -382,7 +401,11 @@ private final class WAVPersonaBenchmark {
             whisper: WhisperAPITranscriber(settingsStore: settingsStore),
             freeSTT: FreeSTTTranscriber(settingsStore: settingsStore),
             appleSpeech: AppleSpeechTranscriber(),
-            localModel: LocalModelTranscriber(settingsStore: settingsStore, modelManager: localModelManager),
+            localModel: LocalModelTranscriber(
+                settingsStore: settingsStore,
+                modelManager: localModelManager,
+                senseVoiceDecodingConfiguration: config.senseVoiceDecodingConfiguration,
+            ),
             multimodal: MultimodalLLMTranscriber(settingsStore: settingsStore),
             aliCloud: AliCloudRealtimeTranscriber(settingsStore: settingsStore),
             doubaoRealtime: DoubaoRealtimeTranscriber(settingsStore: settingsStore),

--- a/Sources/Typeflux/STT/LocalModelTranscriber.swift
+++ b/Sources/Typeflux/STT/LocalModelTranscriber.swift
@@ -15,6 +15,7 @@ final class LocalModelTranscriber: Transcriber {
 
     private let settingsStore: SettingsStore
     private let modelManager: LocalSTTModelManaging
+    private let senseVoiceDecodingConfiguration: SenseVoiceDecodingConfiguration
     private let whisperKitTranscriberFactory: (String, String) -> LocalWhisperKitTranscribing
     private let whisperKitKeepAliveDurationWhenMemoryOptimized: TimeInterval
     private let whisperKitCacheLock = NSLock()
@@ -27,6 +28,7 @@ final class LocalModelTranscriber: Transcriber {
     init(
         settingsStore: SettingsStore,
         modelManager: LocalSTTModelManaging,
+        senseVoiceDecodingConfiguration: SenseVoiceDecodingConfiguration = .default,
         whisperKitKeepAliveDuration: TimeInterval = defaultWhisperKitKeepAliveDuration,
         whisperKitTranscriberFactory: @escaping (String, String) -> LocalWhisperKitTranscribing = { modelName, modelFolder in
             WhisperKitTranscriber(modelName: modelName, modelFolder: modelFolder)
@@ -34,6 +36,7 @@ final class LocalModelTranscriber: Transcriber {
     ) {
         self.settingsStore = settingsStore
         self.modelManager = modelManager
+        self.senseVoiceDecodingConfiguration = senseVoiceDecodingConfiguration
         whisperKitKeepAliveDurationWhenMemoryOptimized = whisperKitKeepAliveDuration
         self.whisperKitTranscriberFactory = whisperKitTranscriberFactory
     }
@@ -74,6 +77,7 @@ final class LocalModelTranscriber: Transcriber {
             let transcriber = SenseVoiceTranscriber(
                 modelIdentifier: model,
                 modelFolder: modelInfo.storagePath,
+                decodingConfiguration: senseVoiceDecodingConfiguration,
             )
             return try await transcriber.transcribeStream(audioFile: audioFile, onUpdate: onUpdate)
 

--- a/Sources/Typeflux/STT/SenseVoiceDecodingConfiguration.swift
+++ b/Sources/Typeflux/STT/SenseVoiceDecodingConfiguration.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+struct SenseVoiceDecodingConfiguration: Equatable {
+    enum Language: String, CaseIterable, Equatable {
+        case auto
+        case zh
+        case en
+    }
+
+    enum AudioNormalization: Equatable {
+        case preserveInput
+        case mono16k
+    }
+
+    static let `default` = SenseVoiceDecodingConfiguration()
+
+    var language: Language = .auto
+    var useITN: Bool = true
+    var audioNormalization: AudioNormalization = .preserveInput
+}

--- a/Sources/Typeflux/STT/SenseVoiceTranscriber.swift
+++ b/Sources/Typeflux/STT/SenseVoiceTranscriber.swift
@@ -6,12 +6,14 @@ final class SenseVoiceTranscriber: Transcriber {
     init(
         modelIdentifier: String,
         modelFolder: String,
+        decodingConfiguration: SenseVoiceDecodingConfiguration = .default,
         processRunner: ProcessCommandRunning = ProcessCommandRunner(),
     ) {
         decoder = SherpaOnnxCommandLineDecoder(
             model: .senseVoiceSmall,
             modelIdentifier: modelIdentifier,
             modelFolder: modelFolder,
+            senseVoiceDecodingConfiguration: decodingConfiguration,
             processRunner: processRunner,
         )
     }

--- a/Sources/Typeflux/STT/SherpaOnnxSupport.swift
+++ b/Sources/Typeflux/STT/SherpaOnnxSupport.swift
@@ -573,17 +573,20 @@ final class SherpaOnnxCommandLineDecoder {
     private let model: LocalSTTModel
     private let modelIdentifier: String
     private let modelFolder: String
+    private let senseVoiceDecodingConfiguration: SenseVoiceDecodingConfiguration
     private let processRunner: ProcessCommandRunning
 
     init(
         model: LocalSTTModel,
         modelIdentifier: String,
         modelFolder: String,
+        senseVoiceDecodingConfiguration: SenseVoiceDecodingConfiguration = .default,
         processRunner: ProcessCommandRunning = ProcessCommandRunner(),
     ) {
         self.model = model
         self.modelIdentifier = modelIdentifier
         self.modelFolder = modelFolder
+        self.senseVoiceDecodingConfiguration = senseVoiceDecodingConfiguration
         self.processRunner = processRunner
     }
 
@@ -614,7 +617,7 @@ final class SherpaOnnxCommandLineDecoder {
             )
         }
 
-        let wavURL = try AudioFileTranscoder.wavFileURL(for: audioFile)
+        let wavURL = try wavFileURL(for: audioFile)
         let arguments = try commandLineArguments(layout: layout, storageURL: storageURL, audioURL: wavURL)
         let result = try await processRunner.run(
             executablePath: executableURL.path,
@@ -626,6 +629,20 @@ final class SherpaOnnxCommandLineDecoder {
         )
 
         return try parseTranscript(stdout: result.stdout)
+    }
+
+    private func wavFileURL(for audioFile: AudioFile) throws -> URL {
+        guard model == .senseVoiceSmall,
+              senseVoiceDecodingConfiguration.audioNormalization == .mono16k
+        else {
+            return try AudioFileTranscoder.wavFileURL(for: audioFile)
+        }
+
+        return try AudioFileTranscoder.wavFileURL(
+            for: audioFile,
+            outputFormat: .mono16k,
+            forceTranscode: true,
+        )
     }
 
     func commandLineArguments(
@@ -646,8 +663,8 @@ final class SherpaOnnxCommandLineDecoder {
                 "--print-args=false",
                 "--tokens=\(modelDirectory.appendingPathComponent("tokens.txt").path)",
                 "--sense-voice-model=\(modelDirectory.appendingPathComponent("model.int8.onnx").path)",
-                "--sense-voice-language=auto",
-                "--sense-voice-use-itn=true",
+                "--sense-voice-language=\(senseVoiceDecodingConfiguration.language.rawValue)",
+                "--sense-voice-use-itn=\(senseVoiceDecodingConfiguration.useITN ? "true" : "false")",
                 "--provider=cpu",
                 audioURL.path,
             ]
@@ -691,10 +708,10 @@ final class SherpaOnnxCommandLineDecoder {
         }
 
         if let jsonTranscript = parseJSONTranscript(stdoutLine: transcript) {
-            return jsonTranscript
+            return cleanedTranscript(jsonTranscript)
         }
 
-        return transcript
+        return cleanedTranscript(transcript)
     }
 
     func parseJSONTranscript(stdoutLine: String) -> String? {
@@ -707,5 +724,17 @@ final class SherpaOnnxCommandLineDecoder {
         }
 
         return text
+    }
+
+    private func cleanedTranscript(_ transcript: String) -> String {
+        transcript
+            .replacingOccurrences(
+                of: #"<\|[^|]+?\|>"#,
+                with: "",
+                options: .regularExpression,
+            )
+            .components(separatedBy: .whitespacesAndNewlines)
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
     }
 }

--- a/Tests/TypefluxTests/LocalModelTranscriberTests.swift
+++ b/Tests/TypefluxTests/LocalModelTranscriberTests.swift
@@ -1,4 +1,5 @@
 @testable import Typeflux
+import AVFoundation
 import WhisperKit
 import XCTest
 
@@ -59,6 +60,54 @@ final class LocalModelTranscriberTests: XCTestCase {
         _ = try await transcriber.transcribe(audioFile: makeTestWAVFile())
 
         XCTAssertTrue(runner.lastArguments.contains("--sense-voice-language=auto"))
+    }
+
+    func testSenseVoiceTranscriberUsesExplicitLanguageAndITNConfiguration() async throws {
+        let modelFolder = try makeSherpaModelFolder(for: .senseVoiceSmall)
+        let runner = CapturingProcessRunner(stdout: "<|en|><|NEUTRAL|><|Speech|><|woitn|> hello Typeflux \n")
+        let transcriber = SenseVoiceTranscriber(
+            modelIdentifier: LocalSTTModel.senseVoiceSmall.defaultModelIdentifier,
+            modelFolder: modelFolder.path,
+            decodingConfiguration: SenseVoiceDecodingConfiguration(
+                language: .en,
+                useITN: false,
+                audioNormalization: .preserveInput,
+            ),
+            processRunner: runner,
+        )
+
+        let text = try await transcriber.transcribe(audioFile: makeTestWAVFile())
+
+        XCTAssertEqual(text, "hello Typeflux")
+        XCTAssertTrue(runner.lastArguments.contains("--sense-voice-language=en"))
+        XCTAssertTrue(runner.lastArguments.contains("--sense-voice-use-itn=false"))
+    }
+
+    func testSenseVoiceTranscriberNormalizesInputTo16kMonoWhenConfigured() async throws {
+        let modelFolder = try makeSherpaModelFolder(for: .senseVoiceSmall)
+        let runner = CapturingProcessRunner(stdout: "normalized\n")
+        let transcriber = SenseVoiceTranscriber(
+            modelIdentifier: LocalSTTModel.senseVoiceSmall.defaultModelIdentifier,
+            modelFolder: modelFolder.path,
+            decodingConfiguration: SenseVoiceDecodingConfiguration(
+                language: .zh,
+                useITN: true,
+                audioNormalization: .mono16k,
+            ),
+            processRunner: runner,
+        )
+        let audioFile = try makeValidTestWAVFile(sampleRate: 44_100)
+
+        _ = try await transcriber.transcribe(audioFile: audioFile)
+
+        let normalizedURL = URL(fileURLWithPath: try XCTUnwrap(runner.lastArguments.last))
+        XCTAssertNotEqual(normalizedURL.path, audioFile.fileURL.path)
+        XCTAssertEqual(normalizedURL.pathExtension.lowercased(), "wav")
+        let normalizedFile = try AVAudioFile(forReading: normalizedURL)
+        XCTAssertEqual(normalizedFile.processingFormat.sampleRate, 16_000, accuracy: 0.1)
+        XCTAssertEqual(normalizedFile.processingFormat.channelCount, 1)
+        XCTAssertTrue(runner.lastArguments.contains("--sense-voice-language=zh"))
+        XCTAssertTrue(runner.lastArguments.contains("--sense-voice-use-itn=true"))
     }
 
     func testQwen3ASRTranscriberUsesQwen3ModelArguments() async throws {
@@ -1017,6 +1066,14 @@ final class LocalModelTranscriberTests: XCTestCase {
             .appendingPathExtension("wav")
         try Data().write(to: fileURL)
         return AudioFile(fileURL: fileURL, duration: 1)
+    }
+
+    private func makeValidTestWAVFile(sampleRate: Int) throws -> AudioFile {
+        let fileURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("typeflux-tests-\(UUID().uuidString)", isDirectory: false)
+            .appendingPathExtension("wav")
+        try RemoteSTTTestAudio.wavSilence(sampleRate: sampleRate, durationMs: 100).write(to: fileURL)
+        return AudioFile(fileURL: fileURL, duration: 0.1)
     }
 
     private func makeDownloadedFileFixtures(

--- a/scripts/local_asr_benchmark.py
+++ b/scripts/local_asr_benchmark.py
@@ -197,7 +197,28 @@ def make_input_directory(samples: list[Sample], target: Path) -> dict[str, Sampl
     return mapping
 
 
-def run_typeflux_batch(model: str, input_dir: Path, output_csv: Path, package_path: Path, typeflux_bin: str | None) -> tuple[int, str]:
+@dataclass(frozen=True)
+class SenseVoiceOptions:
+    language: str = "auto"
+    use_itn: bool = True
+    normalize_16k_mono: bool = False
+
+    def as_report_dict(self) -> dict[str, Any]:
+        return {
+            "language": self.language,
+            "useITN": self.use_itn,
+            "normalize16kMono": self.normalize_16k_mono,
+        }
+
+
+def run_typeflux_batch(
+    model: str,
+    input_dir: Path,
+    output_csv: Path,
+    package_path: Path,
+    typeflux_bin: str | None,
+    sense_voice_options: SenseVoiceOptions,
+) -> tuple[int, str]:
     if typeflux_bin:
         command = [typeflux_bin, "batch-wav"]
     else:
@@ -214,6 +235,12 @@ def run_typeflux_batch(model: str, input_dir: Path, output_csv: Path, package_pa
         model,
         "--no-persona",
     ]
+    if model == "senseVoiceSmall":
+        command += ["--sense-voice-language", sense_voice_options.language]
+        if not sense_voice_options.use_itn:
+            command.append("--sense-voice-no-itn")
+        if sense_voice_options.normalize_16k_mono:
+            command.append("--sense-voice-normalize-16k-mono")
 
     suite = f"ai.gulu.app.typeflux.local-asr-benchmark.{os.getpid()}.{model}"
     env = os.environ.copy()
@@ -280,6 +307,7 @@ def benchmark_model(
     package_path: Path,
     typeflux_bin: str | None,
     models_root: Path,
+    sense_voice_options: SenseVoiceOptions,
 ) -> dict[str, Any]:
     identifier, storage_path, missing_assets = model_storage_info(model, models_root)
     base = {
@@ -289,6 +317,8 @@ def benchmark_model(
         "storagePath": str(storage_path) if storage_path else None,
         "footprintBytes": directory_size_bytes(storage_path),
     }
+    if model == "senseVoiceSmall":
+        base["senseVoiceOptions"] = sense_voice_options.as_report_dict()
     if missing_assets:
         return {
             **base,
@@ -310,7 +340,14 @@ def benchmark_model(
     input_mapping = make_input_directory(samples, input_dir)
 
     started = time.monotonic()
-    exit_code, command_output = run_typeflux_batch(model, input_dir, output_csv, package_path, typeflux_bin)
+    exit_code, command_output = run_typeflux_batch(
+        model,
+        input_dir,
+        output_csv,
+        package_path,
+        typeflux_bin,
+        sense_voice_options,
+    )
     elapsed_ms = int((time.monotonic() - started) * 1000)
     rows = read_batch_csv(output_csv)
 
@@ -438,6 +475,9 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--package-path", type=Path, default=REPO_ROOT)
     parser.add_argument("--typeflux-bin", default=None, help="Optional prebuilt Typeflux executable path.")
     parser.add_argument("--models", nargs="+", default=["senseVoiceSmall", "qwen3ASR", "whisperLocal"])
+    parser.add_argument("--sense-voice-language", choices=["auto", "zh", "en"], default="auto")
+    parser.add_argument("--sense-voice-no-itn", action="store_true")
+    parser.add_argument("--sense-voice-normalize-16k-mono", action="store_true")
     parser.add_argument("--keep-work", action="store_true")
     parser.add_argument("--self-test", action="store_true")
     return parser.parse_args()
@@ -454,11 +494,24 @@ def main() -> int:
 
     samples = load_manifest(args.manifest, args.audio_root)
     args.output_dir.mkdir(parents=True, exist_ok=True)
+    sense_voice_options = SenseVoiceOptions(
+        language=args.sense_voice_language,
+        use_itn=not args.sense_voice_no_itn,
+        normalize_16k_mono=args.sense_voice_normalize_16k_mono,
+    )
 
     work_parent = Path(tempfile.mkdtemp(prefix="typeflux-local-asr-benchmark-"))
     try:
         models = [
-            benchmark_model(model, samples, work_parent, args.package_path, args.typeflux_bin, args.models_root)
+            benchmark_model(
+                model,
+                samples,
+                work_parent,
+                args.package_path,
+                args.typeflux_bin,
+                args.models_root,
+                sense_voice_options,
+            )
             for model in args.models
         ]
         report = {


### PR DESCRIPTION
## Summary
- Add typed SenseVoice decoding configuration for local sherpa-onnx experiments: language, ITN, and optional 16 kHz mono normalization.
- Thread the configuration through the local SenseVoice decoder and batch CLI while preserving existing defaults.
- Add conservative SenseVoice marker/whitespace cleanup and benchmark pass-through/report metadata for experiment runs.

## How to test
- `swift test --filter TypefluxTests.LocalModelTranscriberTests`
- `python3 scripts/local_asr_benchmark.py --self-test`

References TYP-51.
