### PR TITLE
feat: add resumable release workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,12 +4,17 @@ PACKAGE_NAME = Typeflux$(if $(filter full,$(RELEASE_VARIANT)),-full,)
 run:
 	./scripts/run_dev_app.sh
 
-release: release-notarize
-	mv .build/release/$(PACKAGE_NAME).dmg ~/Downloads/
-	mv .build/release/$(PACKAGE_NAME).zip ~/Downloads/
+release:
+	./scripts/release_notarize.sh --move-to-downloads
+
+release-continue:
+	./scripts/release_notarize.sh --continue --move-to-downloads
 
 full-release:
 	TYPEFLUX_RELEASE_VARIANT=full $(MAKE) release
+
+full-release-continue:
+	TYPEFLUX_RELEASE_VARIANT=full $(MAKE) release-continue
 
 dev:
 	TYPEFLUX_API_URL=http://127.0.0.1:8080 ./scripts/run_dev_attached.sh
@@ -32,7 +37,10 @@ dmg:
 release-notarize:
 	./scripts/release_notarize.sh
 
+release-notarize-continue:
+	./scripts/release_notarize.sh --continue
+
 format:
 	./scripts/format.sh
 
-.PHONY: run release full-release dev full-dev build test coverage dmg release-notarize format
+.PHONY: run release release-continue full-release full-release-continue dev full-dev build test coverage dmg release-notarize release-notarize-continue format

--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ make run          # build + launch as .app bundle
 make dev          # launch with terminal logs attached
 make full-dev     # launch dev app with bundled SenseVoice resources
 make full-release # build the full notarized production installer locally
+make release-continue # resume an interrupted local release
 swift test        # run tests
 ```
 

--- a/docs/BUILD_CONFIGURATION.md
+++ b/docs/BUILD_CONFIGURATION.md
@@ -227,6 +227,8 @@ The release script passes `--keychain` automatically when this variable is set.
 | `TYPEFLUX_NOTARY_SUBMIT_RETRIES` | Optional | Integer; default `3` | `scripts/release_notarize.sh` (retries on transient submission failure) |
 | `TYPEFLUX_NOTARY_POLL_INTERVAL_SECONDS` | Optional | Integer; default `15` | `scripts/release_notarize.sh` (sleep between status polls) |
 | `TYPEFLUX_RELEASE_VARIANT` | Optional | `minimal` (default) or `full` | `scripts/build_release.sh` (controls whether SenseVoice is embedded into the app bundle) |
+| `TYPEFLUX_RELEASE_STATE_PATH` | Optional | Path to the resumable release state file; default `.build/release/.release-workflow.env` | `scripts/release_notarize.sh` |
+| `TYPEFLUX_RELEASE_DESTINATION` | Optional | Directory for `make release` / `make release-continue` exports; default `~/Downloads` | `scripts/release_notarize.sh` |
 
 > Variables that are **not** prefixed are intentionally Apple-defined or third-party names: `NOTARYTOOL_APPLE_ID`, `NOTARYTOOL_PASSWORD`, `APPLE_TEAM_ID`, `APPLE_CERTIFICATE_BASE64`, `APPLE_CERTIFICATE_PASSWORD` exist only inside the GitHub Actions workflow.
 

--- a/docs/MAKE_COMMANDS.md
+++ b/docs/MAKE_COMMANDS.md
@@ -189,6 +189,38 @@ Use it when:
 - you want a production-ready installer that already contains the bundled SenseVoice model
 - you want the local full installer without manually exporting `TYPEFLUX_RELEASE_VARIANT=full`
 
+### `make release-continue`
+
+Command:
+
+```bash
+make release-continue
+```
+
+What it does:
+
+- resumes the last interrupted local release using `.build/release/.release-workflow.env`
+- skips completed stages such as app build, DMG build, notarization submission, stapling, or archive export
+- continues waiting on the saved Apple notarization submission ID when the previous run reached Apple before timing out or being stopped
+- moves completed installers into `~/Downloads/`
+
+Use it when:
+
+- `make release` failed or was stopped after making progress
+- Apple notarization took long enough that the local release process timed out
+
+For the full bundled-model variant, run:
+
+```bash
+make full-release-continue
+```
+
+To resume the same workflow without moving artifacts to `~/Downloads`, run:
+
+```bash
+make release-notarize-continue
+```
+
 Requirements:
 
 - the same Developer ID, notarization profile, and `create-dmg` setup required by `make release`

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -25,6 +25,12 @@ For local release validation, use the one-step notarized release command:
 make release-notarize
 ```
 
