### PR TITLE
feat: add Intel release packaging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,9 @@
 name: Release
 
 on:
+  pull_request:
+    branches:
+      - main
   release:
     types:
       - published
@@ -16,9 +19,22 @@ permissions:
   contents: write
 
 jobs:
-  build-signed-macos-app:
+  x86_64-release-build-smoke:
+    if: github.event_name == 'pull_request'
     runs-on: macos-latest
-    timeout-minutes: 120
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build release target for Intel
+        run: swift build --arch x86_64 -c release
+
+  build-signed-macos-app:
+    if: github.event_name != 'pull_request'
+    runs-on: macos-latest
+    timeout-minutes: 180
     env:
       APP_NAME: Typeflux
       BUILD_DIR: .build/release
@@ -165,10 +181,23 @@ jobs:
             done
           done
 
-          codesign --verify --deep --strict --verbose=2 "$BUILD_DIR/$APP_NAME.app"
-          spctl --assess --type execute --verbose=4 "$BUILD_DIR/$APP_NAME.app"
+          VERIFY_ROOT="$(mktemp -d)"
+          trap 'rm -rf "$VERIFY_ROOT"' EXIT
+
           for variant in minimal full app-only; do
             for arch in apple-silicon intel; do
+              if [[ "$arch" == "apple-silicon" ]]; then
+                expected_macho_arch="arm64"
+              else
+                expected_macho_arch="x86_64"
+              fi
+
+              app_verify_dir="$VERIFY_ROOT/${variant}-${arch}"
+              mkdir -p "$app_verify_dir"
+              ditto -x -k "$BUILD_DIR/${PACKAGE_PREFIX}-${variant}-${arch}.zip" "$app_verify_dir"
+              codesign --verify --deep --strict --verbose=2 "$app_verify_dir/$APP_NAME.app"
+              spctl --assess --type execute --verbose=4 "$app_verify_dir/$APP_NAME.app"
+              ./scripts/audit_macho_minos.sh "$app_verify_dir/$APP_NAME.app" "${TYPEFLUX_MAX_MACHO_MINOS:-13.4}" "$expected_macho_arch"
               xcrun stapler validate "$BUILD_DIR/${PACKAGE_PREFIX}-${variant}-${arch}.dmg"
             done
           done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ permissions:
 jobs:
   build-signed-macos-app:
     runs-on: macos-latest
-    timeout-minutes: 60
+    timeout-minutes: 120
     env:
       APP_NAME: Typeflux
       BUILD_DIR: .build/release
@@ -118,39 +118,60 @@ jobs:
             APP_ONLY_PACKAGE_NAME="Typeflux-app-only"
           fi
 
+          TYPEFLUX_RELEASE_ARCH=arm64 \
           TYPEFLUX_RELEASE_VARIANT=minimal \
-          TYPEFLUX_PACKAGE_NAME="$MINIMAL_PACKAGE_NAME" \
+          TYPEFLUX_PACKAGE_NAME="$MINIMAL_PACKAGE_NAME-apple-silicon" \
           ./scripts/release_notarize.sh
 
+          TYPEFLUX_RELEASE_ARCH=x86_64 \
+          TYPEFLUX_RELEASE_VARIANT=minimal \
+          TYPEFLUX_PACKAGE_NAME="$MINIMAL_PACKAGE_NAME-intel" \
+          ./scripts/release_intel.sh
+
+          TYPEFLUX_RELEASE_ARCH=arm64 \
           TYPEFLUX_RELEASE_VARIANT=full \
-          TYPEFLUX_PACKAGE_NAME="$FULL_PACKAGE_NAME" \
+          TYPEFLUX_PACKAGE_NAME="$FULL_PACKAGE_NAME-apple-silicon" \
           ./scripts/release_notarize.sh
 
+          TYPEFLUX_RELEASE_ARCH=x86_64 \
+          TYPEFLUX_RELEASE_VARIANT=full \
+          TYPEFLUX_PACKAGE_NAME="$FULL_PACKAGE_NAME-intel" \
+          ./scripts/release_intel.sh
+
+          TYPEFLUX_RELEASE_ARCH=arm64 \
           TYPEFLUX_RELEASE_VARIANT=app-only \
-          TYPEFLUX_PACKAGE_NAME="$APP_ONLY_PACKAGE_NAME" \
+          TYPEFLUX_PACKAGE_NAME="$APP_ONLY_PACKAGE_NAME-apple-silicon" \
           ./scripts/release_notarize.sh
