### PR TITLE
fix: reduce Typeflux cloud recording startup latency

### DIFF
--- a/Sources/Typeflux/Overlay/OverlayController.swift
+++ b/Sources/Typeflux/Overlay/OverlayController.swift
@@ -80,6 +80,7 @@ private struct LiquidGlassShapeBackground<S: InsettableShape>: View {
 
     var body: some View {
         Group {
+            #if compiler(>=6.2)
             if #available(macOS 26.0, *) {
                 ZStack {
                     shape
@@ -96,18 +97,11 @@ private struct LiquidGlassShapeBackground<S: InsettableShape>: View {
                         .allowsHitTesting(false)
                 }
             } else {
-                ZStack {
-                    RoundedVisualEffectBlur(
-                        material: .popover,
-                        blendingMode: .behindWindow,
-                        cornerRadius: cornerRadius,
-                    )
-                    .allowsHitTesting(false)
-
-                    shape
-                        .fill(Color.black.opacity(tintOpacity))
-                }
+                fallbackBackground
             }
+            #else
+            fallbackBackground
+            #endif
         }
         .overlay(
             shape
@@ -141,6 +135,20 @@ private struct LiquidGlassShapeBackground<S: InsettableShape>: View {
                 )
                 .blendMode(.screen),
         )
+    }
+
+    private var fallbackBackground: some View {
+        ZStack {
+            RoundedVisualEffectBlur(
+                material: .popover,
+                blendingMode: .behindWindow,
+                cornerRadius: cornerRadius,
+            )
+            .allowsHitTesting(false)
+
+            shape
+                .fill(Color.black.opacity(tintOpacity))
+        }
     }
 }
 

--- a/Sources/Typeflux/STT/RealtimeTranscriptionSession.swift
+++ b/Sources/Typeflux/STT/RealtimeTranscriptionSession.swift
@@ -15,6 +15,53 @@ protocol PCM16RealtimeTranscriptionSession: AnyObject {
     func cancel() async
 }
 
+actor DeferredPCM16RealtimeTranscriptionSession: PCM16RealtimeTranscriptionSession {
+    private let makeUpstream: @Sendable () async throws -> any PCM16RealtimeTranscriptionSession
+    private var startingUpstream: (any PCM16RealtimeTranscriptionSession)?
+    private var upstream: (any PCM16RealtimeTranscriptionSession)?
+    private var isCancelled = false
+
+    init(makeUpstream: @escaping @Sendable () async throws -> any PCM16RealtimeTranscriptionSession) {
+        self.makeUpstream = makeUpstream
+    }
+
+    func start() async throws {
+        guard upstream == nil else { return }
+        guard !isCancelled else { throw CancellationError() }
+        let resolved = try await makeUpstream()
+        guard !isCancelled else {
+            await resolved.cancel()
+            throw CancellationError()
+        }
+        startingUpstream = resolved
+        defer { startingUpstream = nil }
+        try await resolved.start()
+        guard !isCancelled else {
+            await resolved.cancel()
+            throw CancellationError()
+        }
+        upstream = resolved
+    }
+
+    func appendPCM16(_ data: Data) async throws {
+        guard let upstream else { throw CancellationError() }
+        try await upstream.appendPCM16(data)
+    }
+
+    func finish() async throws -> String {
+        guard let upstream else { throw CancellationError() }
+        return try await upstream.finish()
+    }
+
+    func cancel() async {
+        isCancelled = true
+        await startingUpstream?.cancel()
+        startingUpstream = nil
+        await upstream?.cancel()
+        upstream = nil
+    }
+}
+
 final class RealtimeAudioBufferPump {
     private let continuation: AsyncStream<AVAudioPCMBuffer>.Continuation
     private let task: Task<Void, Never>

--- a/Sources/Typeflux/STT/TypefluxOfficialTranscriber.swift
+++ b/Sources/Typeflux/STT/TypefluxOfficialTranscriber.swift
@@ -173,35 +173,36 @@ final class TypefluxOfficialTranscriber: TypefluxCloudScenarioAwareTranscriber, 
         scenario: TypefluxCloudScenario,
         onUpdate: @escaping @Sendable (TranscriptionSnapshot) async -> Void,
     ) async throws -> any RealtimeTranscriptionSession {
-        let token = await accessTokenProvider()
-        guard let token, !token.isEmpty else {
-            throw TypefluxOfficialASRError.notLoggedIn
-        }
-
-        let route = try await routingClient.fetchRoute(accessToken: token, scenario: scenario)
-        if case .aliyun(let aliyunToken, _, let usageReportID) = route {
-            let upstream = TypefluxOfficialAliyunUsageReportingPCMStream(
-                upstream: transport.makeDirectAliyunPCMStream(token: aliyunToken, onUpdate: onUpdate),
-                accessToken: token,
-                usageReportID: usageReportID,
-                scenario: scenario,
-                routingClient: routingClient,
-            )
-            return BufferedRealtimeTranscriptionSession(upstream: upstream)
-        }
-
-        let baseURLs = await Self.realtimeCandidateBaseURLs()
-        guard let baseURL = baseURLs.first else {
-            throw TypefluxOfficialASRError.connectionFailed("No Typeflux Cloud endpoint configured.")
-        }
-
         return BufferedRealtimeTranscriptionSession(
-            upstream: TypefluxOfficialRealtimePCMStream(
-                apiBaseURL: baseURL.absoluteString,
-                token: token,
-                scenario: scenario,
-                onUpdate: onUpdate,
-            ),
+            upstream: DeferredPCM16RealtimeTranscriptionSession { [accessTokenProvider, routingClient, transport] in
+                let token = await accessTokenProvider()
+                guard let token, !token.isEmpty else {
+                    throw TypefluxOfficialASRError.notLoggedIn
+                }
+
+                let route = try await routingClient.fetchRoute(accessToken: token, scenario: scenario)
+                if case .aliyun(let aliyunToken, _, let usageReportID) = route {
+                    return TypefluxOfficialAliyunUsageReportingPCMStream(
+                        upstream: transport.makeDirectAliyunPCMStream(token: aliyunToken, onUpdate: onUpdate),
+                        accessToken: token,
+                        usageReportID: usageReportID,
+                        scenario: scenario,
+                        routingClient: routingClient,
+                    )
+                }
+
+                let baseURLs = await Self.realtimeCandidateBaseURLs()
+                guard let baseURL = baseURLs.first else {
+                    throw TypefluxOfficialASRError.connectionFailed("No Typeflux Cloud endpoint configured.")
+                }
+
+                return TypefluxOfficialRealtimePCMStream(
+                    apiBaseURL: baseURL.absoluteString,
+                    token: token,
+                    scenario: scenario,
+                    onUpdate: onUpdate,
+                )
+            },
         )
     }
 