+If local release validation fails after making progress, resume it with:
+
+```bash
+make release-notarize-continue
+```
+
 For a local full-model production installer, use:
 
 ```bash
@@ -122,6 +128,13 @@ This command automatically:
 7. staples the notarization ticket to both the app and the DMG
 8. validates the stapled artifacts
 
+The release script writes resumable state to
+`.build/release/.release-workflow.env` after each completed stage. A fresh
+`make release` or `make release-notarize` starts over and replaces that state.
+`make release-continue` and `make release-notarize-continue` use the saved
+stage and notarization submission ID to resume the previous release, including
+continuing the Apple notarization wait after a timeout or manual stop.
+
 ## Prerequisites
 
 - macOS 13 or later
@@ -162,6 +175,7 @@ Notes:
   a non-default keychain
 - the release script retries transient notarization submission failures
 - if Apple returns a submission ID and the local client times out afterward, the script continues tracking that submission instead of restarting blindly
+- after an interrupted local release, use `make release-continue` or `make release-notarize-continue` to resume from the saved state instead of rebuilding from the beginning
 - see [BUILD_CONFIGURATION.md](./BUILD_CONFIGURATION.md) for the full step-by-step setup of certificates, Developer IDs, provisioning profiles, and notarization credentials
 
 ## One-Step Notarized Release
@@ -176,6 +190,24 @@ For the bundled-model installer:
 
 ```bash
 make full-release