+
+          TYPEFLUX_RELEASE_ARCH=x86_64 \
+          TYPEFLUX_RELEASE_VARIANT=app-only \
+          TYPEFLUX_PACKAGE_NAME="$APP_ONLY_PACKAGE_NAME-intel" \
+          ./scripts/release_intel.sh
 
       - name: Verify release artifacts
         run: |
           set -euo pipefail
 
-          test -f "$BUILD_DIR/Typeflux-minimal.dmg" || test -f "$BUILD_DIR/Typeflux-pre-release-minimal.dmg"
-          test -f "$BUILD_DIR/Typeflux-minimal.zip" || test -f "$BUILD_DIR/Typeflux-pre-release-minimal.zip"
-          test -f "$BUILD_DIR/Typeflux-full.dmg" || test -f "$BUILD_DIR/Typeflux-pre-release-full.dmg"
-          test -f "$BUILD_DIR/Typeflux-full.zip" || test -f "$BUILD_DIR/Typeflux-pre-release-full.zip"
-          test -f "$BUILD_DIR/Typeflux-app-only.dmg" || test -f "$BUILD_DIR/Typeflux-pre-release-app-only.dmg"
-          test -f "$BUILD_DIR/Typeflux-app-only.zip" || test -f "$BUILD_DIR/Typeflux-pre-release-app-only.zip"
+          if [[ "${GITHUB_EVENT_NAME}" == "push" && "${GITHUB_REF_NAME}" == "pre-release" ]]; then
+            PACKAGE_PREFIX="Typeflux-pre-release"
+          else
+            PACKAGE_PREFIX="Typeflux"
+          fi
+
+          for variant in minimal full app-only; do
+            for arch in apple-silicon intel; do
+              test -f "$BUILD_DIR/${PACKAGE_PREFIX}-${variant}-${arch}.dmg"
+              test -f "$BUILD_DIR/${PACKAGE_PREFIX}-${variant}-${arch}.zip"
+            done
+          done
+
           codesign --verify --deep --strict --verbose=2 "$BUILD_DIR/$APP_NAME.app"
           spctl --assess --type execute --verbose=4 "$BUILD_DIR/$APP_NAME.app"
-          if [[ -f "$BUILD_DIR/Typeflux-full.dmg" ]]; then
-            xcrun stapler validate "$BUILD_DIR/Typeflux-full.dmg"
-            xcrun stapler validate "$BUILD_DIR/Typeflux-minimal.dmg"
-            xcrun stapler validate "$BUILD_DIR/Typeflux-app-only.dmg"
-          else
-            xcrun stapler validate "$BUILD_DIR/Typeflux-pre-release-full.dmg"
-            xcrun stapler validate "$BUILD_DIR/Typeflux-pre-release-minimal.dmg"
-            xcrun stapler validate "$BUILD_DIR/Typeflux-pre-release-app-only.dmg"
-          fi
+          for variant in minimal full app-only; do
+            for arch in apple-silicon intel; do
+              xcrun stapler validate "$BUILD_DIR/${PACKAGE_PREFIX}-${variant}-${arch}.dmg"
+            done
+          done
 
       - name: Upload pre-release build artifacts
         if: github.event_name == 'push' && github.ref_name == 'pre-release'
@@ -158,12 +179,18 @@ jobs:
         with:
           name: typeflux-pre-release-installers-${{ github.sha }}
           path: |
-            .build/release/Typeflux-pre-release-minimal.zip
-            .build/release/Typeflux-pre-release-minimal.dmg
-            .build/release/Typeflux-pre-release-full.zip
-            .build/release/Typeflux-pre-release-full.dmg
-            .build/release/Typeflux-pre-release-app-only.zip
-            .build/release/Typeflux-pre-release-app-only.dmg
+            .build/release/Typeflux-pre-release-minimal-apple-silicon.zip
+            .build/release/Typeflux-pre-release-minimal-apple-silicon.dmg
+            .build/release/Typeflux-pre-release-minimal-intel.zip
+            .build/release/Typeflux-pre-release-minimal-intel.dmg
+            .build/release/Typeflux-pre-release-full-apple-silicon.zip
+            .build/release/Typeflux-pre-release-full-apple-silicon.dmg
+            .build/release/Typeflux-pre-release-full-intel.zip
+            .build/release/Typeflux-pre-release-full-intel.dmg
+            .build/release/Typeflux-pre-release-app-only-apple-silicon.zip
+            .build/release/Typeflux-pre-release-app-only-apple-silicon.dmg
+            .build/release/Typeflux-pre-release-app-only-intel.zip
+            .build/release/Typeflux-pre-release-app-only-intel.dmg
           if-no-files-found: error
           retention-days: 14
 
