### PR TITLE
feat: handle Typeflux Cloud error codes

### DIFF
--- a/Sources/Typeflux/Auth/AuthModels.swift
+++ b/Sources/Typeflux/Auth/AuthModels.swift
@@ -197,8 +197,12 @@ enum AuthError: LocalizedError {
         switch self {
         case .networkError(let error):
             error.localizedDescription
-        case .serverError(_, let message):
-            message ?? L("auth.error.unknown")
+        case .serverError(let code, let message):
+            TypefluxCloudServerErrorMessage.userMessage(
+                code: code,
+                message: message,
+                fallback: L("auth.error.unknown")
+            )
         case .invalidResponse:
             L("auth.error.invalidResponse")
         case .unauthorized:

--- a/Sources/Typeflux/Feedback/FeedbackAPIService.swift
+++ b/Sources/Typeflux/Feedback/FeedbackAPIService.swift
@@ -36,8 +36,12 @@ enum FeedbackAPIError: LocalizedError, Equatable {
             L("feedback.error.emptyContent")
         case .networkError(let message):
             message
-        case .serverError(_, let message):
-            message ?? L("feedback.error.server")
+        case .serverError(let code, let message):
+            TypefluxCloudServerErrorMessage.userMessage(
+                code: code,
+                message: message,
+                fallback: L("feedback.error.server")
+            )
         case .invalidResponse:
             L("feedback.error.invalidResponse")
         case .unauthorized:

--- a/Sources/Typeflux/Networking/TypefluxCloudServerErrorMessage.swift
+++ b/Sources/Typeflux/Networking/TypefluxCloudServerErrorMessage.swift
@@ -1,0 +1,61 @@
+import Foundation
+
+enum TypefluxCloudServerErrorMessage {
+    static func userMessage(code: String, message: String?, fallback: String) -> String {
+        if let key = localizationKey(for: code) {
+            return L(key)
+        }
+
+        let trimmedMessage = message?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return trimmedMessage.isEmpty ? fallback : trimmedMessage
+    }
+
+    static func localizationKey(for code: String) -> String? {
+        let normalizedCode = normalized(code)
+
+        switch normalizedCode {
+        case "AUTH_INVALID_CREDENTIALS":
+            return "cloud.error.authInvalidCredentials"
+        case "AUTH_USER_EXISTS":
+            return "cloud.error.authUserExists"
+        case "AUTH_USER_NOT_ACTIVE":
+            return "cloud.error.authUserNotActive"
+        case "AUTH_CODE_INVALID",
+             "AUTH_ACTIVATION_CODE_INVALID",
+             "AUTH_RESET_CODE_INVALID",
+             "AUTH_PASSWORD_RESET_CODE_INVALID":
+            return "cloud.error.authCodeInvalid"
+        case "AUTH_REFRESH_TOKEN_INVALID", "AUTH_REFRESH_TOKEN_REUSED", "USER_NOT_FOUND", "AUTH_USER_NOT_FOUND":
+            return "cloud.error.sessionExpired"
+        case "VALIDATION_ERROR", "BAD_REQUEST", "INVALID_REQUEST":
+            return "cloud.error.validation"
+        case "RATE_LIMITED", "RATE_LIMIT_EXCEEDED", "TOO_MANY_REQUESTS":
+            return "cloud.error.rateLimited"
+        case "QUOTA_EXCEEDED",
+             "ASR_QUOTA_EXCEEDED",
+             "LLM_QUOTA_EXCEEDED",
+             "INSUFFICIENT_CREDITS",
+             "CREDIT_EXHAUSTED":
+            return "cloud.error.quotaExceeded"
+        case "PLAN_REQUIRED", "SUBSCRIPTION_REQUIRED":
+            return "cloud.error.planRequired"
+        case "SERVER_ERROR", "INTERNAL", "INTERNAL_SERVER_ERROR":
+            return "cloud.error.server"
+        default:
+            if normalizedCode.hasSuffix("_RATE_LIMITED") || normalizedCode.hasSuffix("_RATE_LIMIT_EXCEEDED") {
+                return "cloud.error.rateLimited"
+            }
+            if normalizedCode.hasSuffix("_QUOTA_EXCEEDED") {
+                return "cloud.error.quotaExceeded"
+            }
+            return nil
+        }
+    }
+
+    private static func normalized(_ code: String) -> String {
+        code.trimmingCharacters(in: .whitespacesAndNewlines)
+            .replacingOccurrences(of: "-", with: "_")
+            .replacingOccurrences(of: ".", with: "_")
+            .uppercased()
+    }
+}

--- a/Sources/Typeflux/Resources/en.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/en.lproj/Localizable.strings
@@ -994,6 +994,16 @@
 "auth.error.unknown" = "An unknown error occurred.";
 "auth.error.invalidResponse" = "Invalid server response.";
 "auth.error.unauthorized" = "Session expired. Please sign in again.";
+"cloud.error.authInvalidCredentials" = "The email or password is incorrect.";
+"cloud.error.authUserExists" = "An account already exists for this email.";
+"cloud.error.authUserNotActive" = "Please activate your account before signing in.";
+"cloud.error.authCodeInvalid" = "The verification code is invalid or has expired.";
+"cloud.error.sessionExpired" = "Session expired. Please sign in again.";
+"cloud.error.validation" = "The request was invalid. Please check the input and try again.";
+"cloud.error.rateLimited" = "Too many requests. Please wait a moment and try again.";
+"cloud.error.quotaExceeded" = "Your Typeflux Cloud usage quota has been exhausted.";
+"cloud.error.planRequired" = "Your current plan does not include this Typeflux Cloud feature.";
+"cloud.error.server" = "Typeflux Cloud is temporarily unavailable. Please try again later.";
 
 "auth.account.provider" = "Login Method";
 "auth.account.memberSince" = "Member Since";

--- a/Sources/Typeflux/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/ja.lproj/Localizable.strings
@@ -983,6 +983,16 @@
 "auth.error.unknown" = "不明なエラーが発生しました。";
 "auth.error.invalidResponse" = "サーバーの応答が無効です。";
 "auth.error.unauthorized" = "セッションが期限切れです。再度サインインしてください。";
+"cloud.error.authInvalidCredentials" = "メールアドレスまたはパスワードが正しくありません。";
+"cloud.error.authUserExists" = "このメールアドレスのアカウントはすでに存在します。";
+"cloud.error.authUserNotActive" = "サインインする前にアカウントを有効化してください。";
+"cloud.error.authCodeInvalid" = "確認コードが無効または期限切れです。";
+"cloud.error.sessionExpired" = "セッションが期限切れです。再度サインインしてください。";
+"cloud.error.validation" = "リクエストが無効です。入力内容を確認してもう一度お試しください。";
+"cloud.error.rateLimited" = "リクエストが多すぎます。しばらく待ってからもう一度お試しください。";
+"cloud.error.quotaExceeded" = "Typeflux Cloud の利用枠を使い切りました。";
+"cloud.error.planRequired" = "現在のプランではこの Typeflux Cloud 機能を利用できません。";
+"cloud.error.server" = "Typeflux Cloud は一時的に利用できません。後でもう一度お試しください。";
 
 "auth.account.provider" = "ログイン方法";
 "auth.account.memberSince" = "登録日";

--- a/Sources/Typeflux/Resources/ko.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/ko.lproj/Localizable.strings
@@ -983,6 +983,16 @@
 "auth.error.unknown" = "알 수 없는 오류가 발생했습니다.";
 "auth.error.invalidResponse" = "서버 응답이 잘못되었습니다.";
 "auth.error.unauthorized" = "세션이 만료되었습니다. 다시 로그인해 주세요.";
+"cloud.error.authInvalidCredentials" = "이메일 또는 비밀번호가 올바르지 않습니다.";
+"cloud.error.authUserExists" = "이 이메일로 가입된 계정이 이미 있습니다.";
+"cloud.error.authUserNotActive" = "로그인하기 전에 계정을 활성화해 주세요.";
+"cloud.error.authCodeInvalid" = "인증 코드가 잘못되었거나 만료되었습니다.";
+"cloud.error.sessionExpired" = "세션이 만료되었습니다. 다시 로그인해 주세요.";
+"cloud.error.validation" = "요청이 올바르지 않습니다. 입력을 확인한 뒤 다시 시도해 주세요.";
+"cloud.error.rateLimited" = "요청이 너무 많습니다. 잠시 후 다시 시도해 주세요.";
+"cloud.error.quotaExceeded" = "Typeflux Cloud 사용 한도를 모두 사용했습니다.";
+"cloud.error.planRequired" = "현재 요금제에는 이 Typeflux Cloud 기능이 포함되어 있지 않습니다.";
+"cloud.error.server" = "Typeflux Cloud를 일시적으로 사용할 수 없습니다. 나중에 다시 시도해 주세요.";
 
 "auth.account.provider" = "로그인 방법";
 "auth.account.memberSince" = "가입일";

--- a/Sources/Typeflux/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/zh-Hans.lproj/Localizable.strings
@@ -994,6 +994,16 @@
 "auth.error.unknown" = "发生了未知错误。";
 "auth.error.invalidResponse" = "服务器响应无效。";
 "auth.error.unauthorized" = "登录已过期，请重新登录。";
+"cloud.error.authInvalidCredentials" = "邮箱或密码不正确。";
+"cloud.error.authUserExists" = "该邮箱已注册账号。";
+"cloud.error.authUserNotActive" = "请先激活账号后再登录。";
+"cloud.error.authCodeInvalid" = "验证码无效或已过期。";
+"cloud.error.sessionExpired" = "登录已过期，请重新登录。";
+"cloud.error.validation" = "请求无效，请检查输入后重试。";
+"cloud.error.rateLimited" = "请求过于频繁，请稍后再试。";
+"cloud.error.quotaExceeded" = "Typeflux Cloud 使用额度已用完。";
+"cloud.error.planRequired" = "当前套餐不包含此 Typeflux Cloud 功能。";
+"cloud.error.server" = "Typeflux Cloud 暂时不可用，请稍后再试。";
 
 "auth.account.provider" = "登录方式";
 "auth.account.memberSince" = "注册时间";

--- a/Sources/Typeflux/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/zh-Hant.lproj/Localizable.strings
@@ -990,6 +990,16 @@
 "auth.error.unknown" = "發生了未知錯誤。";
 "auth.error.invalidResponse" = "伺服器回應無效。";
 "auth.error.unauthorized" = "登入已過期，請重新登入。";
+"cloud.error.authInvalidCredentials" = "電子郵件或密碼不正確。";
+"cloud.error.authUserExists" = "此電子郵件已註冊帳號。";
+"cloud.error.authUserNotActive" = "請先啟用帳號後再登入。";
+"cloud.error.authCodeInvalid" = "驗證碼無效或已過期。";
+"cloud.error.sessionExpired" = "登入已過期，請重新登入。";
+"cloud.error.validation" = "請求無效，請檢查輸入後重試。";
+"cloud.error.rateLimited" = "請求過於頻繁，請稍後再試。";
+"cloud.error.quotaExceeded" = "Typeflux Cloud 使用額度已用完。";
+"cloud.error.planRequired" = "目前方案不包含此 Typeflux Cloud 功能。";
+"cloud.error.server" = "Typeflux Cloud 暫時無法使用，請稍後再試。";
 
 "auth.account.provider" = "登入方式";
 "auth.account.memberSince" = "註冊時間";

--- a/Sources/Typeflux/STT/TypefluxOfficialASRRoutingClient.swift
+++ b/Sources/Typeflux/STT/TypefluxOfficialASRRoutingClient.swift
@@ -44,8 +44,12 @@ enum TypefluxOfficialASRRoutingError: LocalizedError, Equatable {
             "Received an invalid Typeflux Cloud ASR routing response."
         case .unauthorized:
             "Please sign in to use Typeflux Cloud speech recognition."
-        case .serverError(_, let message):
-            message ?? "Typeflux Cloud ASR routing request failed."
+        case .serverError(let code, let message):
+            TypefluxCloudServerErrorMessage.userMessage(
+                code: code,
+                message: message,
+                fallback: "Typeflux Cloud ASR routing request failed."
+            )
         case .unknownRouteType(let type):
             "Unknown Typeflux Cloud ASR route type: \(type)"
         case .missingAliyunToken:

--- a/Tests/TypefluxTests/AuthModelsTests.swift
+++ b/Tests/TypefluxTests/AuthModelsTests.swift
@@ -306,11 +306,15 @@ final class AuthModelsTests: XCTestCase {
     // MARK: - AuthError
 
     func testAuthErrorDescriptions() {
+        let originalLanguage = AppLocalization.shared.language
+        AppLocalization.shared.setLanguage(.english)
+        defer { AppLocalization.shared.setLanguage(originalLanguage) }
+
         let networkError = AuthError.networkError(URLError(.notConnectedToInternet))
         XCTAssertNotNil(networkError.errorDescription)
 
         let serverError = AuthError.serverError(code: "AUTH_USER_EXISTS", message: "User exists")
-        XCTAssertEqual(serverError.errorDescription, "User exists")
+        XCTAssertEqual(serverError.errorDescription, "An account already exists for this email.")
         XCTAssertEqual(serverError.authErrorCode, "AUTH_USER_EXISTS")
 
         let invalidResponse = AuthError.invalidResponse
@@ -329,14 +333,22 @@ final class AuthModelsTests: XCTestCase {
     }
 
     func testAuthErrorRefreshTokenInvalidCode() {
+        let originalLanguage = AppLocalization.shared.language
+        AppLocalization.shared.setLanguage(.english)
+        defer { AppLocalization.shared.setLanguage(originalLanguage) }
+
         let error = AuthError.serverError(code: "AUTH_REFRESH_TOKEN_INVALID", message: "invalid or expired refresh token")
         XCTAssertEqual(error.authErrorCode, "AUTH_REFRESH_TOKEN_INVALID")
-        XCTAssertEqual(error.errorDescription, "invalid or expired refresh token")
+        XCTAssertEqual(error.errorDescription, "Session expired. Please sign in again.")
     }
 
     func testAuthErrorRefreshTokenReusedCode() {
+        let originalLanguage = AppLocalization.shared.language
+        AppLocalization.shared.setLanguage(.english)
+        defer { AppLocalization.shared.setLanguage(originalLanguage) }
+
         let error = AuthError.serverError(code: "AUTH_REFRESH_TOKEN_REUSED", message: "refresh token already used")
         XCTAssertEqual(error.authErrorCode, "AUTH_REFRESH_TOKEN_REUSED")
-        XCTAssertEqual(error.errorDescription, "refresh token already used")
+        XCTAssertEqual(error.errorDescription, "Session expired. Please sign in again.")
     }
 }

--- a/Tests/TypefluxTests/FeedbackAPIServiceTests.swift
+++ b/Tests/TypefluxTests/FeedbackAPIServiceTests.swift
@@ -105,6 +105,10 @@ final class FeedbackAPIServiceTests: XCTestCase {
     }
 
     func testSubmitMapsServerErrorMessage() async throws {
+        let originalLanguage = AppLocalization.shared.language
+        AppLocalization.shared.setLanguage(.english)
+        defer { AppLocalization.shared.setLanguage(originalLanguage) }
+
         let session = FeedbackStubSession()
         await session.setHandler { request in
             let payload = Data(#"{"code":"VALIDATION_ERROR","message":"Content is too long","data":null}"#.utf8)
@@ -117,6 +121,7 @@ final class FeedbackAPIServiceTests: XCTestCase {
             XCTFail("Expected server error")
         } catch let error as FeedbackAPIError {
             XCTAssertEqual(error, .serverError(code: "VALIDATION_ERROR", message: "Content is too long"))
+            XCTAssertEqual(error.errorDescription, "The request was invalid. Please check the input and try again.")
         }
     }
 

--- a/Tests/TypefluxTests/TypefluxCloudServerErrorMessageTests.swift
+++ b/Tests/TypefluxTests/TypefluxCloudServerErrorMessageTests.swift
@@ -1,0 +1,52 @@
+@testable import Typeflux
+import XCTest
+
+final class TypefluxCloudServerErrorMessageTests: XCTestCase {
+    func testKnownCodeUsesLocalizedMessageInsteadOfServerMessage() {
+        withEnglishLocalization {
+            let message = TypefluxCloudServerErrorMessage.userMessage(
+                code: "AUTH_INVALID_CREDENTIALS",
+                message: "raw backend message",
+                fallback: "fallback"
+            )
+
+            XCTAssertEqual(message, "The email or password is incorrect.")
+        }
+    }
+
+    func testCodeNormalizationAcceptsHyphenatedLowercaseValues() {
+        XCTAssertEqual(
+            TypefluxCloudServerErrorMessage.localizationKey(for: "auth-invalid-credentials"),
+            "cloud.error.authInvalidCredentials"
+        )
+    }
+
+    func testCodeFamilyFallbackHandlesProviderSpecificQuotaCodes() {
+        XCTAssertEqual(
+            TypefluxCloudServerErrorMessage.localizationKey(for: "asr_daily_quota_exceeded"),
+            "cloud.error.quotaExceeded"
+        )
+    }
+
+    func testUnknownCodeUsesTrimmedServerMessageThenFallback() {
+        XCTAssertEqual(
+            TypefluxCloudServerErrorMessage.userMessage(
+                code: "CUSTOM_ERROR",
+                message: "  Custom failure  ",
+                fallback: "fallback"
+            ),
+            "Custom failure"
+        )
+        XCTAssertEqual(
+            TypefluxCloudServerErrorMessage.userMessage(code: "CUSTOM_ERROR", message: "  ", fallback: "fallback"),
+            "fallback"
+        )
+    }
+
+    private func withEnglishLocalization(_ body: () -> Void) {
+        let originalLanguage = AppLocalization.shared.language
+        AppLocalization.shared.setLanguage(.english)
+        defer { AppLocalization.shared.setLanguage(originalLanguage) }
+        body()
+    }
+}

--- a/Tests/TypefluxTests/TypefluxOfficialASRRoutingClientTests.swift
+++ b/Tests/TypefluxTests/TypefluxOfficialASRRoutingClientTests.swift
@@ -68,6 +68,29 @@ final class TypefluxOfficialASRRoutingClientTests: XCTestCase {
         )
     }
 
+    func testFetchRouteMapsKnownServerErrorCodeForUserDescription() async throws {
+        let originalLanguage = AppLocalization.shared.language
+        AppLocalization.shared.setLanguage(.english)
+        defer { AppLocalization.shared.setLanguage(originalLanguage) }
+
+        let session = RoutingStubSession()
+        await session.setHandler { request in
+            (
+                Data(#"{"code":"ASR_QUOTA_EXCEEDED","message":"raw quota message","data":null}"#.utf8),
+                Self.httpResponse(url: request.url!, status: 429)
+            )
+        }
+        let client = makeClient(session: session)
+
+        do {
+            _ = try await client.fetchRoute(accessToken: "cloud-token", scenario: .voiceInput)
+            XCTFail("Expected server error")
+        } catch let error as TypefluxOfficialASRRoutingError {
+            XCTAssertEqual(error, .serverError(code: "ASR_QUOTA_EXCEEDED", message: "raw quota message"))
+            XCTAssertEqual(error.errorDescription, "Your Typeflux Cloud usage quota has been exhausted.")
+        }
+    }
+
     func testAudioDurationMeterUsesPCM16MonoAt16K() {
         XCTAssertEqual(TypefluxOfficialASRUsageMeter.audioDurationMilliseconds(pcm16ByteCount: 0), 0)
         XCTAssertEqual(TypefluxOfficialASRUsageMeter.audioDurationMilliseconds(pcm16ByteCount: 3_200), 100)

--- a/Tests/TypefluxTests/WorkflowControllerProcessingTests.swift
+++ b/Tests/TypefluxTests/WorkflowControllerProcessingTests.swift
@@ -416,6 +416,9 @@ final class WorkflowControllerProcessingTests: XCTestCase {
         XCTAssertEqual(controller.recordingMode, .holdToTalk)
         XCTAssertEqual(audioRecorder.startCallCount, 1)
         XCTAssertEqual(audioRecorder.stopCallCount, 0)
+        await MainActor.run {
+            controller.overlayController.dismissImmediately()
+        }
     }
 
     func testReleasingAfterImmediateAudioStartStopsRecorder() async {


### PR DESCRIPTION
## Summary
- References TYP-75.
- Add a shared Typeflux Cloud server error-code mapper with normalization for known auth, validation, rate limit, quota, plan, and server error codes.
- Use mapped user-facing messages in auth, feedback, and Typeflux Cloud ASR routing errors while preserving raw server messages for unknown codes.
- Add localized copy for all supported app languages and focused unit coverage.

## How to test
- swift test --filter TypefluxCloudServerErrorMessageTests --filter AuthModelsTests --filter FeedbackAPIServiceTests --filter TypefluxOfficialASRRoutingClientTests
- swift test --filter LocalizationResourceTests

## Screenshots
- Not applicable: no UI layout changes.