--- a/Tests/TypefluxTests/RealtimeTranscriptionSessionTests.swift
+++ b/Tests/TypefluxTests/RealtimeTranscriptionSessionTests.swift
@@ -65,6 +65,37 @@ final class RealtimeTranscriptionSessionTests: XCTestCase {
         }
     }
 
+    func testDeferredPCM16SessionResolvesUpstreamOnStart() async throws {
+        let upstream = DelayedStartPCMStream(finalText: "deferred")
+        let factory = DelayedPCMStreamFactory(upstream: upstream)
+        let session = DeferredPCM16RealtimeTranscriptionSession {
+            await factory.makeUpstream()
+        }
+
+        let startTask = Task {
+            try await session.start()
+        }
+        await factory.waitUntilRequested()
+        let requestCountBeforeRelease = await factory.requestCount()
+        let startCountBeforeRelease = await upstream.startCallCount()
+        XCTAssertEqual(requestCountBeforeRelease, 1)
+        XCTAssertEqual(startCountBeforeRelease, 0)
+
+        await factory.release()
+        await upstream.waitUntilStartCalled()
+        await upstream.releaseStart()
+        try await startTask.value
+
+        try await session.appendPCM16(Data([1, 2, 3]))
+        let finalText = try await session.finish()
+
+        let startCountAfterFinish = await upstream.startCallCount()
+        let sentByteCount = await upstream.sentByteCount()
+        XCTAssertEqual(finalText, "deferred")
+        XCTAssertEqual(startCountAfterFinish, 1)
+        XCTAssertEqual(sentByteCount, 3)
+    }
+
     private func makeFloatBuffer(frameCount: AVAudioFrameCount) throws -> AVAudioPCMBuffer {
         let format = AVAudioFormat(
             commonFormat: .pcmFormatFloat32,
@@ -85,13 +116,18 @@ final class RealtimeTranscriptionSessionTests: XCTestCase {
 private actor DelayedStartPCMStream: PCM16RealtimeTranscriptionSession {
     private let finalText: String
     private var startContinuation: CheckedContinuation<Void, Never>?
+    private var startRequestedContinuation: CheckedContinuation<Void, Never>?
     private var chunks: [Data] = []
+    private var starts = 0
 
     init(finalText: String) {
         self.finalText = finalText
     }
 
     func start() async throws {
+        starts += 1
+        startRequestedContinuation?.resume()
+        startRequestedContinuation = nil
         await withCheckedContinuation { continuation in
             startContinuation = continuation
         }
@@ -122,6 +158,17 @@ private actor DelayedStartPCMStream: PCM16RealtimeTranscriptionSession {
     func sentByteCount() -> Int {
         chunks.reduce(0) { $0 + $1.count }
     }
+
+    func startCallCount() -> Int {
+        starts
+    }
+
+    func waitUntilStartCalled() async {
+        if starts > 0 { return }
+        await withCheckedContinuation { continuation in
+            startRequestedContinuation = continuation
+        }
+    }
 }
 
 private actor FailingStartPCMStream: PCM16RealtimeTranscriptionSession {
@@ -136,4 +183,41 @@ private actor FailingStartPCMStream: PCM16RealtimeTranscriptionSession {
     }
 
     func cancel() async {}
+}
+
+private actor DelayedPCMStreamFactory {
+    private let upstream: any PCM16RealtimeTranscriptionSession
+    private var requestContinuation: CheckedContinuation<Void, Never>?
+    private var releaseContinuation: CheckedContinuation<Void, Never>?
+    private var requests = 0
+
+    init(upstream: any PCM16RealtimeTranscriptionSession) {
+        self.upstream = upstream
+    }
+
+    func makeUpstream() async -> any PCM16RealtimeTranscriptionSession {
+        requests += 1
+        requestContinuation?.resume()
+        requestContinuation = nil
+        await withCheckedContinuation { continuation in
+            releaseContinuation = continuation
+        }
+        return upstream
+    }
+
+    func waitUntilRequested() async {
+        if requests > 0 { return }
+        await withCheckedContinuation { continuation in
+            requestContinuation = continuation
+        }
+    }
+
+    func release() {
+        releaseContinuation?.resume()
+        releaseContinuation = nil
+    }
+
+    func requestCount() -> Int {
+        requests
+    }
 }

--- a/Tests/TypefluxTests/TypefluxOfficialASRRoutingClientTests.swift
+++ b/Tests/TypefluxTests/TypefluxOfficialASRRoutingClientTests.swift
@@ -1,3 +1,4 @@
+import AVFoundation
 @testable import Typeflux
 import XCTest
 
@@ -150,6 +151,60 @@ final class TypefluxOfficialTranscriberRoutingTests: XCTestCase {
         XCTAssertNil(report)
     }
 
+    func testRealtimeSessionCreationDoesNotWaitForRouteFetch() async throws {
+        let routing = DelayedTypefluxRoutingClient()
+        let stream = RecordingPCM16RealtimeTranscriptionSession(finalText: "realtime")
+        let transport = MockTypefluxTransport()
+        transport.directPCMStreamFactory = { stream }
+        let transcriber = TypefluxOfficialTranscriber(
+            routingClient: routing,
+            transport: transport,
+            accessTokenProvider: { "cloud-token" }
+        )
+
+        let session = try await transcriber.makeRealtimeTranscriptionSession(
+            scenario: .voiceInput,
+            onUpdate: { _ in }
+        )
+
+        await session.start()
+        await routing.waitUntilFetchStarted()
+        let startCountBeforeRoute = await stream.startCallCount()
+        XCTAssertEqual(startCountBeforeRoute, 0)
+
+        let buffer = try makeFloatBuffer(frameCount: 1_600)
+        await session.append(buffer)
+        await routing.release(route: .aliyun(
+            token: "st-temp",
+            expiresAt: nil,
+            usageReportID: "report-1"
+        ))
+
+        let transcript = try await session.finish()
+
+        let startCountAfterFinish = await stream.startCallCount()
+        let sentByteCount = await stream.sentByteCount()
+        XCTAssertEqual(transcript, "realtime")
+        XCTAssertEqual(startCountAfterFinish, 1)
+        XCTAssertEqual(sentByteCount, CloudASRAudioConverter.chunkSize)
+    }
+
+    private func makeFloatBuffer(frameCount: AVAudioFrameCount) throws -> AVAudioPCMBuffer {
+        let format = AVAudioFormat(
+            commonFormat: .pcmFormatFloat32,
+            sampleRate: CloudASRAudioConverter.targetSampleRate,
+            channels: 1,
+            interleaved: false,
+        )!
+        let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: frameCount)!
+        buffer.frameLength = frameCount
+        let channel = buffer.floatChannelData![0]
+        for index in 0 ..< Int(frameCount) {
+            channel[index] = sinf(Float(index) / 20.0) * 0.2
+        }
+        return buffer
+    }
+
     private func makeSilentAudioFile(duration: TimeInterval) throws -> AudioFile {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent("typeflux-routing-\(UUID().uuidString).wav")
@@ -265,6 +320,44 @@ private actor MockTypefluxRoutingClient: TypefluxOfficialASRRoutingClient {
     }
 }
 
+private actor DelayedTypefluxRoutingClient: TypefluxOfficialASRRoutingClient {
+    private var fetchStartedContinuation: CheckedContinuation<Void, Never>?
+    private var routeContinuation: CheckedContinuation<TypefluxOfficialASRRouteDecision, Never>?
+    private var didStartFetch = false
+
+    func fetchRoute(
+        accessToken _: String,
+        scenario _: TypefluxCloudScenario
+    ) async throws -> TypefluxOfficialASRRouteDecision {
+        didStartFetch = true
+        fetchStartedContinuation?.resume()
+        fetchStartedContinuation = nil
+        return await withCheckedContinuation { continuation in
+            routeContinuation = continuation
+        }
+    }
+
+    func reportAliyunUsage(
+        accessToken _: String,
+        usageReportID _: String,
+        audioDurationMs _: Int64,
+        outputChars _: Int,
+        scenario _: TypefluxCloudScenario
+    ) async throws {}
+
+    func waitUntilFetchStarted() async {
+        if didStartFetch { return }
+        await withCheckedContinuation { continuation in
+            fetchStartedContinuation = continuation
+        }
+    }
+
+    func release(route: TypefluxOfficialASRRouteDecision) {
+        routeContinuation?.resume(returning: route)
+        routeContinuation = nil
+    }
+}
+
 private final class MockTypefluxTransport: TypefluxOfficialASRTransport, @unchecked Sendable {
     var directTranscript = "direct"
     var webSocketTranscript = "websocket"
@@ -273,6 +366,9 @@ private final class MockTypefluxTransport: TypefluxOfficialASRTransport, @unchec
     var webSocketCallCount = 0
     var webSocketLLMCallCount = 0
     var lastDirectAliyunToken: String?
+    var directPCMStreamFactory: @Sendable () -> any PCM16RealtimeTranscriptionSession = {
+        MockPCM16RealtimeTranscriptionSession()
+    }
 
     func transcribeViaWebSocket(
         pcmData _: Data,
@@ -310,10 +406,11 @@ private final class MockTypefluxTransport: TypefluxOfficialASRTransport, @unchec
     }
 
     func makeDirectAliyunPCMStream(
-        token _: String,
+        token: String,
         onUpdate _: @escaping @Sendable (TranscriptionSnapshot) async -> Void
     ) -> any PCM16RealtimeTranscriptionSession {
-        MockPCM16RealtimeTranscriptionSession()
+        lastDirectAliyunToken = token
+        return directPCMStreamFactory()
     }
 }
 
@@ -322,4 +419,36 @@ private actor MockPCM16RealtimeTranscriptionSession: PCM16RealtimeTranscriptionS
     func appendPCM16(_: Data) async throws {}
     func finish() async throws -> String { "realtime" }
     func cancel() async {}
+}
+
+private actor RecordingPCM16RealtimeTranscriptionSession: PCM16RealtimeTranscriptionSession {
+    private let finalText: String
+    private var starts = 0
+    private var chunks: [Data] = []
+
+    init(finalText: String) {
+        self.finalText = finalText
+    }
+
+    func start() async throws {
+        starts += 1
+    }
+
+    func appendPCM16(_ data: Data) async throws {
+        chunks.append(data)
+    }
+
+    func finish() async throws -> String {
+        finalText
+    }
+
+    func cancel() async {}
+
+    func startCallCount() -> Int {
+        starts
+    }
+
+    func sentByteCount() -> Int {
+        chunks.reduce(0) { $0 + $1.count }
+    }
 }


### PR DESCRIPTION
References TYP-64

## Summary
- Add a deferred PCM16 realtime session wrapper so provider route/token setup can happen after the workflow has a realtime session object.
- Make Typeflux Official realtime startup resolve access token, route decision, and upstream transport inside the session start task instead of before returning from `makeRealtimeTranscriptionSession`.
- Cover deferred startup and Typeflux Official delayed-route buffering with focused unit tests.

## How to test
- `swift test --filter TypefluxTests.RealtimeTranscriptionSessionTests`
- `swift test --filter TypefluxTests.TypefluxOfficialTranscriberRoutingTests`

## Screenshots
- Not applicable; no UI changes.

## Notes
- `make format` could not run locally because `swiftformat` is not installed in this environment.