@@ -192,12 +219,18 @@ jobs:
             Branch: pre-release
             Workflow run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           files: |
-            .build/release/Typeflux-pre-release-minimal.zip
-            .build/release/Typeflux-pre-release-minimal.dmg
-            .build/release/Typeflux-pre-release-full.zip
-            .build/release/Typeflux-pre-release-full.dmg
-            .build/release/Typeflux-pre-release-app-only.zip
-            .build/release/Typeflux-pre-release-app-only.dmg
+            .build/release/Typeflux-pre-release-minimal-apple-silicon.zip
+            .build/release/Typeflux-pre-release-minimal-apple-silicon.dmg
+            .build/release/Typeflux-pre-release-minimal-intel.zip
+            .build/release/Typeflux-pre-release-minimal-intel.dmg
+            .build/release/Typeflux-pre-release-full-apple-silicon.zip
+            .build/release/Typeflux-pre-release-full-apple-silicon.dmg
+            .build/release/Typeflux-pre-release-full-intel.zip
+            .build/release/Typeflux-pre-release-full-intel.dmg
+            .build/release/Typeflux-pre-release-app-only-apple-silicon.zip
+            .build/release/Typeflux-pre-release-app-only-apple-silicon.dmg
+            .build/release/Typeflux-pre-release-app-only-intel.zip
+            .build/release/Typeflux-pre-release-app-only-intel.dmg
           fail_on_unmatched_files: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -208,12 +241,18 @@ jobs:
         with:
           tag_name: ${{ github.event.release.tag_name }}
           files: |
-            .build/release/Typeflux-minimal.zip
-            .build/release/Typeflux-minimal.dmg
-            .build/release/Typeflux-full.zip
-            .build/release/Typeflux-full.dmg
-            .build/release/Typeflux-app-only.zip
-            .build/release/Typeflux-app-only.dmg
+            .build/release/Typeflux-minimal-apple-silicon.zip
+            .build/release/Typeflux-minimal-apple-silicon.dmg
+            .build/release/Typeflux-minimal-intel.zip
+            .build/release/Typeflux-minimal-intel.dmg
+            .build/release/Typeflux-full-apple-silicon.zip
+            .build/release/Typeflux-full-apple-silicon.dmg
+            .build/release/Typeflux-full-intel.zip
+            .build/release/Typeflux-full-intel.dmg
+            .build/release/Typeflux-app-only-apple-silicon.zip
+            .build/release/Typeflux-app-only-apple-silicon.dmg
+            .build/release/Typeflux-app-only-intel.zip
+            .build/release/Typeflux-app-only-intel.dmg
           fail_on_unmatched_files: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -9,13 +9,13 @@ release:
 	./scripts/release_notarize.sh --move-to-downloads
 
 intel-release:
-	TYPEFLUX_RELEASE_ARCH=x86_64 ./scripts/release_intel.sh --move-to-downloads
+	./scripts/release_intel.sh --move-to-downloads
 
 release-continue:
 	./scripts/release_notarize.sh --continue --move-to-downloads
 
 intel-release-continue:
-	TYPEFLUX_RELEASE_ARCH=x86_64 ./scripts/release_intel.sh --continue --move-to-downloads
+	./scripts/release_intel.sh --continue --move-to-downloads
 
 full-release:
 	TYPEFLUX_RELEASE_VARIANT=full $(MAKE) release

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 RELEASE_VARIANT := $(if $(TYPEFLUX_RELEASE_VARIANT),$(TYPEFLUX_RELEASE_VARIANT),minimal)
-PACKAGE_NAME = Typeflux$(if $(filter full,$(RELEASE_VARIANT)),-full,$(if $(filter app-only,$(RELEASE_VARIANT)),-app-only,))
+RELEASE_ARCH := $(if $(TYPEFLUX_RELEASE_ARCH),$(TYPEFLUX_RELEASE_ARCH),native)
+PACKAGE_NAME = Typeflux$(if $(filter full,$(RELEASE_VARIANT)),-full,$(if $(filter app-only,$(RELEASE_VARIANT)),-app-only,))$(if $(filter arm64,$(RELEASE_ARCH)),-apple-silicon,$(if $(filter x86_64,$(RELEASE_ARCH)),-intel,$(if $(filter universal,$(RELEASE_ARCH)),-universal,)))
 
 run:
 	./scripts/run_dev_app.sh
