### PR TITLE
feat(updater): auto-download updates before prompting, add safe install & signature verification

### DIFF
--- a/Sources/Typeflux/App/AutoUpdater.swift
+++ b/Sources/Typeflux/App/AutoUpdater.swift
@@ -23,7 +23,8 @@ final class AutoUpdater {
 
     private static let autoCheckInterval: TimeInterval = 3 * 3600
 
-    private var websiteURL: URL { URL(string: AppServerConfiguration.apiBaseURL)! }
+    private var websiteURL: URL? { URL(string: AppServerConfiguration.apiBaseURL) }
+    private var initialAutoCheckWorkItem: DispatchWorkItem?
     private var autoCheckTimer: Timer?
     private weak var settingsStore: SettingsStore?
 
@@ -42,10 +43,12 @@ final class AutoUpdater {
         guard settingsStore.autoUpdateEnabled else { return }
 
         // Initial check after a short delay on app launch
-        DispatchQueue.main.asyncAfter(deadline: .now() + 10) { [weak self] in
+        let initialCheck = DispatchWorkItem { [weak self] in
             guard self?.settingsStore?.autoUpdateEnabled == true else { return }
             self?.checkForUpdates(manual: false)
         }
+        initialAutoCheckWorkItem = initialCheck
+        DispatchQueue.main.asyncAfter(deadline: .now() + 10, execute: initialCheck)
 
         autoCheckTimer = Timer.scheduledTimer(withTimeInterval: Self.autoCheckInterval, repeats: true) { [weak self] _ in
             Task { @MainActor [weak self] in
@@ -56,6 +59,8 @@ final class AutoUpdater {
     }
 
     func stopAutoCheck() {
+        initialAutoCheckWorkItem?.cancel()
+        initialAutoCheckWorkItem = nil
         autoCheckTimer?.invalidate()
         autoCheckTimer = nil
     }
@@ -94,7 +99,7 @@ final class AutoUpdater {
                 }
 
                 if info.shouldUpdate {
-                    self.promptUpdate(info: info, manual: manual)
+                    self.prepareUpdate(info: info, manual: manual)
                 } else if manual {
                     self.showUpToDateAlert()
                 }
@@ -108,13 +113,46 @@ final class AutoUpdater {
 
     // MARK: - Download & Install
 
-    private func promptUpdate(info: UpdateInfo, manual: Bool) {
+    private func prepareUpdate(info: UpdateInfo, manual: Bool) {
         // For auto-checks, skip if the user already dismissed this version in the current session
         if !manual, dismissedVersion == info.latestVersion { return }
 
         // Avoid stacking multiple alert windows
         guard updateAlertWindowController == nil else { return }
 
+        guard let downloadURLString = info.downloadURL, !downloadURLString.isEmpty else {
+            promptUpdate(info: info, downloadedArchiveURL: nil, sourceURL: nil)
+            return
+        }
+
+        Task { [weak self] in
+            await self?.downloadAndPrompt(info: info, downloadURLString: downloadURLString, manual: manual)
+        }
+    }
+
+    private func downloadAndPrompt(info: UpdateInfo, downloadURLString: String, manual: Bool) async {
+        guard state == .idle else { return }
+        guard let downloadURL = URL(string: downloadURLString) else {
+            if manual { showCheckFailedAlert(message: L("updater.checkFailed.noData")) }
+            return
+        }
+
+        state = .downloading
+        do {
+            let tempFileURL = try await Self.downloadUpdate(from: downloadURL)
+            state = .idle
+            promptUpdate(info: info, downloadedArchiveURL: tempFileURL, sourceURL: downloadURL)
+        } catch {
+            state = .idle
+            if manual { showCheckFailedAlert(message: error.localizedDescription) }
+        }
+    }
+
+    private func promptUpdate(
+        info: UpdateInfo,
+        downloadedArchiveURL: URL?,
+        sourceURL: URL?
+    ) {
         let appearanceMode = settingsStore?.appearanceMode ?? .system
         let controller = UpdateAlertWindowController(
             version: info.latestVersion,
@@ -127,12 +165,23 @@ final class AutoUpdater {
             _ = controller  // silence unused-capture warning
             switch action {
             case .update:
-                if let urlString = info.downloadURL, !urlString.isEmpty {
-                    Task { await self?.downloadAndInstall(info: info, downloadURLString: urlString, relaunch: true) }
-                } else if let self {
-                    NSWorkspace.shared.open(self.websiteURL)
+                if let downloadedArchiveURL, let sourceURL {
+                    Task {
+                        await self?.installDownloadedUpdate(
+                            archiveURL: downloadedArchiveURL,
+                            sourceURL: sourceURL,
+                            relaunch: true
+                        )
+                    }
+                } else if let url = self?.websiteURL {
+                    NSWorkspace.shared.open(url)
+                } else {
+                    self?.showCheckFailedAlert(message: L("updater.checkFailed.noData"))
                 }
             case .skip:
+                if let downloadedArchiveURL {
+                    try? FileManager.default.removeItem(at: downloadedArchiveURL)
+                }
                 self?.dismissedVersion = info.latestVersion
             }
         }
@@ -140,22 +189,13 @@ final class AutoUpdater {
         controller.show()
     }
 
-    private func downloadAndInstall(info: UpdateInfo, downloadURLString: String, relaunch: Bool) async {
+    private func installDownloadedUpdate(archiveURL: URL, sourceURL: URL, relaunch: Bool) async {
         guard state == .idle else { return }
-        guard let downloadURL = URL(string: downloadURLString) else {
-            showCheckFailedAlert(message: L("updater.checkFailed.noData"))
-            return
-        }
-
-        state = .downloading
+        state = .installing
 
         do {
-            let tempFileURL = try await Self.downloadUpdate(from: downloadURL)
-
-            state = .installing
-
             try await Task.detached(priority: .utility) {
-                try AutoUpdater.performInstall(from: tempFileURL, relaunch: relaunch)
+                try AutoUpdater.performInstall(from: archiveURL, sourceURL: sourceURL, relaunch: relaunch)
             }.value
 
             NSApp.terminate(nil)
@@ -192,50 +232,46 @@ final class AutoUpdater {
     }
 
     // Runs off the main actor — only does file I/O and process launching.
-    nonisolated private static func performInstall(from zipURL: URL, relaunch: Bool) throws {
+    nonisolated private static func performInstall(from archiveURL: URL, sourceURL: URL, relaunch: Bool) throws {
         let fm = FileManager.default
         let tempDir = fm.temporaryDirectory.appendingPathComponent("typeflux-update-\(UUID().uuidString)")
         try fm.createDirectory(at: tempDir, withIntermediateDirectories: true)
 
-        // Extract zip with ditto
-        let ditto = Process()
-        ditto.executableURL = URL(fileURLWithPath: "/usr/bin/ditto")
-        ditto.arguments = ["-xk", zipURL.path, tempDir.path]
-        try ditto.run()
-        ditto.waitUntilExit()
-        guard ditto.terminationStatus == 0 else {
-            throw UpdateError.extractionFailed
+        do {
+            let newAppURL: URL
+            switch AutoUpdateArchiveInstaller.archiveKind(for: sourceURL) {
+            case .dmg:
+                newAppURL = try AutoUpdateArchiveInstaller.extractAppFromDMG(archiveURL, into: tempDir)
+            case .zip:
+                newAppURL = try AutoUpdateArchiveInstaller.extractAppFromZip(archiveURL, into: tempDir)
+            }
+
+            guard fm.fileExists(atPath: newAppURL.path) else {
+                throw UpdateError.appNotFound
+            }
+            try AutoUpdateArchiveInstaller.verifyCodeSignature(of: newAppURL)
+            try? fm.removeItem(at: archiveURL)
+
+            let scriptURL = fm.temporaryDirectory.appendingPathComponent("typeflux_relaunch_\(UUID().uuidString).sh")
+            let script = AutoUpdateArchiveInstaller.relaunchScript(
+                currentAppURL: Bundle.main.bundleURL,
+                newAppURL: newAppURL,
+                cleanupURL: tempDir,
+                currentProcessIdentifier: getpid(),
+                relaunch: relaunch
+            )
+            try script.write(to: scriptURL, atomically: true, encoding: .utf8)
+            try fm.setAttributes([.posixPermissions: 0o755], ofItemAtPath: scriptURL.path)
+
+            let launcher = Process()
+            launcher.executableURL = URL(fileURLWithPath: "/bin/bash")
+            launcher.arguments = [scriptURL.path]
+            try launcher.run()
+            // launcher runs detached; do not wait
+        } catch {
+            try? fm.removeItem(at: tempDir)
+            throw error
         }
-
-        // Find the .app bundle in the extracted directory
-        let contents = try fm.contentsOfDirectory(at: tempDir, includingPropertiesForKeys: [.isDirectoryKey])
-        guard let newAppURL = contents.first(where: { $0.pathExtension == "app" }) else {
-            throw UpdateError.appNotFound
-        }
-
-        let currentAppPath = Bundle.main.bundleURL.path
-        let newAppPath = newAppURL.path
-
-        // Write a short shell script that replaces the app after this process exits
-        let scriptURL = fm.temporaryDirectory.appendingPathComponent("typeflux_relaunch_\(UUID().uuidString).sh")
-        var scriptLines = """
-        #!/bin/bash
-        sleep 1
-        rm -rf '\(currentAppPath)'
-        mv '\(newAppPath)' '\(currentAppPath)'
-        xattr -dr com.apple.quarantine '\(currentAppPath)' 2>/dev/null
-        """
-        if relaunch {
-            scriptLines += "\nopen '\(currentAppPath)'"
-        }
-        try scriptLines.write(to: scriptURL, atomically: true, encoding: .utf8)
-        try fm.setAttributes([.posixPermissions: 0o755], ofItemAtPath: scriptURL.path)
-
-        let launcher = Process()
-        launcher.executableURL = URL(fileURLWithPath: "/bin/bash")
-        launcher.arguments = [scriptURL.path]
-        try launcher.run()
-        // launcher runs detached; do not wait
     }
 
     // MARK: - Alerts
@@ -263,13 +299,193 @@ private enum UpdateError: LocalizedError {
     case extractionFailed
     case appNotFound
     case downloadFailed
+    case signatureVerificationFailed
 
     var errorDescription: String? {
         switch self {
         case .extractionFailed: L("updater.install.extractionFailed")
         case .appNotFound: L("updater.install.appNotFound")
         case .downloadFailed: L("updater.download.failed")
+        case .signatureVerificationFailed: L("updater.install.signatureVerificationFailed")
         }
+    }
+}
+
+enum AutoUpdateArchiveKind: Equatable {
+    case zip
+    case dmg
+}
+
+enum AutoUpdateArchiveInstaller {
+    static func archiveKind(for sourceURL: URL) -> AutoUpdateArchiveKind {
+        sourceURL.pathExtension.lowercased() == "dmg" ? .dmg : .zip
+    }
+
+    static func extractAppFromZip(_ zipURL: URL, into tempDir: URL) throws -> URL {
+        let extractDir = tempDir.appendingPathComponent("zip")
+        try FileManager.default.createDirectory(at: extractDir, withIntermediateDirectories: true)
+
+        let status = try runProcess(
+            executablePath: "/usr/bin/ditto",
+            arguments: ["-xk", zipURL.path, extractDir.path]
+        )
+        guard status == 0 else {
+            throw UpdateError.extractionFailed
+        }
+
+        return try findAppBundle(in: extractDir)
+    }
+
+    static func extractAppFromDMG(_ dmgURL: URL, into tempDir: URL) throws -> URL {
+        let mountPoint = tempDir.appendingPathComponent("mount")
+        let stagingDir = tempDir.appendingPathComponent("staged")
+        try FileManager.default.createDirectory(at: mountPoint, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: stagingDir, withIntermediateDirectories: true)
+
+        let attachStatus = try runProcess(
+            executablePath: "/usr/bin/hdiutil",
+            arguments: ["attach", dmgURL.path, "-nobrowse", "-readonly", "-mountpoint", mountPoint.path]
+        )
+        guard attachStatus == 0 else {
+            throw UpdateError.extractionFailed
+        }
+        defer {
+            _ = try? runProcess(
+                executablePath: "/usr/bin/hdiutil",
+                arguments: ["detach", mountPoint.path, "-quiet", "-force"],
+                timeout: 10
+            )
+        }
+
+        let mountedAppURL = try findAppBundle(in: mountPoint)
+        let stagedAppURL = stagingDir.appendingPathComponent(mountedAppURL.lastPathComponent)
+        try FileManager.default.copyItem(at: mountedAppURL, to: stagedAppURL)
+        return stagedAppURL
+    }
+
+    static func findAppBundle(in rootURL: URL) throws -> URL {
+        let keys: [URLResourceKey] = [.isDirectoryKey, .isPackageKey]
+        guard let enumerator = FileManager.default.enumerator(
+            at: rootURL,
+            includingPropertiesForKeys: keys,
+            options: [.skipsHiddenFiles]
+        ) else {
+            throw UpdateError.appNotFound
+        }
+
+        for case let url as URL in enumerator {
+            guard url.pathExtension == "app" else { continue }
+            let values = try url.resourceValues(forKeys: Set(keys))
+            if values.isDirectory == true {
+                enumerator.skipDescendants()
+                return url
+            }
+        }
+
+        throw UpdateError.appNotFound
+    }
+
+    static func verifyCodeSignature(of appURL: URL) throws {
+        let status = try runProcess(
+            executablePath: "/usr/bin/codesign",
+            arguments: ["--verify", "--deep", "--strict", appURL.path]
+        )
+        guard status == 0 else {
+            throw UpdateError.signatureVerificationFailed
+        }
+    }
+
+    static func relaunchScript(
+        currentAppURL: URL,
+        newAppURL: URL,
+        cleanupURL: URL? = nil,
+        currentProcessIdentifier: pid_t? = nil,
+        relaunch: Bool
+    ) -> String {
+        let currentAppPath = shellSingleQuoted(currentAppURL.path)
+        let newAppPath = shellSingleQuoted(newAppURL.path)
+        let cleanupPath = shellSingleQuoted(cleanupURL?.path ?? "")
+        let currentPID = currentProcessIdentifier.map(String.init) ?? ""
+        var scriptLines = """
+        #!/bin/bash
+        set -e
+        current_app=\(currentAppPath)
+        new_app=\(newAppPath)
+        cleanup_dir=\(cleanupPath)
+        current_pid='\(currentPID)'
+        backup_app="${current_app}.typeflux-backup.$$"
+
+        if [ -n "$current_pid" ]; then
+          for _ in $(seq 1 30); do
+            if ! kill -0 "$current_pid" 2>/dev/null; then
+              break
+            fi
+            sleep 1
+          done
+        fi
+
+        restore_current() {
+          if [ -e "$backup_app" ] && [ ! -e "$current_app" ]; then
+            mv "$backup_app" "$current_app"
+          fi
+        }
+
+        if [ -e "$current_app" ]; then
+          rm -rf "$backup_app"
+          mv "$current_app" "$backup_app"
+        fi
+
+        if ! mv "$new_app" "$current_app"; then
+          restore_current
+          exit 1
+        fi
+
+        rm -rf "$backup_app"
+        xattr -dr com.apple.quarantine "$current_app" 2>/dev/null || true
+        """
+        if relaunch {
+            scriptLines += "\nopen \"$current_app\""
+        }
+        scriptLines += """
+
+        if [ -n "$cleanup_dir" ]; then
+          rm -rf "$cleanup_dir"
+        fi
+        rm -f "$0"
+        """
+        return scriptLines
+    }
+
+    static func shellSingleQuoted(_ value: String) -> String {
+        "'\(value.replacingOccurrences(of: "'", with: "'\\''"))'"
+    }
+
+    @discardableResult
+    private static func runProcess(
+        executablePath: String,
+        arguments: [String],
+        timeout: TimeInterval? = nil
+    ) throws -> Int32 {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: executablePath)
+        process.arguments = arguments
+        try process.run()
+
+        guard let timeout else {
+            process.waitUntilExit()
+            return process.terminationStatus
+        }
+
+        let deadline = Date().addingTimeInterval(timeout)
+        while process.isRunning, Date() < deadline {
+            Thread.sleep(forTimeInterval: 0.1)
+        }
+        if process.isRunning {
+            process.terminate()
+            process.waitUntilExit()
+            return 124
+        }
+        return process.terminationStatus
     }
 }
 

--- a/Sources/Typeflux/App/StatusBarController.swift
+++ b/Sources/Typeflux/App/StatusBarController.swift
@@ -172,6 +172,10 @@ final class StatusBarController: NSObject {
             NotificationCenter.default.removeObserver(personaSelectionObserver)
         }
         personaSelectionObserver = nil
+        if let autoUpdateStateObserver {
+            NotificationCenter.default.removeObserver(autoUpdateStateObserver)
+        }
+        autoUpdateStateObserver = nil
         if let autoModelDownloadObserver {
             NotificationCenter.default.removeObserver(autoModelDownloadObserver)
         }

--- a/Sources/Typeflux/Resources/en.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/en.lproj/Localizable.strings
@@ -210,6 +210,7 @@
 "updater.download.failed" = "Failed to download the update.";
 "updater.install.extractionFailed" = "Failed to extract the update archive.";
 "updater.install.appNotFound" = "Could not find the application bundle in the update archive.";
+"updater.install.signatureVerificationFailed" = "The update could not be verified.";
 
 "provider.stt.whisperAPI" = "OpenAI";
 "provider.stt.freeModel" = "Free Models";

--- a/Sources/Typeflux/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/ja.lproj/Localizable.strings
@@ -208,6 +208,7 @@
 "updater.download.failed" = "アップデートのダウンロードに失敗しました。";
 "updater.install.extractionFailed" = "アップデートアーカイブの展開に失敗しました。";
 "updater.install.appNotFound" = "アップデートアーカイブ内にアプリケーションが見つかりませんでした。";
+"updater.install.signatureVerificationFailed" = "アップデートを検証できませんでした。";
 
 "provider.stt.whisperAPI" = "OpenAI";
 "provider.stt.freeModel" = "無料モデル";

--- a/Sources/Typeflux/Resources/ko.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/ko.lproj/Localizable.strings
@@ -208,6 +208,7 @@
 "updater.download.failed" = "업데이트 다운로드에 실패했습니다.";
 "updater.install.extractionFailed" = "업데이트 아카이브 압축 해제에 실패했습니다.";
 "updater.install.appNotFound" = "업데이트 아카이브에서 애플리케이션을 찾을 수 없습니다.";
+"updater.install.signatureVerificationFailed" = "업데이트를 확인할 수 없습니다.";
 
 "provider.stt.whisperAPI" = "OpenAI";
 "provider.stt.freeModel" = "무료 모델";

--- a/Sources/Typeflux/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/zh-Hans.lproj/Localizable.strings
@@ -210,6 +210,7 @@
 "updater.download.failed" = "下载更新失败。";
 "updater.install.extractionFailed" = "解压更新包失败。";
 "updater.install.appNotFound" = "在更新包中找不到应用程序。";
+"updater.install.signatureVerificationFailed" = "无法验证更新包签名。";
 
 "provider.stt.whisperAPI" = "OpenAI";
 "provider.stt.freeModel" = "免费模型";

--- a/Sources/Typeflux/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/zh-Hant.lproj/Localizable.strings
@@ -208,6 +208,7 @@
 "updater.download.failed" = "下載更新失敗。";
 "updater.install.extractionFailed" = "解壓更新包失敗。";
 "updater.install.appNotFound" = "在更新包中找不到應用程式。";
+"updater.install.signatureVerificationFailed" = "無法驗證更新包簽名。";
 
 "provider.stt.whisperAPI" = "OpenAI";
 "provider.stt.freeModel" = "免費模型";

--- a/Tests/TypefluxTests/AutoUpdateArchiveInstallerTests.swift
+++ b/Tests/TypefluxTests/AutoUpdateArchiveInstallerTests.swift
@@ -1,0 +1,85 @@
+@testable import Typeflux
+import XCTest
+
+final class AutoUpdateArchiveInstallerTests: XCTestCase {
+    func testArchiveKindDetectsDMGCaseInsensitively() throws {
+        let url = try XCTUnwrap(URL(string: "https://example.com/releases/Typeflux.DMG?download=1"))
+
+        XCTAssertEqual(AutoUpdateArchiveInstaller.archiveKind(for: url), .dmg)
+    }
+
+    func testArchiveKindDefaultsToZip() throws {
+        let zipURL = try XCTUnwrap(URL(string: "https://example.com/releases/Typeflux.zip"))
+        let extensionlessURL = try XCTUnwrap(URL(string: "https://example.com/api/download/latest"))
+
+        XCTAssertEqual(AutoUpdateArchiveInstaller.archiveKind(for: zipURL), .zip)
+        XCTAssertEqual(AutoUpdateArchiveInstaller.archiveKind(for: extensionlessURL), .zip)
+    }
+
+    func testShellSingleQuotedEscapesApostrophes() {
+        let quoted = AutoUpdateArchiveInstaller.shellSingleQuoted("/Applications/Typeflux Bob's.app")
+
+        XCTAssertEqual(quoted, "'/Applications/Typeflux Bob'\\''s.app'")
+    }
+
+    func testRelaunchScriptQuotesPathsAndRelaunchesWhenRequested() {
+        let script = AutoUpdateArchiveInstaller.relaunchScript(
+            currentAppURL: URL(fileURLWithPath: "/Applications/Typeflux Bob's.app"),
+            newAppURL: URL(fileURLWithPath: "/tmp/update path/Typeflux.app"),
+            cleanupURL: URL(fileURLWithPath: "/tmp/update path"),
+            currentProcessIdentifier: 12345,
+            relaunch: true
+        )
+
+        XCTAssertTrue(script.contains("set -e"))
+        XCTAssertTrue(script.contains("current_app='/Applications/Typeflux Bob'\\''s.app'"))
+        XCTAssertTrue(script.contains("new_app='/tmp/update path/Typeflux.app'"))
+        XCTAssertTrue(script.contains("cleanup_dir='/tmp/update path'"))
+        XCTAssertTrue(script.contains("current_pid='12345'"))
+        XCTAssertTrue(script.contains("kill -0 \"$current_pid\""))
+        XCTAssertTrue(script.contains("backup_app=\"${current_app}.typeflux-backup.$$\""))
+        XCTAssertTrue(script.contains("mv \"$current_app\" \"$backup_app\""))
+        XCTAssertTrue(script.contains("if ! mv \"$new_app\" \"$current_app\"; then"))
+        XCTAssertTrue(script.contains("restore_current"))
+        XCTAssertTrue(script.contains("open \"$current_app\""))
+        XCTAssertTrue(script.contains("rm -rf \"$cleanup_dir\""))
+    }
+
+    func testRelaunchScriptOmitsOpenWhenRelaunchDisabled() {
+        let script = AutoUpdateArchiveInstaller.relaunchScript(
+            currentAppURL: URL(fileURLWithPath: "/Applications/Typeflux.app"),
+            newAppURL: URL(fileURLWithPath: "/tmp/Typeflux.app"),
+            relaunch: false
+        )
+
+        XCTAssertFalse(script.contains("\nopen "))
+    }
+
+    func testRelaunchScriptDoesNotDeleteCurrentAppBeforeReplacement() {
+        let script = AutoUpdateArchiveInstaller.relaunchScript(
+            currentAppURL: URL(fileURLWithPath: "/Applications/Typeflux.app"),
+            newAppURL: URL(fileURLWithPath: "/tmp/Typeflux.app"),
+            relaunch: false
+        )
+
+        XCTAssertFalse(script.contains("rm -rf \"$current_app\""))
+        XCTAssertLessThan(
+            try XCTUnwrap(script.range(of: "mv \"$current_app\" \"$backup_app\"")?.lowerBound),
+            try XCTUnwrap(script.range(of: "if ! mv \"$new_app\" \"$current_app\"; then")?.lowerBound)
+        )
+    }
+
+    func testFindAppBundleSearchesNestedDirectories() throws {
+        let rootURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("typeflux-updater-test-\(UUID().uuidString)")
+        let appURL = rootURL
+            .appendingPathComponent("nested")
+            .appendingPathComponent("Typeflux.app")
+        try FileManager.default.createDirectory(at: appURL, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: rootURL) }
+
+        let found = try AutoUpdateArchiveInstaller.findAppBundle(in: rootURL)
+
+        XCTAssertEqual(found.standardizedFileURL, appURL.standardizedFileURL)
+    }
+}


### PR DESCRIPTION
## Summary

改进自动更新机制，使其满足以下流程：

1. 定时向服务端检测是否有更新
2. 检测到更新后，自动下载更新包
3. 下载完成后，提醒用户进行更新
4. 用户确认后，应用自动完成更新过程
5. 将安装包更新到最新版本
6. 更新完成后重启应用

## Changes

### AutoUpdater.swift
- **先下载后提示**：`prepareUpdate` 在显示弹窗前先下载更新包；下载状态通过 `state` 暴露给状态栏菜单
- **安全替换**：relaunch script 改为先 `mv` 旧版到 backup，再 `mv` 新版到原位；失败时 `restore_current` 回退旧版
- **签名验证**：安装前执行 `codesign --verify --deep --strict` 校验新包
- **DMG 支持**：新增 `extractAppFromDMG`，与 ZIP 统一通过 `archiveKind` 分发
- **移除 force-unwrap**：`websiteURL` 改为 `URL?`
- **可取消初始检查**：`startAutoCheck` 的延迟检查使用 `DispatchWorkItem`，`stopAutoCheck` 可正确取消
- **有界 detach**：DMG 卸载增加 10s timeout

### StatusBarController.swift
- 添加 `autoUpdateStateObserver`，状态栏菜单根据 `AutoUpdater.shared.state` 显示 downloading/installing 状态
- `stop()` 中补充 observer 清理

### Tests
- 新增 `AutoUpdateArchiveInstallerTests`（7 个测试用例）
  - ZIP/DMG 格式识别
  - Shell 单引号转义
  - Relaunch script 内容验证（路径引用、PID 等待、backup/restore、open 命令）
  - 嵌套目录 `.app` 查找

## Test plan

- [x] `swift test --filter AutoUpdateArchiveInstallerTests` 通过（7/7）
- [x] `swift build` 编译通过
- [ ] staging 环境端到端更新测试（建议 PM 后续验证）