### PR TITLE
feat: add direct feedback submission

### DIFF
--- a/Sources/Typeflux/Feedback/DirectFeedbackSheet.swift
+++ b/Sources/Typeflux/Feedback/DirectFeedbackSheet.swift
@@ -1,0 +1,111 @@
+import SwiftUI
+
+struct DirectFeedbackSheet: View {
+    @Binding var content: String
+    @Binding var contact: String
+    let isSubmitting: Bool
+    let errorMessage: String?
+    let onCancel: () -> Void
+    let onSubmit: () -> Void
+
+    @FocusState private var isContentFocused: Bool
+
+    private var trimmedContent: String {
+        content.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: StudioTheme.Spacing.mediumLarge) {
+            VStack(alignment: .leading, spacing: StudioTheme.Spacing.xSmall) {
+                Text(L("feedback.direct.title"))
+                    .font(.studioDisplay(20, weight: .semibold))
+                    .foregroundStyle(StudioTheme.textPrimary)
+
+                Text(L("feedback.direct.subtitle"))
+                    .font(.studioBody(13))
+                    .foregroundStyle(StudioTheme.textSecondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            VStack(alignment: .leading, spacing: StudioTheme.Spacing.small) {
+                Text(L("feedback.direct.contentLabel"))
+                    .font(.studioBody(12, weight: .semibold))
+                    .foregroundStyle(StudioTheme.textSecondary)
+
+                ZStack(alignment: .topLeading) {
+                    TextEditor(text: $content)
+                        .font(.studioBody(13))
+                        .scrollContentBackground(.hidden)
+                        .padding(10)
+                        .frame(minHeight: 160)
+                        .background(StudioTheme.controlSurface)
+                        .clipShape(RoundedRectangle(cornerRadius: StudioTheme.CornerRadius.medium, style: .continuous))
+                        .overlay {
+                            RoundedRectangle(cornerRadius: StudioTheme.CornerRadius.medium, style: .continuous)
+                                .stroke(StudioTheme.border.opacity(0.72), lineWidth: 1)
+                        }
+                        .focused($isContentFocused)
+
+                    if content.isEmpty {
+                        Text(L("feedback.direct.contentPlaceholder"))
+                            .font(.studioBody(13))
+                            .foregroundStyle(StudioTheme.textTertiary)
+                            .padding(.horizontal, 15)
+                            .padding(.vertical, 18)
+                            .allowsHitTesting(false)
+                    }
+                }
+            }
+
+            VStack(alignment: .leading, spacing: StudioTheme.Spacing.small) {
+                Text(L("feedback.direct.contactLabel"))
+                    .font(.studioBody(12, weight: .semibold))
+                    .foregroundStyle(StudioTheme.textSecondary)
+
+                TextField(L("feedback.direct.contactPlaceholder"), text: $contact)
+                    .textFieldStyle(.plain)
+                    .font(.studioBody(13))
+                    .padding(.horizontal, 12)
+                    .frame(height: 38)
+                    .background(StudioTheme.controlSurface)
+                    .clipShape(RoundedRectangle(cornerRadius: StudioTheme.CornerRadius.medium, style: .continuous))
+                    .overlay {
+                        RoundedRectangle(cornerRadius: StudioTheme.CornerRadius.medium, style: .continuous)
+                            .stroke(StudioTheme.border.opacity(0.72), lineWidth: 1)
+                    }
+            }
+
+            if let errorMessage {
+                Text(errorMessage)
+                    .font(.studioBody(12))
+                    .foregroundStyle(StudioTheme.danger)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            HStack {
+                Spacer()
+
+                Button(L("common.cancel"), action: onCancel)
+                    .disabled(isSubmitting)
+
+                Button {
+                    onSubmit()
+                } label: {
+                    if isSubmitting {
+                        ProgressView()
+                            .controlSize(.small)
+                    } else {
+                        Text(L("feedback.direct.submit"))
+                    }
+                }
+                .keyboardShortcut(.defaultAction)
+                .disabled(isSubmitting || trimmedContent.isEmpty)
+            }
+        }
+        .padding(24)
+        .frame(width: 480)
+        .onAppear {
+            isContentFocused = true
+        }
+    }
+}

--- a/Sources/Typeflux/Feedback/FeedbackAPIService.swift
+++ b/Sources/Typeflux/Feedback/FeedbackAPIService.swift
@@ -1,0 +1,122 @@
+import Foundation
+import os
+
+struct CreateFeedbackRequest: Encodable, Equatable {
+    let content: String
+    let contact: String?
+    let imageURLs: [String]
+
+    init(content: String, contact: String? = nil, imageURLs: [String] = []) {
+        self.content = content
+        self.contact = contact
+        self.imageURLs = imageURLs
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case content, contact
+        case imageURLs = "image_urls"
+    }
+}
+
+struct FeedbackSubmissionResponse: Decodable, Equatable {
+    let id: String
+    let status: String
+}
+
+enum FeedbackAPIError: LocalizedError, Equatable {
+    case emptyContent
+    case networkError(String)
+    case serverError(code: String, message: String?)
+    case invalidResponse
+    case unauthorized
+
+    var errorDescription: String? {
+        switch self {
+        case .emptyContent:
+            L("feedback.error.emptyContent")
+        case .networkError(let message):
+            message
+        case .serverError(_, let message):
+            message ?? L("feedback.error.server")
+        case .invalidResponse:
+            L("feedback.error.invalidResponse")
+        case .unauthorized:
+            L("auth.error.unauthorized")
+        }
+    }
+}
+
+struct FeedbackAPIService {
+    private static let logger = Logger(subsystem: "ai.gulu.app.typeflux", category: "FeedbackAPIService")
+
+    static func submit(
+        content: String,
+        contact: String?,
+        token: String? = nil,
+        executor: CloudRequestExecutor = CloudRequestExecutor()
+    ) async throws -> FeedbackSubmissionResponse {
+        let trimmedContent = content.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedContent.isEmpty else {
+            throw FeedbackAPIError.emptyContent
+        }
+
+        let trimmedContact = contact?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let request = CreateFeedbackRequest(
+            content: trimmedContent,
+            contact: trimmedContact?.isEmpty == false ? trimmedContact : nil
+        )
+        let payload: Data
+        do {
+            payload = try JSONEncoder().encode(request)
+        } catch {
+            throw FeedbackAPIError.networkError(error.localizedDescription)
+        }
+
+        let data: Data
+        let httpResponse: HTTPURLResponse
+        do {
+            (data, httpResponse) = try await executor.execute { baseURL in
+                let url = AuthEndpointResolver.resolve(baseURL: baseURL, path: "/api/v1/feedback")
+                var urlRequest = URLRequest(url: url)
+                urlRequest.httpMethod = "POST"
+                urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
+                if let token, !token.isEmpty {
+                    urlRequest.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+                }
+                urlRequest.httpBody = payload
+                urlRequest.timeoutInterval = 30
+                return urlRequest
+            }
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch CloudRequestExecutorError.allEndpointsFailed(let lastError) {
+            logger.error("Feedback submission failed on all endpoints: \(lastError.localizedDescription)")
+            throw FeedbackAPIError.networkError(lastError.localizedDescription)
+        } catch {
+            logger.error("Feedback submission network error: \(error.localizedDescription)")
+            throw FeedbackAPIError.networkError(error.localizedDescription)
+        }
+
+        let envelope: APIResponse<FeedbackSubmissionResponse>
+        do {
+            envelope = try JSONDecoder().decode(APIResponse<FeedbackSubmissionResponse>.self, from: data)
+        } catch {
+            logger.error("Feedback response decoding error: \(error.localizedDescription)")
+            throw FeedbackAPIError.invalidResponse
+        }
+
+        if httpResponse.statusCode == 401 {
+            throw FeedbackAPIError.unauthorized
+        }
+
+        guard httpResponse.statusCode >= 200, httpResponse.statusCode < 300,
+              envelope.code == "OK",
+              let responseData = envelope.data
+        else {
+            logger.error("Feedback submission failed with HTTP \(httpResponse.statusCode, privacy: .public)")
+            throw FeedbackAPIError.serverError(code: envelope.code, message: envelope.message)
+        }
+
+        return responseData
+    }
+}

--- a/Sources/Typeflux/Resources/en.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/en.lproj/Localizable.strings
@@ -23,9 +23,22 @@
 "sidebar.about" = "About";
 "sidebar.aboutAccessibility" = "About Typeflux";
 "sidebar.feedbackAccessibility" = "Send feedback";
+"sidebar.feedback.directOption" = "Direct feedback";
 "sidebar.feedback.emailOption" = "Send feedback email";
 "sidebar.feedback.githubOption" = "Open GitHub issue";
 "sidebar.settingsAccessibility" = "Open settings";
+
+"feedback.direct.title" = "Send feedback";
+"feedback.direct.subtitle" = "Describe the problem or suggestion. Typeflux will send it to the service and create an issue for follow-up.";
+"feedback.direct.contentLabel" = "Feedback";
+"feedback.direct.contentPlaceholder" = "What happened? Include the expected behavior, actual behavior, and any useful context.";
+"feedback.direct.contactLabel" = "Contact (optional)";
+"feedback.direct.contactPlaceholder" = "Email or other contact";
+"feedback.direct.submit" = "Submit";
+"feedback.toast.submitted" = "Feedback submitted. Thank you.";
+"feedback.error.emptyContent" = "Please enter feedback content.";
+"feedback.error.server" = "Failed to submit feedback.";
+"feedback.error.invalidResponse" = "Received an invalid feedback response.";
 
 "studio.section.home" = "Overview";
 "studio.section.models" = "Models";

--- a/Sources/Typeflux/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/ja.lproj/Localizable.strings
@@ -23,9 +23,22 @@
 "sidebar.about" = "について";
 "sidebar.aboutAccessibility" = "Typeflux について";
 "sidebar.feedbackAccessibility" = "フィードバック";
+"sidebar.feedback.directOption" = "直接フィードバック";
 "sidebar.feedback.emailOption" = "メールでフィードバックを送る";
 "sidebar.feedback.githubOption" = "GitHub Issue を作成する";
 "sidebar.settingsAccessibility" = "設定を開く";
+
+"feedback.direct.title" = "フィードバック";
+"feedback.direct.subtitle" = "問題や提案を入力してください。Typeflux がサーバーへ送信し、フォローアップ用の Issue を作成します。";
+"feedback.direct.contentLabel" = "フィードバック内容";
+"feedback.direct.contentPlaceholder" = "何が起きましたか？期待した動作、実際の動作、役立つ背景情報を入力してください。";
+"feedback.direct.contactLabel" = "連絡先（任意）";
+"feedback.direct.contactPlaceholder" = "メールアドレスまたは連絡先";
+"feedback.direct.submit" = "送信";
+"feedback.toast.submitted" = "フィードバックを送信しました。ありがとうございます。";
+"feedback.error.emptyContent" = "フィードバック内容を入力してください。";
+"feedback.error.server" = "フィードバックの送信に失敗しました。";
+"feedback.error.invalidResponse" = "フィードバックの応答が無効です。";
 
 "studio.section.home" = "概要";
 "studio.section.models" = "モデル";

--- a/Sources/Typeflux/Resources/ko.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/ko.lproj/Localizable.strings
@@ -23,9 +23,22 @@
 "sidebar.about" = "소개";
 "sidebar.aboutAccessibility" = "Typeflux 정보";
 "sidebar.feedbackAccessibility" = "문제 피드백";
+"sidebar.feedback.directOption" = "직접 피드백";
 "sidebar.feedback.emailOption" = "이메일로 문제 보내기";
 "sidebar.feedback.githubOption" = "GitHub 이슈 등록";
 "sidebar.settingsAccessibility" = "설정 열기";
+
+"feedback.direct.title" = "문제 피드백";
+"feedback.direct.subtitle" = "문제나 제안을 입력하세요. Typeflux가 서버로 전송하고 후속 조치를 위한 Issue를 생성합니다.";
+"feedback.direct.contentLabel" = "피드백 내용";
+"feedback.direct.contentPlaceholder" = "무슨 일이 있었나요? 기대한 동작, 실제 동작, 도움이 되는 맥락을 입력하세요.";
+"feedback.direct.contactLabel" = "연락처(선택 사항)";
+"feedback.direct.contactPlaceholder" = "이메일 또는 기타 연락처";
+"feedback.direct.submit" = "제출";
+"feedback.toast.submitted" = "피드백이 제출되었습니다. 감사합니다.";
+"feedback.error.emptyContent" = "피드백 내용을 입력하세요.";
+"feedback.error.server" = "피드백 제출에 실패했습니다.";
+"feedback.error.invalidResponse" = "피드백 응답이 올바르지 않습니다.";
 
 "studio.section.home" = "개요";
 "studio.section.models" = "모델";

--- a/Sources/Typeflux/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/zh-Hans.lproj/Localizable.strings
@@ -23,9 +23,22 @@
 "sidebar.about" = "关于";
 "sidebar.aboutAccessibility" = "关于 Typeflux";
 "sidebar.feedbackAccessibility" = "问题反馈";
+"sidebar.feedback.directOption" = "直接反馈";
 "sidebar.feedback.emailOption" = "发邮件反馈问题";
 "sidebar.feedback.githubOption" = "GitHub 提 Issue";
 "sidebar.settingsAccessibility" = "打开设置";
+
+"feedback.direct.title" = "问题反馈";
+"feedback.direct.subtitle" = "描述你遇到的问题或建议。Typeflux 会提交到服务端并创建 Issue 便于跟进。";
+"feedback.direct.contentLabel" = "反馈内容";
+"feedback.direct.contentPlaceholder" = "发生了什么？请包含预期行为、实际行为和有用的上下文。";
+"feedback.direct.contactLabel" = "联系方式（可选）";
+"feedback.direct.contactPlaceholder" = "邮箱或其他联系方式";
+"feedback.direct.submit" = "提交";
+"feedback.toast.submitted" = "反馈已提交，谢谢。";
+"feedback.error.emptyContent" = "请输入反馈内容。";
+"feedback.error.server" = "提交反馈失败。";
+"feedback.error.invalidResponse" = "收到的反馈响应无效。";
 
 "studio.section.home" = "概览";
 "studio.section.models" = "模型";

--- a/Sources/Typeflux/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/zh-Hant.lproj/Localizable.strings
@@ -23,9 +23,22 @@
 "sidebar.about" = "關於";
 "sidebar.aboutAccessibility" = "關於 Typeflux";
 "sidebar.feedbackAccessibility" = "問題回饋";
+"sidebar.feedback.directOption" = "直接回饋";
 "sidebar.feedback.emailOption" = "透過電子郵件回饋問題";
 "sidebar.feedback.githubOption" = "在 GitHub 提交 Issue";
 "sidebar.settingsAccessibility" = "打開設定";
+
+"feedback.direct.title" = "問題回饋";
+"feedback.direct.subtitle" = "描述你遇到的問題或建議。Typeflux 會提交到服務端並建立 Issue 方便後續追蹤。";
+"feedback.direct.contentLabel" = "回饋內容";
+"feedback.direct.contentPlaceholder" = "發生了什麼？請包含預期行為、實際行為和有用的上下文。";
+"feedback.direct.contactLabel" = "聯絡方式（選填）";
+"feedback.direct.contactPlaceholder" = "電子郵件或其他聯絡方式";
+"feedback.direct.submit" = "提交";
+"feedback.toast.submitted" = "回饋已提交，謝謝。";
+"feedback.error.emptyContent" = "請輸入回饋內容。";
+"feedback.error.server" = "提交回饋失敗。";
+"feedback.error.invalidResponse" = "收到的回饋回應無效。";
 
 "studio.section.home" = "總覽";
 "studio.section.models" = "模型";

--- a/Sources/Typeflux/Settings/SettingsView.swift
+++ b/Sources/Typeflux/Settings/SettingsView.swift
@@ -197,6 +197,11 @@ struct StudioView: View {
     @State private var agentJobPendingDeletion: AgentJob?
     @State private var showingClearAllJobsConfirmation = false
     @State private var showingClearHistoryConfirmation = false
+    @State private var isDirectFeedbackPresented = false
+    @State private var feedbackContent = ""
+    @State private var feedbackContact = ""
+    @State private var isSubmittingFeedback = false
+    @State private var feedbackSubmissionError: String?
     @State private var agentConfigurationTab: AgentConfigurationTab = .general
     @State private var isAdvancedSettingsExpanded = false
     @ObservedObject private var localization = AppLocalization.shared
@@ -207,6 +212,7 @@ struct StudioView: View {
             currentSection: viewModel.currentSection,
             onSelect: viewModel.navigate,
             onOpenAbout: { AboutWindowController.shared.show() },
+            onSendDirectFeedback: openDirectFeedback,
             onSendFeedbackEmail: sendFeedbackEmail,
             onOpenGitHubIssue: openGitHubIssue,
             onAccountAction: handleAccountAction,
@@ -363,6 +369,30 @@ struct StudioView: View {
         .sheet(isPresented: $viewModel.showingJobsPage) {
             agentJobsSheet
         }
+        .sheet(isPresented: $isDirectFeedbackPresented) {
+            directFeedbackSheet
+        }
+    }
+
+    private var directFeedbackSheet: some View {
+        DirectFeedbackSheet(
+            content: $feedbackContent,
+            contact: $feedbackContact,
+            isSubmitting: isSubmittingFeedback,
+            errorMessage: feedbackSubmissionError,
+            onCancel: {
+                isDirectFeedbackPresented = false
+            },
+            onSubmit: submitDirectFeedback
+        )
+    }
+
+    private func openDirectFeedback() {
+        feedbackContent = ""
+        feedbackContact = authState.userProfile?.email ?? ""
+        feedbackSubmissionError = nil
+        isSubmittingFeedback = false
+        isDirectFeedbackPresented = true
     }
 
     private func sendFeedbackEmail() {
@@ -383,6 +413,28 @@ struct StudioView: View {
     private func openGitHubIssue() {
         guard let url = URL(string: "https://github.com/mylxsw/typeflux/issues/new") else { return }
         NSWorkspace.shared.open(url)
+    }
+
+    private func submitDirectFeedback() {
+        let content = feedbackContent
+        let contact = feedbackContact
+        let token = authState.accessToken
+        isSubmittingFeedback = true
+        feedbackSubmissionError = nil
+
+        Task { @MainActor in
+            do {
+                _ = try await FeedbackAPIService.submit(content: content, contact: contact, token: token)
+                isSubmittingFeedback = false
+                isDirectFeedbackPresented = false
+                feedbackContent = ""
+                feedbackContact = ""
+                viewModel.showToast(L("feedback.toast.submitted"))
+            } catch {
+                isSubmittingFeedback = false
+                feedbackSubmissionError = error.localizedDescription
+            }
+        }
     }
 
     private func handleAccountAction() {

--- a/Sources/Typeflux/Settings/SettingsViewModel.swift
+++ b/Sources/Typeflux/Settings/SettingsViewModel.swift
@@ -2526,7 +2526,7 @@ final class StudioViewModel: ObservableObject {
         }
     }
 
-    private func showToast(_ text: String) {
+    func showToast(_ text: String) {
         toastMessage = text
         Task {
             try? await Task.sleep(nanoseconds: 2_200_000_000)

--- a/Sources/Typeflux/UI/StudioComponents.swift
+++ b/Sources/Typeflux/UI/StudioComponents.swift
@@ -552,6 +552,7 @@ struct StudioShell<Content: View>: View {
     let currentSection: StudioSection
     let onSelect: (StudioSection) -> Void
     let onOpenAbout: () -> Void
+    let onSendDirectFeedback: () -> Void
     let onSendFeedbackEmail: () -> Void
     let onOpenGitHubIssue: () -> Void
     let onAccountAction: () -> Void
@@ -565,6 +566,7 @@ struct StudioShell<Content: View>: View {
         currentSection: StudioSection,
         onSelect: @escaping (StudioSection) -> Void,
         onOpenAbout: @escaping () -> Void,
+        onSendDirectFeedback: @escaping () -> Void,
         onSendFeedbackEmail: @escaping () -> Void,
         onOpenGitHubIssue: @escaping () -> Void,
         onAccountAction: @escaping () -> Void,
@@ -577,6 +579,7 @@ struct StudioShell<Content: View>: View {
         self.currentSection = currentSection
         self.onSelect = onSelect
         self.onOpenAbout = onOpenAbout
+        self.onSendDirectFeedback = onSendDirectFeedback
         self.onSendFeedbackEmail = onSendFeedbackEmail
         self.onOpenGitHubIssue = onOpenGitHubIssue
         self.onAccountAction = onAccountAction
@@ -596,6 +599,7 @@ struct StudioShell<Content: View>: View {
                 StudioSidebar(
                     currentSection: currentSection,
                     onSelect: onSelect,
+                    onSendDirectFeedback: onSendDirectFeedback,
                     onSendFeedbackEmail: onSendFeedbackEmail,
                     onOpenGitHubIssue: onOpenGitHubIssue,
                     onOpenAbout: onOpenAbout,
@@ -689,6 +693,7 @@ struct StudioGlassBackground: View {
 struct StudioSidebar: View {
     let currentSection: StudioSection
     let onSelect: (StudioSection) -> Void
+    let onSendDirectFeedback: () -> Void
     let onSendFeedbackEmail: () -> Void
     let onOpenGitHubIssue: () -> Void
     let onOpenAbout: () -> Void
@@ -809,6 +814,7 @@ struct StudioSidebar: View {
             systemImage: "envelope.stack",
             accessibilityLabel: L("sidebar.feedbackAccessibility"),
         ) {
+            Button(L("sidebar.feedback.directOption"), action: onSendDirectFeedback)
             Button(L("sidebar.feedback.emailOption"), action: onSendFeedbackEmail)
             Button(L("sidebar.feedback.githubOption"), action: onOpenGitHubIssue)
         }

--- a/Tests/TypefluxTests/FeedbackAPIServiceTests.swift
+++ b/Tests/TypefluxTests/FeedbackAPIServiceTests.swift
@@ -1,0 +1,229 @@
+@testable import Typeflux
+import XCTest
+
+final class FeedbackAPIServiceTests: XCTestCase {
+    private let baseURL = URL(string: "https://api.example")!
+
+    func testCreateFeedbackRequestEncodesSnakeCaseImageURLs() throws {
+        let request = CreateFeedbackRequest(
+            content: "App crashed",
+            contact: "user@example.com",
+            imageURLs: ["https://example.com/image.png"]
+        )
+
+        let data = try JSONEncoder().encode(request)
+        let dict = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+
+        XCTAssertEqual(dict?["content"] as? String, "App crashed")
+        XCTAssertEqual(dict?["contact"] as? String, "user@example.com")
+        XCTAssertEqual(dict?["image_urls"] as? [String], ["https://example.com/image.png"])
+        XCTAssertNil(dict?["imageURLs"])
+    }
+
+    func testSubmitPostsFeedbackToCloudEndpoint() async throws {
+        let session = FeedbackStubSession()
+        await session.setHandler { request in
+            XCTAssertEqual(request.url?.absoluteString, "https://api.example/api/v1/feedback")
+            XCTAssertEqual(request.httpMethod, "POST")
+            XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "application/json")
+            XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer token-1")
+
+            let body = try XCTUnwrap(request.httpBody)
+            let dict = try JSONSerialization.jsonObject(with: body) as? [String: Any]
+            XCTAssertEqual(dict?["content"] as? String, "Please fix this")
+            XCTAssertEqual(dict?["contact"] as? String, "user@example.com")
+
+            let payload = Data(#"{"code":"OK","data":{"id":"feedback-1","status":"pending"}}"#.utf8)
+            return (payload, Self.httpResponse(url: request.url!, status: 200))
+        }
+        let executor = makeExecutor(session: session)
+
+        let response = try await FeedbackAPIService.submit(
+            content: "  Please fix this  ",
+            contact: " user@example.com ",
+            token: "token-1",
+            executor: executor
+        )
+
+        XCTAssertEqual(response, FeedbackSubmissionResponse(id: "feedback-1", status: "pending"))
+    }
+
+    func testSubmitOmitsAuthorizationAndBlankContactForAnonymousFeedback() async throws {
+        let session = FeedbackStubSession()
+        await session.setHandler { request in
+            XCTAssertNil(request.value(forHTTPHeaderField: "Authorization"))
+
+            let body = try XCTUnwrap(request.httpBody)
+            let dict = try JSONSerialization.jsonObject(with: body) as? [String: Any]
+            XCTAssertEqual(dict?["content"] as? String, "Anonymous report")
+            XCTAssertNil(dict?["contact"])
+
+            let payload = Data(#"{"code":"OK","data":{"id":"feedback-2","status":"pending"}}"#.utf8)
+            return (payload, Self.httpResponse(url: request.url!, status: 200))
+        }
+        let executor = makeExecutor(session: session)
+
+        let response = try await FeedbackAPIService.submit(
+            content: "Anonymous report",
+            contact: "   ",
+            token: nil,
+            executor: executor
+        )
+
+        XCTAssertEqual(response, FeedbackSubmissionResponse(id: "feedback-2", status: "pending"))
+    }
+
+    func testSubmitRejectsEmptyContentBeforeNetworkRequest() async throws {
+        let session = FeedbackStubSession()
+        let executor = makeExecutor(session: session)
+
+        do {
+            _ = try await FeedbackAPIService.submit(content: "   ", contact: nil, executor: executor)
+            XCTFail("Expected empty content error")
+        } catch let error as FeedbackAPIError {
+            XCTAssertEqual(error, .emptyContent)
+        }
+
+        let callCount = await session.callCount
+        XCTAssertEqual(callCount, 0)
+    }
+
+    func testSubmitMapsUnauthorizedResponse() async throws {
+        let session = FeedbackStubSession()
+        await session.setHandler { request in
+            let payload = Data(#"{"code":"UNAUTHORIZED","message":"Sign in required","data":null}"#.utf8)
+            return (payload, Self.httpResponse(url: request.url!, status: 401))
+        }
+        let executor = makeExecutor(session: session)
+
+        do {
+            _ = try await FeedbackAPIService.submit(content: "Please fix this", contact: nil, executor: executor)
+            XCTFail("Expected unauthorized error")
+        } catch let error as FeedbackAPIError {
+            XCTAssertEqual(error, .unauthorized)
+        }
+    }
+
+    func testSubmitMapsServerErrorMessage() async throws {
+        let session = FeedbackStubSession()
+        await session.setHandler { request in
+            let payload = Data(#"{"code":"VALIDATION_ERROR","message":"Content is too long","data":null}"#.utf8)
+            return (payload, Self.httpResponse(url: request.url!, status: 400))
+        }
+        let executor = makeExecutor(session: session)
+
+        do {
+            _ = try await FeedbackAPIService.submit(content: "Please fix this", contact: nil, executor: executor)
+            XCTFail("Expected server error")
+        } catch let error as FeedbackAPIError {
+            XCTAssertEqual(error, .serverError(code: "VALIDATION_ERROR", message: "Content is too long"))
+        }
+    }
+
+    func testSubmitMapsInvalidJSONToInvalidResponse() async throws {
+        let session = FeedbackStubSession()
+        await session.setHandler { request in
+            (Data("not json".utf8), Self.httpResponse(url: request.url!, status: 200))
+        }
+        let executor = makeExecutor(session: session)
+
+        do {
+            _ = try await FeedbackAPIService.submit(content: "Please fix this", contact: nil, executor: executor)
+            XCTFail("Expected invalid response error")
+        } catch let error as FeedbackAPIError {
+            XCTAssertEqual(error, .invalidResponse)
+        }
+    }
+
+    func testSubmitMapsNetworkFailure() async throws {
+        let session = FeedbackStubSession()
+        await session.setHandler { _ in
+            throw URLError(.notConnectedToInternet)
+        }
+        let executor = makeExecutor(session: session)
+
+        do {
+            _ = try await FeedbackAPIService.submit(content: "Please fix this", contact: nil, executor: executor)
+            XCTFail("Expected network error")
+        } catch let error as FeedbackAPIError {
+            guard case .networkError(let message) = error else {
+                XCTFail("Expected network error, got \(error)")
+                return
+            }
+            XCTAssertFalse(message.isEmpty)
+        }
+    }
+
+    func testSubmitFailsOverAfterHTTP500() async throws {
+        let fallbackURL = URL(string: "https://api-fallback.example")!
+        let session = FeedbackStubSession()
+        await session.setHandler { request in
+            if request.url?.host == "api.example" {
+                let payload = Data(#"{"code":"SERVER_ERROR","message":"Try later","data":null}"#.utf8)
+                return (payload, Self.httpResponse(url: request.url!, status: 500))
+            }
+
+            let payload = Data(#"{"code":"OK","data":{"id":"feedback-3","status":"pending"}}"#.utf8)
+            return (payload, Self.httpResponse(url: request.url!, status: 200))
+        }
+        let executor = makeExecutor(session: session, baseURLs: [baseURL, fallbackURL])
+
+        let response = try await FeedbackAPIService.submit(
+            content: "Please fix this",
+            contact: nil,
+            executor: executor
+        )
+
+        XCTAssertEqual(response, FeedbackSubmissionResponse(id: "feedback-3", status: "pending"))
+        let requestedHosts = await session.requestedHosts
+        XCTAssertEqual(requestedHosts, ["api.example", "api-fallback.example"])
+    }
+
+    private func makeExecutor(
+        session: FeedbackStubSession,
+        baseURLs: [URL]? = nil
+    ) -> CloudRequestExecutor {
+        let selector = CloudEndpointSelector(baseURLs: baseURLs ?? [baseURL], prober: FeedbackNoOpProber())
+        return CloudRequestExecutor(selector: selector, session: session)
+    }
+}
+
+private actor FeedbackStubSession: CloudHTTPSession {
+    typealias Handler = @Sendable (URLRequest) async throws -> (Data, URLResponse)
+
+    private var handler: Handler?
+    private(set) var callCount = 0
+    private(set) var requestedHosts: [String] = []
+
+    func setHandler(_ handler: @escaping Handler) {
+        self.handler = handler
+    }
+
+    func data(for request: URLRequest) async throws -> (Data, URLResponse) {
+        callCount += 1
+        if let host = request.url?.host {
+            requestedHosts.append(host)
+        }
+        guard let handler else {
+            throw URLError(.badServerResponse)
+        }
+        return try await handler(request)
+    }
+}
+
+private struct FeedbackNoOpProber: CloudEndpointProbing {
+    func probe(baseURL: URL, nonce: String, timeout: TimeInterval) async throws -> CloudEndpointProbeResult {
+        CloudEndpointProbeResult(latencyMs: 1, serverID: nil, serverVersion: nil, nonceMatches: true)
+    }
+}
+
+private extension FeedbackAPIServiceTests {
+    static func httpResponse(url: URL, status: Int) -> HTTPURLResponse {
+        HTTPURLResponse(
+            url: url,
+            statusCode: status,
+            httpVersion: nil,
+            headerFields: nil
+        )!
+    }
+}


### PR DESCRIPTION
## Summary
- Add the Direct feedback option to the sidebar feedback menu and present an in-app feedback sheet.
- Submit feedback to Typeflux Cloud via `POST /api/v1/feedback`, including optional contact and bearer token when available.
- Add localized sheet copy, editor placeholder, success toast, and focused API coverage for happy path, anonymous submission, auth/server/network/decode errors, and 5xx failover.

## How to test
- `swift test --filter TypefluxTests.FeedbackAPIServiceTests`
- `swift test --filter TypefluxTests.LocalizationResourceTests`

Refs TYP-74