@@ -7,14 +8,26 @@ run:
 release:
 	./scripts/release_notarize.sh --move-to-downloads
 
+intel-release:
+	TYPEFLUX_RELEASE_ARCH=x86_64 ./scripts/release_intel.sh --move-to-downloads
+
 release-continue:
 	./scripts/release_notarize.sh --continue --move-to-downloads
+
+intel-release-continue:
+	TYPEFLUX_RELEASE_ARCH=x86_64 ./scripts/release_intel.sh --continue --move-to-downloads
 
 full-release:
 	TYPEFLUX_RELEASE_VARIANT=full $(MAKE) release
 
+full-intel-release:
+	TYPEFLUX_RELEASE_VARIANT=full $(MAKE) intel-release
+
 app-only-release:
 	TYPEFLUX_RELEASE_VARIANT=app-only $(MAKE) release
+
+app-only-intel-release:
+	TYPEFLUX_RELEASE_VARIANT=app-only $(MAKE) intel-release
 
 full-release-continue:
 	TYPEFLUX_RELEASE_VARIANT=full $(MAKE) release-continue
@@ -46,4 +59,4 @@ release-notarize-continue:
 format:
 	./scripts/format.sh
 
-.PHONY: run release release-continue full-release app-only-release full-release-continue dev full-dev build test coverage dmg release-notarize release-notarize-continue format
+.PHONY: run release intel-release release-continue intel-release-continue full-release full-intel-release app-only-release app-only-intel-release full-release-continue dev full-dev build test coverage dmg release-notarize release-notarize-continue format

