### PR TITLE
feat: prompt for history export directory

### DIFF
--- a/Sources/Typeflux/Resources/en.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/en.lproj/Localizable.strings
@@ -368,6 +368,9 @@
 "history.privacy.subtitle" = "Voice dictation history is only stored on this Mac. Auto-cleanup removes expired local entries and linked audio files.";
 "history.export.title" = "Export archive";
 "history.export.subtitle" = "Download your history as markdown or clear the current timeline.";
+"history.export.chooseDirectory" = "Choose Export Folder";
+"history.export.chooseDirectoryMessage" = "Typeflux will save the Markdown history archive in this folder.";
+"history.export.chooseDirectoryPrompt" = "Export";
 "history.empty" = "No history entries yet.";
 "history.loadingMore" = "Loading more history...";
 "history.section.today" = "Today";

--- a/Sources/Typeflux/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/zh-Hans.lproj/Localizable.strings
@@ -368,6 +368,9 @@
 "history.privacy.subtitle" = "语音听写历史只保存在这台 Mac 上。自动清理会移除过期本地记录和关联音频文件。";
 "history.export.title" = "导出归档";
 "history.export.subtitle" = "将历史导出为 Markdown，或清空当前时间线。";
+"history.export.chooseDirectory" = "选择导出文件夹";
+"history.export.chooseDirectoryMessage" = "Typeflux 会将 Markdown 历史归档保存到这个文件夹。";
+"history.export.chooseDirectoryPrompt" = "导出";
 "history.empty" = "还没有历史记录。";
 "history.loadingMore" = "正在加载更多历史...";
 "history.section.today" = "今天";

--- a/Sources/Typeflux/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/zh-Hant.lproj/Localizable.strings
@@ -366,6 +366,9 @@
 "history.privacy.subtitle" = "語音聽寫歷史只保存在這台 Mac 上。自動清理會移除過期本地記錄和關聯音訊檔。";
 "history.export.title" = "匯出封存";
 "history.export.subtitle" = "將歷史匯出為 Markdown，或清空目前時間線。";
+"history.export.chooseDirectory" = "選擇匯出資料夾";
+"history.export.chooseDirectoryMessage" = "Typeflux 會將 Markdown 歷史封存儲存到這個資料夾。";
+"history.export.chooseDirectoryPrompt" = "匯出";
 "history.empty" = "還沒有歷史記錄。";
 "history.loadingMore" = "正在載入更多歷史...";
 "history.section.today" = "今天";

--- a/Sources/Typeflux/Settings/HistoryExportDestination.swift
+++ b/Sources/Typeflux/Settings/HistoryExportDestination.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+enum HistoryExportDestination {
+    static func downloadsDirectory(fileManager: FileManager = .default) -> URL {
+        fileManager.urls(for: .downloadsDirectory, in: .userDomainMask).first
+            ?? URL(fileURLWithPath: NSHomeDirectory(), isDirectory: true)
+                .appendingPathComponent("Downloads", isDirectory: true)
+    }
+
+    static func moveExport(
+        at sourceURL: URL,
+        to directoryURL: URL,
+        fileManager: FileManager = .default,
+    ) throws -> URL {
+        let destinationURL = directoryURL.appendingPathComponent(sourceURL.lastPathComponent, isDirectory: false)
+
+        if sourceURL.standardizedFileURL.path == destinationURL.standardizedFileURL.path {
+            return destinationURL
+        }
+
+        if fileManager.fileExists(atPath: destinationURL.path) {
+            try fileManager.removeItem(at: destinationURL)
+        }
+
+        try fileManager.moveItem(at: sourceURL, to: destinationURL)
+        return destinationURL
+    }
+}

