### PR TITLE
fix: unify login modal glass background

### DIFF
--- a/Sources/Typeflux/Auth/LoginView.swift
+++ b/Sources/Typeflux/Auth/LoginView.swift
@@ -180,7 +180,7 @@ struct LoginView: View {
             .frame(maxWidth: .infinity, alignment: .top)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
-        .background(StudioTheme.windowBackground)
+        .background(loginWindowBackground)
     }
 
     private var plainBody: some View {
@@ -732,6 +732,11 @@ struct LoginView: View {
 
     private var loginCardShadow: Color {
         colorScheme == .dark ? Color.black.opacity(0.28) : Color.black.opacity(0.08)
+    }
+
+    private var loginWindowBackground: some View {
+        StudioGlassBackground(tintOpacity: StudioTheme.Opacity.glassBackgroundTint)
+            .ignoresSafeArea()
     }
 
     private var showsPolicyAgreement: Bool {

--- a/Sources/Typeflux/Auth/LoginWindowController.swift
+++ b/Sources/Typeflux/Auth/LoginWindowController.swift
@@ -36,7 +36,7 @@ final class LoginWindowController: NSObject {
         let contentRect = NSRect(origin: .zero, size: Self.defaultWindowSize)
         let window = NSWindow(
             contentRect: contentRect,
-            styleMask: [.titled, .closable],
+            styleMask: [.titled, .closable, .fullSizeContentView],
             backing: .buffered,
             defer: false,
         )
@@ -54,8 +54,10 @@ final class LoginWindowController: NSObject {
         window.title = L("auth.login.windowTitle")
         window.titleVisibility = .hidden
         window.titlebarAppearsTransparent = true
+        window.titlebarSeparatorStyle = .none
         window.isMovableByWindowBackground = true
-        window.backgroundColor = NSColor(StudioTheme.windowBackground)
+        window.isOpaque = false
+        window.backgroundColor = .clear
         window.contentView = hosting
         // Lock the window to a fixed size (no resizing)
         window.minSize = Self.defaultWindowSize

--- a/Sources/Typeflux/UI/StudioComponents.swift
+++ b/Sources/Typeflux/UI/StudioComponents.swift
@@ -641,7 +641,7 @@ struct StudioShell<Content: View>: View {
     }
 }
 
-private struct StudioGlassBackground: View {
+struct StudioGlassBackground: View {
     let tintOpacity: Double
 
     var body: some View {


### PR DESCRIPTION
## Summary
- Fixes TYP-71 by extending the login window content under the transparent title bar.
- Replaces the login window plain translucent fill with the shared Studio glass background so the title bar and body read as one surface.
- Removes the titlebar separator and uses a clear non-opaque AppKit window background.

## How to test
- swift build
- swift test --filter TypefluxTests.LoginViewPolicyGuardTests

## Screenshots
- Not captured in this heartbeat; change is a macOS window chrome/material update.