--- a/scripts/audit_macho_minos.sh
+++ b/scripts/audit_macho_minos.sh
@@ -1,13 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if [[ $# -lt 1 || $# -gt 2 ]]; then
-  echo "Usage: $0 <app-bundle-or-folder> [max-macos-minos]" >&2
+if [[ $# -lt 1 || $# -gt 3 ]]; then
+  echo "Usage: $0 <app-bundle-or-folder> [max-macos-minos] [required-arch]" >&2
   exit 1
 fi
 
 SCAN_ROOT="$1"
 MAX_MACOS_MINOS="${2:-${TYPEFLUX_MAX_MACHO_MINOS:-13.4}}"
+REQUIRED_ARCH="${3:-${TYPEFLUX_REQUIRED_MACHO_ARCH:-}}"
 
 if [[ ! -d "$SCAN_ROOT" ]]; then
   echo "Error: scan root does not exist: $SCAN_ROOT" >&2
@@ -18,6 +19,20 @@ if ! command -v vtool >/dev/null 2>&1 && ! command -v otool >/dev/null 2>&1; the
   echo "Error: vtool or otool is required to audit Mach-O minimum OS versions" >&2
   exit 1
 fi
+
+if [[ -n "$REQUIRED_ARCH" ]] && ! command -v lipo >/dev/null 2>&1; then
+  echo "Error: lipo is required to audit Mach-O architecture slices" >&2
+  exit 1
+fi
+
+case "$REQUIRED_ARCH" in
+  ""|native|arm64|x86_64|universal)
+    ;;
+  *)
+    echo "Error: unsupported required Mach-O architecture: ${REQUIRED_ARCH}" >&2
+    exit 1
+    ;;
+esac
 
 version_gt() {
   local lhs="$1"
@@ -70,10 +85,31 @@ minos_versions_for_file() {
   printf '%s\n' "$versions" | sed '/^$/d'
 }
 
+file_has_required_architecture() {
+  local file_path="$1"
+  local archs
+
+  [[ -z "$REQUIRED_ARCH" || "$REQUIRED_ARCH" == "native" ]] && return 0
+
+  archs="$(lipo -archs "$file_path" 2>/dev/null || true)"
+  case "$REQUIRED_ARCH" in
+    arm64|x86_64)
+      [[ " ${archs} " == *" ${REQUIRED_ARCH} "* ]]
+      ;;
+    universal)
+      [[ " ${archs} " == *" arm64 "* && " ${archs} " == *" x86_64 "* ]]
+      ;;
+  esac
+}
+
 echo "Auditing Mach-O minos under ${SCAN_ROOT}"
 echo "Maximum allowed macOS minos: ${MAX_MACOS_MINOS}"
+if [[ -n "$REQUIRED_ARCH" && "$REQUIRED_ARCH" != "native" ]]; then
+  echo "Required Mach-O architecture: ${REQUIRED_ARCH}"
+fi
 
-offenders=()
+minos_offenders=()
+arch_offenders=()
 scanned_count=0
 
 while IFS= read -r -d '' candidate; do
@@ -85,14 +121,26 @@ while IFS= read -r -d '' candidate; do
   scanned_count=$((scanned_count + 1))
   while IFS= read -r minos; do
     if version_gt "$minos" "$MAX_MACOS_MINOS"; then
-      offenders+=("${candidate#$SCAN_ROOT/}: minos ${minos}")
+      minos_offenders+=("${candidate#$SCAN_ROOT/}: minos ${minos}")
     fi
   done < <(minos_versions_for_file "$candidate")
+
+  if ! file_has_required_architecture "$candidate"; then
+    arch_offenders+=("${candidate#$SCAN_ROOT/}: missing ${REQUIRED_ARCH}")
+  fi
 done < <(find "$SCAN_ROOT" -type f -print0)
 
-if (( ${#offenders[@]} > 0 )); then
+if (( ${#minos_offenders[@]} > 0 )); then
   echo "Error: Mach-O files exceed allowed macOS minos ${MAX_MACOS_MINOS}:" >&2
-  printf '  %s\n' "${offenders[@]}" >&2
+  printf '  %s\n' "${minos_offenders[@]}" >&2
+fi
+
+if (( ${#arch_offenders[@]} > 0 )); then
+  echo "Error: Mach-O files are missing required architecture ${REQUIRED_ARCH}:" >&2
+  printf '  %s\n' "${arch_offenders[@]}" >&2
+fi
+
+if (( ${#minos_offenders[@]} > 0 || ${#arch_offenders[@]} > 0 )); then
   exit 1
 fi
 

--- a/scripts/build_dmg.sh
+++ b/scripts/build_dmg.sh
@@ -5,12 +5,30 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 BUILD_DIR="${ROOT_DIR}/.build/release"
 APP_NAME="Typeflux"
 RELEASE_VARIANT="${TYPEFLUX_RELEASE_VARIANT:-minimal}"
+RELEASE_ARCH="${TYPEFLUX_RELEASE_ARCH:-native}"
 DEFAULT_PACKAGE_NAME="$APP_NAME"
 if [[ "$RELEASE_VARIANT" == "full" ]]; then
   DEFAULT_PACKAGE_NAME="${APP_NAME}-full"
 elif [[ "$RELEASE_VARIANT" == "app-only" ]]; then
   DEFAULT_PACKAGE_NAME="${APP_NAME}-app-only"
 fi
+case "$RELEASE_ARCH" in
+  native)
+    ;;
+  arm64)
+    DEFAULT_PACKAGE_NAME="${DEFAULT_PACKAGE_NAME}-apple-silicon"
+    ;;
+  x86_64)
+    DEFAULT_PACKAGE_NAME="${DEFAULT_PACKAGE_NAME}-intel"
+    ;;
+  universal)
+    DEFAULT_PACKAGE_NAME="${DEFAULT_PACKAGE_NAME}-universal"
+    ;;
+  *)
+    echo "Error: unsupported TYPEFLUX_RELEASE_ARCH: ${RELEASE_ARCH}" >&2
+    exit 1
+    ;;
+esac
 PACKAGE_NAME="${TYPEFLUX_PACKAGE_NAME:-$DEFAULT_PACKAGE_NAME}"
 APP_BUNDLE="${BUILD_DIR}/${APP_NAME}.app"
 DMG_NAME="${PACKAGE_NAME}.dmg"

--- a/scripts/build_release.sh
+++ b/scripts/build_release.sh
@@ -258,7 +258,11 @@ else
   echo "Warning: To enable it, set TYPEFLUX_PROVISIONING_PROFILE to a macOS provisioning profile whose App ID matches ai.gulu.app.typeflux and includes the Sign In with Apple capability."
 fi
 
-"${ROOT_DIR}/scripts/audit_macho_minos.sh" "$APP_BUNDLE" "${TYPEFLUX_MAX_MACHO_MINOS:-13.4}"
+if [[ "$RELEASE_ARCH" == "arm64" || "$RELEASE_ARCH" == "x86_64" || "$RELEASE_ARCH" == "universal" ]]; then
+  "${ROOT_DIR}/scripts/audit_macho_minos.sh" "$APP_BUNDLE" "${TYPEFLUX_MAX_MACHO_MINOS:-13.4}" "$RELEASE_ARCH"
+else
+  "${ROOT_DIR}/scripts/audit_macho_minos.sh" "$APP_BUNDLE" "${TYPEFLUX_MAX_MACHO_MINOS:-13.4}"
+fi
 
 create_zip_archive
 

--- a/scripts/build_release.sh
+++ b/scripts/build_release.sh
@@ -5,12 +5,30 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 BUILD_DIR="${ROOT_DIR}/.build/release"
 APP_NAME="Typeflux"
 RELEASE_VARIANT="${TYPEFLUX_RELEASE_VARIANT:-minimal}"
+RELEASE_ARCH="${TYPEFLUX_RELEASE_ARCH:-native}"
 DEFAULT_PACKAGE_NAME="$APP_NAME"
 if [[ "$RELEASE_VARIANT" == "full" ]]; then
   DEFAULT_PACKAGE_NAME="${APP_NAME}-full"
 elif [[ "$RELEASE_VARIANT" == "app-only" ]]; then
   DEFAULT_PACKAGE_NAME="${APP_NAME}-app-only"
 fi
+case "$RELEASE_ARCH" in
+  native)
+    ;;
+  arm64)
+    DEFAULT_PACKAGE_NAME="${DEFAULT_PACKAGE_NAME}-apple-silicon"
+    ;;
+  x86_64)
+    DEFAULT_PACKAGE_NAME="${DEFAULT_PACKAGE_NAME}-intel"
+    ;;
+  universal)
+    DEFAULT_PACKAGE_NAME="${DEFAULT_PACKAGE_NAME}-universal"
+    ;;
+  *)
+    echo "Error: unsupported TYPEFLUX_RELEASE_ARCH: ${RELEASE_ARCH}" >&2
+    exit 1
+    ;;
+esac
 PACKAGE_NAME="${TYPEFLUX_PACKAGE_NAME:-$DEFAULT_PACKAGE_NAME}"
 APP_BUNDLE="${BUILD_DIR}/${APP_NAME}.app"
 APP_EXECUTABLE="${APP_BUNDLE}/Contents/MacOS/${APP_NAME}"
@@ -44,8 +62,44 @@ create_zip_archive() {
   )
 }
 
+verify_main_executable_architecture() {
+  if ! command -v lipo >/dev/null 2>&1; then
+    echo "Warning: lipo not available; skipping executable architecture audit."
+    return 0
+  fi
+
+  local archs
+  archs="$(lipo -archs "$APP_EXECUTABLE")"
+  echo "Main executable architectures: ${archs}"
+
+  case "$RELEASE_ARCH" in
+    native)
+      return 0
+      ;;
+    arm64)
+      [[ " ${archs} " == *" arm64 "* ]] || {
+        echo "Error: expected arm64 slice in ${APP_EXECUTABLE}" >&2
+        exit 1
+      }
+      ;;
+    x86_64)
+      [[ " ${archs} " == *" x86_64 "* ]] || {
+        echo "Error: expected x86_64 slice in ${APP_EXECUTABLE}" >&2
+        exit 1
+      }
+      ;;
+    universal)
+      [[ " ${archs} " == *" arm64 "* && " ${archs} " == *" x86_64 "* ]] || {
+        echo "Error: expected universal executable with arm64 and x86_64 slices in ${APP_EXECUTABLE}" >&2
+        exit 1
+      }
+      ;;
+  esac
+}
+
 echo "Building Typeflux release bundle..."
 echo "Release variant: ${RELEASE_VARIANT}"
