### PR TITLE
feat(overlay): 增大录音胶囊波形振动幅度

### DIFF
--- a/Sources/Typeflux/Overlay/OverlayController.swift
+++ b/Sources/Typeflux/Overlay/OverlayController.swift
@@ -2170,18 +2170,15 @@ private struct LevelWaveform: View {
 
     var body: some View {
         HStack(alignment: .center, spacing: 2.2) {
-            ForEach(0 ..< 9, id: \.self) { index in
+            ForEach(0 ..< OverlayWaveformMetrics.barCount, id: \.self) { index in
                 RoundedRectangle(cornerRadius: 2, style: .continuous)
                     .fill(activeColor)
-                    .frame(width: 2.3, height: barHeight(for: index))
+                    .frame(
+                        width: 2.3,
+                        height: OverlayWaveformMetrics.barHeight(for: index, level: level),
+                    )
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
-    }
-
-    private func barHeight(for index: Int) -> CGFloat {
-        let normalizedLevel = CGFloat(max(0.08, min(1.0, level)))
-        let profile: [CGFloat] = [0.34, 0.52, 0.72, 0.9, 1.0, 0.86, 0.7, 0.5, 0.32]
-        return 4.5 + (10.8 * normalizedLevel * profile[index])
     }
 }

--- a/Sources/Typeflux/Overlay/OverlayWaveformMetrics.swift
+++ b/Sources/Typeflux/Overlay/OverlayWaveformMetrics.swift
@@ -1,0 +1,19 @@
+import CoreGraphics
+
+enum OverlayWaveformMetrics {
+    static let barCount = 9
+
+    private static let minimumResponsiveLevel: CGFloat = 0.06
+    private static let responseCurveExponent: CGFloat = 0.58
+    private static let baseBarHeight: CGFloat = 3.8
+    private static let dynamicBarHeight: CGFloat = 11.2
+    private static let profile: [CGFloat] = [0.34, 0.52, 0.72, 0.9, 1.0, 0.86, 0.7, 0.5, 0.32]
+
+    static func barHeight(for index: Int, level: Float) -> CGFloat {
+        guard profile.indices.contains(index) else { return baseBarHeight }
+
+        let clampedLevel = max(0, min(1.0, CGFloat(level)))
+        let responsiveLevel = max(minimumResponsiveLevel, pow(clampedLevel, responseCurveExponent))
+        return baseBarHeight + (dynamicBarHeight * responsiveLevel * profile[index])
+    }
+}

--- a/Tests/TypefluxTests/OverlayWaveformMetricsTests.swift
+++ b/Tests/TypefluxTests/OverlayWaveformMetricsTests.swift
@@ -1,0 +1,27 @@
+@testable import Typeflux
+import XCTest
+
+final class OverlayWaveformMetricsTests: XCTestCase {
+    func testSpeakingLevelsProduceNoticeablyTallerCenterBar() {
+        let quietHeight = OverlayWaveformMetrics.barHeight(for: 4, level: 0)
+        let speakingHeight = OverlayWaveformMetrics.barHeight(for: 4, level: 0.2)
+
+        XCTAssertGreaterThan(speakingHeight - quietHeight, 3.5)
+    }
+
+    func testLevelsClampToCapsuleWaveformBounds() {
+        let minimumHeight = OverlayWaveformMetrics.barHeight(for: 4, level: -1)
+        let zeroHeight = OverlayWaveformMetrics.barHeight(for: 4, level: 0)
+        let maximumHeight = OverlayWaveformMetrics.barHeight(for: 4, level: 2)
+
+        XCTAssertEqual(minimumHeight, zeroHeight, accuracy: 0.001)
+        XCTAssertEqual(maximumHeight, 15.0, accuracy: 0.001)
+    }
+
+    func testProfileKeepsOuterBarsShorterThanCenter() {
+        let centerHeight = OverlayWaveformMetrics.barHeight(for: 4, level: 0.6)
+        let outerHeight = OverlayWaveformMetrics.barHeight(for: 8, level: 0.6)
+
+        XCTAssertLessThan(outerHeight, centerHeight)
+    }
+}


### PR DESCRIPTION
## 摘要

优化录音状态下胶囊波形的变化幅度，使其对低音量语音输入更加灵敏。

## 变更内容

- 新增 `OverlayWaveformMetrics.swift`：将波形高度计算提取为可测试的独立组件
- 引入非线性响应曲线 `pow(level, 0.58)`（指数 < 1），显著放大低电平输入时的波形幅度
- 微调基础高度（4.5 → 3.8）和动态范围（10.8 → 11.2），增强静音/有声对比度
- `OverlayController.swift`：改用 `OverlayWaveformMetrics` 计算 bar 高度
- 新增 `OverlayWaveformMetricsTests.swift`：3 个单元测试覆盖灵敏度、边界 clamp 和 profile 形状

## 效果对比

| 场景 | 旧实现 | 新实现 |
|------|--------|--------|
| 小声说话 (level=0.2) | 6.66pt | 8.06pt (+21%) |
| 完全静音 (level=0) | 5.36pt | 4.47pt（更低基线） |
| 大声说话 (level=1.0) | 15.3pt | 15.0pt（基本持平） |

## 静默行为

通过 `minimumResponsiveLevel = 0.06` 设置了死区阈值：level < ~0.02 时波形高度固定不变，不受微小噪声干扰。

## 测试

```bash
swift test --filter TypefluxTests.OverlayWaveformMetricsTests
```

3 tests passed.