+```
+
+Resume an interrupted default release validation:
+
+```bash
+make release-notarize-continue
+```
+
+Resume an interrupted default release that exports artifacts to `~/Downloads`:
+
+```bash
+make release-continue
+```
+
+Resume an interrupted full release:
+
+```bash
+make full-release-continue
 ```
 
 Successful output artifacts:

--- a/scripts/release_notarize.sh
+++ b/scripts/release_notarize.sh
@@ -13,9 +13,15 @@ PACKAGE_NAME="${TYPEFLUX_PACKAGE_NAME:-$DEFAULT_PACKAGE_NAME}"
 APP_BUNDLE="${BUILD_DIR}/${APP_NAME}.app"
 DMG_PATH="${BUILD_DIR}/${PACKAGE_NAME}.dmg"
 ZIP_PATH="${BUILD_DIR}/${PACKAGE_NAME}.zip"
+STATE_PATH="${TYPEFLUX_RELEASE_STATE_PATH:-${BUILD_DIR}/.release-workflow.env}"
+DESTINATION_DIR="${TYPEFLUX_RELEASE_DESTINATION:-${HOME}/Downloads}"
 TYPEFLUX_NOTARY_POLL_INTERVAL_SECONDS="${TYPEFLUX_NOTARY_POLL_INTERVAL_SECONDS:-15}"
 TYPEFLUX_NOTARY_SUBMIT_RETRIES="${TYPEFLUX_NOTARY_SUBMIT_RETRIES:-3}"
 TYPEFLUX_NOTARY_KEYCHAIN="${TYPEFLUX_NOTARY_KEYCHAIN:-}"
+CONTINUE_RELEASE=false
+MOVE_TO_DOWNLOADS=false
+RELEASE_STAGE="new"
+SUBMISSION_ID=""
 
 TYPEFLUX_CODESIGN_IDENTITY="${TYPEFLUX_CODESIGN_IDENTITY:-${TYPEFLUX_DEVELOPER_ID_APPLICATION:-${TYPEFLUX_APPLE_DISTRIBUTION:-}}}"
 export TYPEFLUX_CODESIGN_IDENTITY
@@ -41,11 +47,125 @@ require_env() {
   [[ -n "${!env_name:-}" ]] || fail "Missing required environment variable: $env_name"
 }
 
+usage() {
+  cat >&2 <<'EOF'
+Usage: scripts/release_notarize.sh [--continue] [--move-to-downloads]
+
+Options:
+  --continue           Resume the release recorded in .build/release/.release-workflow.env.
+  --move-to-downloads Move finished ZIP and DMG artifacts to ~/Downloads as a resumable stage.
+EOF
+}
+
+parse_args() {
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --continue)
+        CONTINUE_RELEASE=true
+        ;;
+      --move-to-downloads)
+        MOVE_TO_DOWNLOADS=true
+        ;;
+      -h|--help)
+        usage
+        exit 0
+        ;;
+      *)
+        usage
+        fail "Unknown argument: $1"
+        ;;
+    esac
+    shift
+  done
+}
+
 parse_notary_field() {
   local field_name="$1"
   local raw_output="$2"
 
   awk -F': ' -v key="$field_name" '$1 ~ key"$" {print $2; exit}' <<<"$raw_output"
+}
+
+stage_rank() {
+  case "$1" in
+    "new") echo 0 ;;
+    "app_built") echo 10 ;;
+    "dmg_built") echo 20 ;;
+    "notarization_submitted") echo 30 ;;
+    "notarization_accepted") echo 40 ;;
+    "stapled") echo 50 ;;
+    "archived") echo 60 ;;
+    "exported") echo 70 ;;
+    *) fail "Unknown release stage in ${STATE_PATH}: $1" ;;
+  esac
+}
+
+has_reached_stage() {
+  local target_stage="$1"
+  [[ "$(stage_rank "$RELEASE_STAGE")" -ge "$(stage_rank "$target_stage")" ]]
+}
+
+write_state() {
+  local state_tmp
+  mkdir -p "$(dirname "$STATE_PATH")"
+  state_tmp="$(mktemp "${STATE_PATH}.XXXXXX")"
+  {
+    printf 'RELEASE_STAGE=%q\n' "$RELEASE_STAGE"
+    printf 'RELEASE_VARIANT=%q\n' "$RELEASE_VARIANT"
+    printf 'PACKAGE_NAME=%q\n' "$PACKAGE_NAME"
+    printf 'APP_BUNDLE=%q\n' "$APP_BUNDLE"
+    printf 'DMG_PATH=%q\n' "$DMG_PATH"
+    printf 'ZIP_PATH=%q\n' "$ZIP_PATH"
+    printf 'DESTINATION_DIR=%q\n' "$DESTINATION_DIR"
+    printf 'SUBMISSION_ID=%q\n' "$SUBMISSION_ID"
+  } >"$state_tmp"
+  mv "$state_tmp" "$STATE_PATH"
+}
+
+set_stage() {
+  RELEASE_STAGE="$1"
+  write_state
+}
+
+load_state() {
+  local expected_release_variant="$RELEASE_VARIANT"
+  local expected_package_name="$PACKAGE_NAME"
+  local expected_app_bundle="$APP_BUNDLE"
+  local expected_dmg_path="$DMG_PATH"
+  local expected_zip_path="$ZIP_PATH"
+  local requested_destination_dir="$DESTINATION_DIR"
+
+  [[ -f "$STATE_PATH" ]] || fail "No resumable release state found at ${STATE_PATH}. Run 'make release' first."
+
+  # shellcheck disable=SC1090
+  source "$STATE_PATH"
+
+  RELEASE_STAGE="${RELEASE_STAGE:-new}"
+  SUBMISSION_ID="${SUBMISSION_ID:-}"
+  DESTINATION_DIR="${DESTINATION_DIR:-$requested_destination_dir}"
+
+  [[ "${RELEASE_VARIANT:-}" == "$expected_release_variant" ]] \
+    || fail "Release state variant '${RELEASE_VARIANT:-}' does not match requested variant '${expected_release_variant}'."
+  [[ "${PACKAGE_NAME:-}" == "$expected_package_name" ]] \
+    || fail "Release state package '${PACKAGE_NAME:-}' does not match requested package '${expected_package_name}'."
+  [[ "${APP_BUNDLE:-}" == "$expected_app_bundle" ]] \
+    || fail "Release state app path '${APP_BUNDLE:-}' does not match expected path '${expected_app_bundle}'."
+  [[ "${DMG_PATH:-}" == "$expected_dmg_path" ]] \
+    || fail "Release state DMG path '${DMG_PATH:-}' does not match expected path '${expected_dmg_path}'."
+  [[ "${ZIP_PATH:-}" == "$expected_zip_path" ]] \
+    || fail "Release state ZIP path '${ZIP_PATH:-}' does not match expected path '${expected_zip_path}'."
+  [[ "$DESTINATION_DIR" == "$requested_destination_dir" ]] \
+    || fail "Release state destination '${DESTINATION_DIR}' does not match requested destination '${requested_destination_dir}'."
+}
+
+prepare_state() {
+  if [[ "$CONTINUE_RELEASE" == true ]]; then
+    load_state
+    log "Resuming release from stage: ${RELEASE_STAGE}"
+  else
+    rm -f "$STATE_PATH"
+    set_stage "new"
+  fi
 }
 
 find_valid_codesign_identity() {
@@ -192,9 +312,33 @@ refresh_zip_archive() {
   )
 }
 
-main() {
-  local submission_id
+move_artifact() {
+  local source_path="$1"
+  local destination_path="${DESTINATION_DIR}/$(basename "$source_path")"
 
+  if [[ -f "$source_path" ]]; then
+    mkdir -p "$DESTINATION_DIR"
+    mv -f "$source_path" "$destination_path"
+    log "Moved $(basename "$source_path") to ${DESTINATION_DIR}."
+    return 0
+  fi
+
+  if [[ -f "$destination_path" ]]; then
+    log "$(basename "$source_path") is already in ${DESTINATION_DIR}."
+    return 0
+  fi
+
+  fail "Missing release artifact: ${source_path}"
+}
+
+export_artifacts() {
+  log "Moving release artifacts to ${DESTINATION_DIR}..."
+  move_artifact "$DMG_PATH"
+  move_artifact "$ZIP_PATH"
+}
+
+main() {
+  parse_args "$@"
   require_command swift
   require_command codesign
   require_command xcrun
@@ -206,24 +350,70 @@ main() {
   log "Using notary profile: ${TYPEFLUX_NOTARY_PROFILE}"
   log "Using release variant: ${RELEASE_VARIANT}"
   log "Using package name: ${PACKAGE_NAME}"
+  log "Using release state: ${STATE_PATH}"
 
-  log "Building signed release app..."
-  "${ROOT_DIR}/scripts/build_release.sh"
+  prepare_state
 
-  log "Building signed DMG..."
-  "${ROOT_DIR}/scripts/build_dmg.sh"
+  if has_reached_stage "app_built"; then
+    log "Skipping release app build; stage ${RELEASE_STAGE} already completed it."
+  else
+    log "Building signed release app..."
+    "${ROOT_DIR}/scripts/build_release.sh"
+    set_stage "app_built"
+  fi
 
-  submission_id="$(submit_for_notarization)"
-  log "Notarization submission ID: ${submission_id}"
+  if has_reached_stage "dmg_built"; then
+    log "Skipping DMG build; stage ${RELEASE_STAGE} already completed it."
+  else
+    log "Building signed DMG..."
+    "${ROOT_DIR}/scripts/build_dmg.sh"
+    set_stage "dmg_built"
+  fi
 
-  wait_for_notarization "$submission_id"
-  staple_artifacts
-  refresh_zip_archive
+  if has_reached_stage "notarization_submitted"; then
+    [[ -n "$SUBMISSION_ID" ]] || fail "Release state is missing notarization submission ID."
+    log "Reusing notarization submission ID: ${SUBMISSION_ID}"
+  else
+    SUBMISSION_ID="$(submit_for_notarization)"
+    log "Notarization submission ID: ${SUBMISSION_ID}"
+    set_stage "notarization_submitted"
+  fi
+
+  if has_reached_stage "notarization_accepted"; then
+    log "Skipping notarization wait; stage ${RELEASE_STAGE} already accepted submission."
+  else
+    wait_for_notarization "$SUBMISSION_ID"
+    set_stage "notarization_accepted"
+  fi
+
+  if has_reached_stage "stapled"; then
+    log "Skipping stapling; stage ${RELEASE_STAGE} already completed it."
+  else
+    staple_artifacts
+    set_stage "stapled"
+  fi
+
+  if has_reached_stage "archived"; then
+    log "Skipping ZIP refresh; stage ${RELEASE_STAGE} already completed it."
+  else
+    refresh_zip_archive
+    set_stage "archived"
+  fi
+
+  if [[ "$MOVE_TO_DOWNLOADS" == true ]]; then
+    if has_reached_stage "exported"; then
+      log "Skipping artifact move; stage ${RELEASE_STAGE} already completed it."
+    else
+      export_artifacts
+      set_stage "exported"
+    fi
+  fi
 
   log "Release workflow completed successfully."
   log "App: ${APP_BUNDLE}"
   log "ZIP: ${ZIP_PATH}"
   log "DMG: ${DMG_PATH}"
+  log "State: ${STATE_PATH}"
 }
 
 main "$@"


### PR DESCRIPTION
## Summary

References Paperclip issue TYP-72.

- Add `make release-continue`, `make full-release-continue`, and `make release-notarize-continue`.
- Persist release progress in `.build/release/.release-workflow.env` after each completed stage.
- Resume completed app/DMG build stages, saved notarization submissions, notarization waits, stapling, ZIP refresh, and final export to `~/Downloads`.
- Document the resume workflow and new release environment overrides.

## How to Test

- `bash -n scripts/release_notarize.sh scripts/build_release.sh scripts/build_dmg.sh`
- `git diff --check`
- `make -n release release-continue full-release full-release-continue release-notarize release-notarize-continue`
- Simulated `release_notarize.sh --continue --move-to-downloads` from a saved `notarization_submitted` state using fake `security`, `swift`, `codesign`, `create-dmg`, `xcrun`, and `ditto`, verifying `Typeflux.dmg` and `Typeflux.zip` were exported.

## Screenshots

Not applicable; release script and docs only.