+echo "Release architecture: ${RELEASE_ARCH}"
 
 case "$RELEASE_VARIANT" in
   minimal|full|app-only)
@@ -56,9 +110,21 @@ case "$RELEASE_VARIANT" in
     ;;
 esac
 
-swift build --package-path "$ROOT_DIR" -c release
+SWIFT_BUILD_ARGS=(--package-path "$ROOT_DIR" -c release)
+case "$RELEASE_ARCH" in
+  native)
+    ;;
+  arm64 | x86_64)
+    SWIFT_BUILD_ARGS+=(--arch "$RELEASE_ARCH")
+    ;;
+  universal)
+    SWIFT_BUILD_ARGS+=(--arch arm64 --arch x86_64)
+    ;;
+esac
 
-BIN_DIR="$(swift build --package-path "$ROOT_DIR" -c release --show-bin-path)"
+swift build "${SWIFT_BUILD_ARGS[@]}"
+
+BIN_DIR="$(swift build "${SWIFT_BUILD_ARGS[@]}" --show-bin-path)"
 BIN="$BIN_DIR/Typeflux"
 RESOURCE_BUNDLE="$BIN_DIR/Typeflux_Typeflux.bundle"
 
@@ -70,6 +136,7 @@ cp "$ROOT_DIR/app/Info.plist" "$APP_BUNDLE/Contents/Info.plist"
 cp "$BIN" "$APP_BUNDLE/Contents/MacOS/Typeflux"
 cp "$ROOT_DIR/app/Typeflux.icns" "$APP_BUNDLE/Contents/Resources/Typeflux.icns"
 cp -R "$RESOURCE_BUNDLE" "$APP_BUNDLE/Contents/Resources/Typeflux_Typeflux.bundle"