--- a/Sources/Typeflux/Settings/SettingsViewModel.swift
+++ b/Sources/Typeflux/Settings/SettingsViewModel.swift
@@ -1931,13 +1931,34 @@ final class StudioViewModel: ObservableObject {
     }
 
     func exportHistory() {
+        guard let destinationDirectoryURL = chooseHistoryExportDirectory() else { return }
+
         do {
-            let url = try historyStore.exportMarkdown()
+            let exportedURL = try historyStore.exportMarkdown()
+            let url = try HistoryExportDestination.moveExport(
+                at: exportedURL,
+                to: destinationDirectoryURL,
+            )
             NSWorkspace.shared.activateFileViewerSelecting([url])
             showToast(L("history.toast.exported"))
         } catch {
             showToast(L("history.toast.exportFailed"))
         }
+    }
+
+    private func chooseHistoryExportDirectory() -> URL? {
+        let panel = NSOpenPanel()
+        panel.title = L("history.export.chooseDirectory")
+        panel.message = L("history.export.chooseDirectoryMessage")
+        panel.prompt = L("history.export.chooseDirectoryPrompt")
+        panel.canChooseFiles = false
+        panel.canChooseDirectories = true
+        panel.allowsMultipleSelection = false
+        panel.canCreateDirectories = true
+        panel.directoryURL = HistoryExportDestination.downloadsDirectory()
+
+        guard panel.runModal() == .OK else { return nil }
+        return panel.url
     }
 
     func clearHistory() {

--- a/Tests/TypefluxTests/HistoryExportDestinationTests.swift
+++ b/Tests/TypefluxTests/HistoryExportDestinationTests.swift
@@ -1,0 +1,68 @@
+import XCTest
+@testable import Typeflux
+
+final class HistoryExportDestinationTests: XCTestCase {
+    private var testDir: URL!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        testDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("HistoryExportDestinationTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: testDir, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        if let testDir {
+            try? FileManager.default.removeItem(at: testDir)
+        }
+        testDir = nil
+        try super.tearDownWithError()
+    }
+
+    func testMoveExportMovesFileIntoSelectedDirectory() throws {
+        let sourceURL = testDir.appendingPathComponent("history-123.md")
+        let destinationDirectoryURL = testDir.appendingPathComponent("exports", isDirectory: true)
+        try FileManager.default.createDirectory(at: destinationDirectoryURL, withIntermediateDirectories: true)
+        try "export body".write(to: sourceURL, atomically: true, encoding: .utf8)
+
+        let destinationURL = try HistoryExportDestination.moveExport(
+            at: sourceURL,
+            to: destinationDirectoryURL,
+        )
+
+        XCTAssertEqual(destinationURL, destinationDirectoryURL.appendingPathComponent("history-123.md"))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: sourceURL.path))
+        XCTAssertEqual(try String(contentsOf: destinationURL, encoding: .utf8), "export body")
+    }
+
+    func testMoveExportReplacesExistingFileInSelectedDirectory() throws {
+        let sourceURL = testDir.appendingPathComponent("history-123.md")
+        let destinationDirectoryURL = testDir.appendingPathComponent("exports", isDirectory: true)
+        let destinationURL = destinationDirectoryURL.appendingPathComponent("history-123.md")
+        try FileManager.default.createDirectory(at: destinationDirectoryURL, withIntermediateDirectories: true)
+        try "old body".write(to: destinationURL, atomically: true, encoding: .utf8)
+        try "new body".write(to: sourceURL, atomically: true, encoding: .utf8)
+
+        let resultURL = try HistoryExportDestination.moveExport(
+            at: sourceURL,
+            to: destinationDirectoryURL,
+        )
+
+        XCTAssertEqual(resultURL, destinationURL)
+        XCTAssertEqual(try String(contentsOf: destinationURL, encoding: .utf8), "new body")
+    }
+
+    func testMoveExportReturnsExistingFileWhenDirectoryAlreadyContainsSource() throws {
+        let sourceURL = testDir.appendingPathComponent("history-123.md")
+        try "export body".write(to: sourceURL, atomically: true, encoding: .utf8)
+
+        let destinationURL = try HistoryExportDestination.moveExport(
+            at: sourceURL,
+            to: testDir,
+        )
+
+        XCTAssertEqual(destinationURL, sourceURL)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: sourceURL.path))
+        XCTAssertEqual(try String(contentsOf: destinationURL, encoding: .utf8), "export body")
+    }
+}


### PR DESCRIPTION
References TYP-65

## Summary
- Adds a folder picker before exporting history, defaulting to the user Downloads directory.
- Moves the generated Markdown archive into the selected folder and reveals it in Finder.
- Adds localized picker text and focused unit coverage for export file placement/replacement.

## How to test
- swift test --filter TypefluxTests.HistoryExportDestinationTests

## Screenshots
- Not applicable; native macOS folder picker behavior.