+verify_main_executable_architecture
 
 rm -rf "$APP_BUNDLE/Contents/Resources/BundledModels"
 rm -rf "$APP_BUNDLE/Contents/Resources/LocalRuntimes"

--- a/scripts/release_intel.sh
+++ b/scripts/release_intel.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+export TYPEFLUX_RELEASE_ARCH="${TYPEFLUX_RELEASE_ARCH:-x86_64}"
+
+if [[ "$TYPEFLUX_RELEASE_ARCH" != "x86_64" ]]; then
+  echo "Error: scripts/release_intel.sh only supports TYPEFLUX_RELEASE_ARCH=x86_64" >&2
+  exit 1
+fi
+
+"${ROOT_DIR}/scripts/release_notarize.sh" "$@"

--- a/scripts/release_notarize.sh
+++ b/scripts/release_notarize.sh
@@ -5,12 +5,30 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 BUILD_DIR="${ROOT_DIR}/.build/release"
 APP_NAME="Typeflux"
 RELEASE_VARIANT="${TYPEFLUX_RELEASE_VARIANT:-minimal}"
+RELEASE_ARCH="${TYPEFLUX_RELEASE_ARCH:-native}"
 DEFAULT_PACKAGE_NAME="$APP_NAME"
 if [[ "$RELEASE_VARIANT" == "full" ]]; then
   DEFAULT_PACKAGE_NAME="${APP_NAME}-full"
 elif [[ "$RELEASE_VARIANT" == "app-only" ]]; then
   DEFAULT_PACKAGE_NAME="${APP_NAME}-app-only"
 fi
+case "$RELEASE_ARCH" in
+  native)
+    ;;
+  arm64)
+    DEFAULT_PACKAGE_NAME="${DEFAULT_PACKAGE_NAME}-apple-silicon"
+    ;;
+  x86_64)
+    DEFAULT_PACKAGE_NAME="${DEFAULT_PACKAGE_NAME}-intel"
+    ;;
+  universal)
+    DEFAULT_PACKAGE_NAME="${DEFAULT_PACKAGE_NAME}-universal"
+    ;;
+  *)
+    echo "Error: unsupported TYPEFLUX_RELEASE_ARCH: ${RELEASE_ARCH}" >&2
+    exit 1
+    ;;
+esac
 PACKAGE_NAME="${TYPEFLUX_PACKAGE_NAME:-$DEFAULT_PACKAGE_NAME}"
 APP_BUNDLE="${BUILD_DIR}/${APP_NAME}.app"
 DMG_PATH="${BUILD_DIR}/${PACKAGE_NAME}.dmg"
@@ -114,6 +132,7 @@ write_state() {
   {
     printf 'RELEASE_STAGE=%q\n' "$RELEASE_STAGE"
     printf 'RELEASE_VARIANT=%q\n' "$RELEASE_VARIANT"
+    printf 'RELEASE_ARCH=%q\n' "$RELEASE_ARCH"
     printf 'PACKAGE_NAME=%q\n' "$PACKAGE_NAME"
     printf 'APP_BUNDLE=%q\n' "$APP_BUNDLE"
     printf 'DMG_PATH=%q\n' "$DMG_PATH"
@@ -131,6 +150,7 @@ set_stage() {
 
 load_state() {
   local expected_release_variant="$RELEASE_VARIANT"
+  local expected_release_arch="$RELEASE_ARCH"
   local expected_package_name="$PACKAGE_NAME"
   local expected_app_bundle="$APP_BUNDLE"
   local expected_dmg_path="$DMG_PATH"
@@ -148,6 +168,8 @@ load_state() {
 
   [[ "${RELEASE_VARIANT:-}" == "$expected_release_variant" ]] \
     || fail "Release state variant '${RELEASE_VARIANT:-}' does not match requested variant '${expected_release_variant}'."
+  [[ "${RELEASE_ARCH:-native}" == "$expected_release_arch" ]] \
+    || fail "Release state architecture '${RELEASE_ARCH:-native}' does not match requested architecture '${expected_release_arch}'."
   [[ "${PACKAGE_NAME:-}" == "$expected_package_name" ]] \
     || fail "Release state package '${PACKAGE_NAME:-}' does not match requested package '${expected_package_name}'."
   [[ "${APP_BUNDLE:-}" == "$expected_app_bundle" ]] \
@@ -371,6 +393,7 @@ main() {
   log "Using signing identity: ${TYPEFLUX_CODESIGN_IDENTITY}"
   log "Using notary profile: ${TYPEFLUX_NOTARY_PROFILE}"
   log "Using release variant: ${RELEASE_VARIANT}"
+  log "Using release architecture: ${RELEASE_ARCH}"
   log "Using package name: ${PACKAGE_NAME}"
   log "Using release state: ${STATE_PATH}"
 

--- a/scripts/release_notarize.sh
+++ b/scripts/release_notarize.sh
@@ -33,7 +33,7 @@ PACKAGE_NAME="${TYPEFLUX_PACKAGE_NAME:-$DEFAULT_PACKAGE_NAME}"
 APP_BUNDLE="${BUILD_DIR}/${APP_NAME}.app"
 DMG_PATH="${BUILD_DIR}/${PACKAGE_NAME}.dmg"
 ZIP_PATH="${BUILD_DIR}/${PACKAGE_NAME}.zip"
-STATE_PATH="${TYPEFLUX_RELEASE_STATE_PATH:-${BUILD_DIR}/.release-workflow.env}"
+STATE_PATH="${TYPEFLUX_RELEASE_STATE_PATH:-${BUILD_DIR}/.release-workflow-${RELEASE_VARIANT}-${RELEASE_ARCH}.env}"
 DESTINATION_DIR="${TYPEFLUX_RELEASE_DESTINATION:-${HOME}/Downloads}"
 TYPEFLUX_NOTARY_POLL_INTERVAL_SECONDS="${TYPEFLUX_NOTARY_POLL_INTERVAL_SECONDS:-15}"
 TYPEFLUX_NOTARY_SUBMIT_RETRIES="${TYPEFLUX_NOTARY_SUBMIT_RETRIES:-3}"
@@ -72,7 +72,7 @@ usage() {
 Usage: scripts/release_notarize.sh [--continue] [--move-to-downloads]
 
 Options:
-  --continue           Resume the release recorded in .build/release/.release-workflow.env.
+  --continue           Resume the matching release recorded in .build/release/.release-workflow-<variant>-<arch>.env.
   --move-to-downloads Move finished ZIP and DMG artifacts to ~/Downloads as a resumable stage.
 EOF
 }


### PR DESCRIPTION
## Summary

- References TYP-76.
- Adds architecture-aware release packaging via `TYPEFLUX_RELEASE_ARCH` (`native`, `arm64`, `x86_64`, `universal`).
- Adds `scripts/release_intel.sh` as the Intel-only release entrypoint.
- Updates the release workflow to publish separate Apple Silicon and Intel ZIP/DMG artifacts for `minimal`, `full`, and `app-only` variants.
- Adds architecture audit for the main app executable so Intel/universal builds fail fast if the expected slice is missing.

## How to test

- `bash -n scripts/build_release.sh scripts/build_dmg.sh scripts/release_notarize.sh scripts/release_intel.sh`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "release workflow YAML parsed"'`
- `make -n intel-release full-intel-release app-only-intel-release`
- `TYPEFLUX_RELEASE_ARCH=x86_64 TYPEFLUX_RELEASE_VARIANT=app-only TYPEFLUX_PACKAGE_NAME=Typeflux-test-app-only-intel ./scripts/build_release.sh`
- Verified `.build/release/Typeflux.app/Contents/MacOS/Typeflux` reports `x86_64` via `lipo -archs` and the Intel ZIP is created.

## Screenshots

Not applicable: release scripting and CI workflow only.