### PR TITLE
feat(feedback): support image attachments with S3 presigned upload

### DIFF
--- a/Sources/Typeflux/Feedback/DirectFeedbackSheet.swift
+++ b/Sources/Typeflux/Feedback/DirectFeedbackSheet.swift
@@ -1,10 +1,58 @@
 import SwiftUI
 
+enum FeedbackImageUploadState: Equatable {
+    case preparing
+    case uploading
+    case uploaded(String)
+    case failed(String)
+
+    var isReady: Bool {
+        if case .uploaded = self { return true }
+        return false
+    }
+
+    var isInProgress: Bool {
+        switch self {
+        case .preparing, .uploading:
+            return true
+        case .uploaded, .failed:
+            return false
+        }
+    }
+
+    var uploadedURL: String? {
+        if case .uploaded(let url) = self { return url }
+        return nil
+    }
+}
+
+struct FeedbackImageAttachment: Identifiable {
+    let id: UUID
+    var filename: String
+    var thumbnail: NSImage?
+    var state: FeedbackImageUploadState
+
+    init(
+        id: UUID = UUID(),
+        filename: String,
+        thumbnail: NSImage? = nil,
+        state: FeedbackImageUploadState
+    ) {
+        self.id = id
+        self.filename = filename
+        self.thumbnail = thumbnail
+        self.state = state
+    }
+}
+
 struct DirectFeedbackSheet: View {
     @Binding var content: String
     @Binding var contact: String
+    @Binding var images: [FeedbackImageAttachment]
     let isSubmitting: Bool
     let errorMessage: String?
+    let onAddImages: () -> Void
+    let onRemoveImage: (FeedbackImageAttachment.ID) -> Void
     let onCancel: () -> Void
     let onSubmit: () -> Void
 
@@ -16,6 +64,15 @@ struct DirectFeedbackSheet: View {
 
     private var trimmedContent: String {
         content.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private var canSubmit: Bool {
+        !trimmedContent.isEmpty
+            && !images.contains { $0.state.isInProgress }
+            && !images.contains {
+                if case .failed = $0.state { return true }
+                return false
+            }
     }
 
     var body: some View {
@@ -51,6 +108,39 @@ struct DirectFeedbackSheet: View {
                             .padding(.vertical, contentPlaceholderVerticalPadding)
                             .fixedSize(horizontal: false, vertical: true)
                             .allowsHitTesting(false)
+                    }
+                }
+            }
+
+            VStack(alignment: .leading, spacing: StudioTheme.Spacing.small) {
+                HStack {
+                    Text(L("feedback.direct.imagesLabel"))
+                        .font(.studioBody(12, weight: .semibold))
+                        .foregroundStyle(StudioTheme.textSecondary)
+
+                    Spacer()
+
+                    Button(action: onAddImages) {
+                        Label(L("feedback.direct.addImage"), systemImage: "plus")
+                    }
+                    .disabled(isSubmitting || images.count >= 4)
+                }
+
+                if !images.isEmpty {
+                    LazyVGrid(
+                        columns: Array(
+                            repeating: GridItem(.fixed(68), spacing: StudioTheme.Spacing.small),
+                            count: 4
+                        ),
+                        alignment: .leading,
+                        spacing: StudioTheme.Spacing.small
+                    ) {
+                        ForEach(images) { image in
+                            FeedbackImageThumbnail(
+                                image: image,
+                                onRemove: { onRemoveImage(image.id) }
+                            )
+                        }
                     }
                 }
             }
@@ -97,13 +187,79 @@ struct DirectFeedbackSheet: View {
                     }
                 }
                 .keyboardShortcut(.defaultAction)
-                .disabled(isSubmitting || trimmedContent.isEmpty)
+                .disabled(isSubmitting || !canSubmit)
             }
         }
         .padding(24)
         .frame(width: 480)
         .onAppear {
             isContentFocused = true
+        }
+    }
+}
+
+private struct FeedbackImageThumbnail: View {
+    let image: FeedbackImageAttachment
+    let onRemove: () -> Void
+
+    var body: some View {
+        ZStack(alignment: .topTrailing) {
+            ZStack {
+                RoundedRectangle(cornerRadius: StudioTheme.CornerRadius.medium, style: .continuous)
+                    .fill(StudioTheme.controlSurface)
+
+                if let thumbnail = image.thumbnail {
+                    Image(nsImage: thumbnail)
+                        .resizable()
+                        .scaledToFill()
+                        .frame(width: 68, height: 68)
+                        .clipShape(RoundedRectangle(cornerRadius: StudioTheme.CornerRadius.medium, style: .continuous))
+                } else {
+                    Image(systemName: "photo")
+                        .font(.system(size: 20, weight: .medium))
+                        .foregroundStyle(StudioTheme.textTertiary)
+                }
+
+                statusOverlay
+            }
+            .frame(width: 68, height: 68)
+            .clipShape(RoundedRectangle(cornerRadius: StudioTheme.CornerRadius.medium, style: .continuous))
+            .overlay {
+                RoundedRectangle(cornerRadius: StudioTheme.CornerRadius.medium, style: .continuous)
+                    .stroke(StudioTheme.border.opacity(0.72), lineWidth: 1)
+            }
+
+            Button(action: onRemove) {
+                Image(systemName: "xmark.circle.fill")
+                    .font(.system(size: 15, weight: .semibold))
+                    .symbolRenderingMode(.palette)
+                    .foregroundStyle(StudioTheme.textPrimary, StudioTheme.surface.opacity(0.92))
+            }
+            .buttonStyle(.plain)
+            .padding(4)
+            .accessibilityLabel(L("feedback.direct.removeImage"))
+        }
+    }
+
+    @ViewBuilder
+    private var statusOverlay: some View {
+        switch image.state {
+        case .preparing, .uploading:
+            Rectangle()
+                .fill(.black.opacity(0.32))
+                .overlay {
+                    ProgressView()
+                        .controlSize(.small)
+                }
+        case .uploaded:
+            EmptyView()
+        case .failed:
+            Rectangle()
+                .fill(StudioTheme.danger.opacity(0.76))
+                .overlay {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .foregroundStyle(.white)
+                }
         }
     }
 }

--- a/Sources/Typeflux/Feedback/FeedbackAPIService.swift
+++ b/Sources/Typeflux/Feedback/FeedbackAPIService.swift
@@ -23,6 +23,41 @@ struct FeedbackSubmissionResponse: Decodable, Equatable {
     let status: String
 }
 
+struct FeedbackUploadPresignRequest: Encodable, Equatable {
+    let filename: String
+    let contentType: String
+    let sizeBytes: Int64
+
+    enum CodingKeys: String, CodingKey {
+        case filename
+        case contentType = "content_type"
+        case sizeBytes = "size_bytes"
+    }
+}
+
+struct FeedbackUploadTarget: Decodable, Equatable {
+    let type: String
+    let method: String
+    let url: String
+    let bucket: String
+    let region: String
+    let key: String
+    let expiresAt: Int64
+    let maxSizeBytes: Int64
+    let headers: [String: String]
+    let fields: [String: String]
+    let imageURL: String
+    let uploadID: String
+
+    enum CodingKeys: String, CodingKey {
+        case type, method, url, bucket, region, key, headers, fields
+        case expiresAt = "expires_at"
+        case maxSizeBytes = "max_size_bytes"
+        case imageURL = "image_url"
+        case uploadID = "upload_id"
+    }
+}
+
 enum FeedbackAPIError: LocalizedError, Equatable {
     case emptyContent
     case networkError(String)
@@ -56,6 +91,7 @@ struct FeedbackAPIService {
     static func submit(
         content: String,
         contact: String?,
+        imageURLs: [String] = [],
         token: String? = nil,
         executor: CloudRequestExecutor = CloudRequestExecutor()
     ) async throws -> FeedbackSubmissionResponse {
@@ -67,7 +103,8 @@ struct FeedbackAPIService {
         let trimmedContact = contact?.trimmingCharacters(in: .whitespacesAndNewlines)
         let request = CreateFeedbackRequest(
             content: trimmedContent,
-            contact: trimmedContact?.isEmpty == false ? trimmedContact : nil
+            contact: trimmedContact?.isEmpty == false ? trimmedContact : nil,
+            imageURLs: imageURLs
         )
         let payload: Data
         do {
@@ -122,5 +159,122 @@ struct FeedbackAPIService {
         }
 
         return responseData
+    }
+
+    static func createImageUploadTarget(
+        filename: String,
+        contentType: String,
+        sizeBytes: Int64,
+        token: String? = nil,
+        executor: CloudRequestExecutor = CloudRequestExecutor()
+    ) async throws -> FeedbackUploadTarget {
+        let request = FeedbackUploadPresignRequest(
+            filename: filename,
+            contentType: contentType,
+            sizeBytes: sizeBytes
+        )
+
+        let payload: Data
+        do {
+            payload = try JSONEncoder().encode(request)
+        } catch {
+            throw FeedbackAPIError.networkError(error.localizedDescription)
+        }
+
+        let data: Data
+        let httpResponse: HTTPURLResponse
+        do {
+            (data, httpResponse) = try await executor.execute { baseURL in
+                let url = AuthEndpointResolver.resolve(baseURL: baseURL, path: "/api/v1/feedback/uploads/presign")
+                var urlRequest = URLRequest(url: url)
+                urlRequest.httpMethod = "POST"
+                urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
+                if let token, !token.isEmpty {
+                    urlRequest.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+                }
+                urlRequest.httpBody = payload
+                urlRequest.timeoutInterval = 30
+                return urlRequest
+            }
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch CloudRequestExecutorError.allEndpointsFailed(let lastError) {
+            logger.error("Feedback upload presign failed on all endpoints: \(lastError.localizedDescription)")
+            throw FeedbackAPIError.networkError(lastError.localizedDescription)
+        } catch {
+            logger.error("Feedback upload presign network error: \(error.localizedDescription)")
+            throw FeedbackAPIError.networkError(error.localizedDescription)
+        }
+
+        let envelope: APIResponse<FeedbackUploadTarget>
+        do {
+            envelope = try JSONDecoder().decode(APIResponse<FeedbackUploadTarget>.self, from: data)
+        } catch {
+            logger.error("Feedback upload presign decoding error: \(error.localizedDescription)")
+            throw FeedbackAPIError.invalidResponse
+        }
+
+        if httpResponse.statusCode == 401 {
+            throw FeedbackAPIError.unauthorized
+        }
+
+        guard httpResponse.statusCode >= 200, httpResponse.statusCode < 300,
+              envelope.code == "OK",
+              let responseData = envelope.data
+        else {
+            logger.error("Feedback upload presign failed with HTTP \(httpResponse.statusCode, privacy: .public)")
+            throw FeedbackAPIError.serverError(code: envelope.code, message: envelope.message)
+        }
+
+        return responseData
+    }
+
+    static func uploadImage(
+        data: Data,
+        filename: String,
+        contentType: String,
+        to target: FeedbackUploadTarget,
+        session: CloudHTTPSession = URLSession.shared
+    ) async throws {
+        guard let url = URL(string: target.url) else {
+            throw FeedbackAPIError.invalidResponse
+        }
+
+        let boundary = "Boundary-\(UUID().uuidString)"
+        var request = URLRequest(url: url)
+        request.httpMethod = target.method.isEmpty ? "POST" : target.method
+        request.timeoutInterval = 60
+        for (name, value) in target.headers {
+            request.setValue(value, forHTTPHeaderField: name)
+        }
+        request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
+
+        let fieldParts = target.fields
+            .sorted { $0.key < $1.key }
+            .map { MultipartPart.text(name: $0.key, value: $0.value) }
+        request.httpBody = try MultipartFormData.build(
+            boundary: boundary,
+            parts: fieldParts + [.fileData(name: "file", filename: filename, mimeType: contentType, data: data)]
+        )
+        try Task.checkCancellation()
+
+        do {
+            let (_, response) = try await session.data(for: request)
+            guard let httpResponse = response as? HTTPURLResponse else {
+                throw FeedbackAPIError.invalidResponse
+            }
+            guard httpResponse.statusCode >= 200, httpResponse.statusCode < 300 else {
+                throw FeedbackAPIError.serverError(code: "UPLOAD_FAILED", message: "HTTP \(httpResponse.statusCode)")
+            }
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch let error as URLError where error.code == .cancelled {
+            throw CancellationError()
+        } catch let error as FeedbackAPIError {
+            throw error
+        } catch {
+            logger.error("Feedback image upload failed: \(error.localizedDescription)")
+            throw FeedbackAPIError.networkError(error.localizedDescription)
+        }
     }
 }

--- a/Sources/Typeflux/Feedback/FeedbackImageProcessor.swift
+++ b/Sources/Typeflux/Feedback/FeedbackImageProcessor.swift
@@ -1,0 +1,81 @@
+import AppKit
+import Foundation
+
+struct PreparedFeedbackImage: Equatable {
+    let data: Data
+    let filename: String
+    let contentType: String
+    let thumbnail: NSImage
+
+    static func == (lhs: PreparedFeedbackImage, rhs: PreparedFeedbackImage) -> Bool {
+        lhs.data == rhs.data
+            && lhs.filename == rhs.filename
+            && lhs.contentType == rhs.contentType
+    }
+}
+
+enum FeedbackImageProcessor {
+    static let maxPixelDimension = 1_600
+    static let jpegCompression: CGFloat = 0.78
+
+    static func prepare(url: URL) throws -> PreparedFeedbackImage {
+        guard let sourceImage = NSImage(contentsOf: url),
+              let sourceRep = bitmapRepresentation(for: sourceImage)
+        else {
+            throw FeedbackAPIError.networkError(L("feedback.error.invalidImage"))
+        }
+
+        let resizedImage = resized(sourceImage, pixelsWide: sourceRep.pixelsWide, pixelsHigh: sourceRep.pixelsHigh)
+        guard let resizedRep = bitmapRepresentation(for: resizedImage),
+              let data = resizedRep.representation(
+                  using: .jpeg,
+                  properties: [.compressionFactor: jpegCompression]
+              )
+        else {
+            throw FeedbackAPIError.networkError(L("feedback.error.invalidImage"))
+        }
+
+        return PreparedFeedbackImage(
+            data: data,
+            filename: jpegFilename(from: url),
+            contentType: "image/jpeg",
+            thumbnail: resizedImage
+        )
+    }
+
+    private static func bitmapRepresentation(for image: NSImage) -> NSBitmapImageRep? {
+        if let tiffData = image.tiffRepresentation,
+           let rep = NSBitmapImageRep(data: tiffData) {
+            return rep
+        }
+        guard let cgImage = image.cgImage(forProposedRect: nil, context: nil, hints: nil) else {
+            return nil
+        }
+        return NSBitmapImageRep(cgImage: cgImage)
+    }
+
+    private static func resized(_ image: NSImage, pixelsWide: Int, pixelsHigh: Int) -> NSImage {
+        let longestSide = max(pixelsWide, pixelsHigh)
+        guard longestSide > maxPixelDimension else {
+            return image
+        }
+
+        let scale = CGFloat(maxPixelDimension) / CGFloat(longestSide)
+        let targetSize = NSSize(
+            width: max(1, CGFloat(pixelsWide) * scale),
+            height: max(1, CGFloat(pixelsHigh) * scale)
+        )
+        let resized = NSImage(size: targetSize)
+        resized.lockFocus()
+        NSGraphicsContext.current?.imageInterpolation = .high
+        image.draw(in: NSRect(origin: .zero, size: targetSize))
+        resized.unlockFocus()
+        return resized
+    }
+
+    private static func jpegFilename(from url: URL) -> String {
+        let baseName = url.deletingPathExtension().lastPathComponent
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return "\(baseName.isEmpty ? "feedback-image" : baseName).jpg"
+    }
+}

--- a/Sources/Typeflux/Networking/CloudRequestExecutor.swift
+++ b/Sources/Typeflux/Networking/CloudRequestExecutor.swift
@@ -92,6 +92,8 @@ struct CloudRequestExecutor: Sendable {
                 return (data, http)
             } catch is CancellationError {
                 throw CancellationError()
+            } catch let error as URLError where error.code == .cancelled {
+                throw CancellationError()
             } catch {
                 await selector.reportFailure(endpoint, error: error)
                 lastError = error

--- a/Sources/Typeflux/Resources/en.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/en.lproj/Localizable.strings
@@ -34,9 +34,13 @@
 "feedback.direct.contentPlaceholder" = "Tell us what happened or what you would like to improve.\nExample: I pressed the shortcut, but dictation did not start, even after restarting the app.\nOr: I would like finished text to copy to the clipboard automatically.";
 "feedback.direct.contactLabel" = "Contact (optional)";
 "feedback.direct.contactPlaceholder" = "Email or other contact";
+"feedback.direct.imagesLabel" = "Images";
+"feedback.direct.addImage" = "Add image";
+"feedback.direct.removeImage" = "Remove image";
 "feedback.direct.submit" = "Submit";
 "feedback.toast.submitted" = "Feedback submitted. Thank you.";
 "feedback.error.emptyContent" = "Please enter feedback content.";
+"feedback.error.invalidImage" = "Unable to read this image.";
 "feedback.error.server" = "Failed to submit feedback.";
 "feedback.error.invalidResponse" = "Received an invalid feedback response.";
 

--- a/Sources/Typeflux/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/ja.lproj/Localizable.strings
@@ -34,9 +34,13 @@
 "feedback.direct.contentPlaceholder" = "困っていることや改善してほしいことを簡単に書いてください。\n例：ショートカットを押しても文字起こしが始まらず、アプリを再起動しても同じです。\nまたは：文字起こし後のテキストを自動でクリップボードにコピーしてほしいです。";
 "feedback.direct.contactLabel" = "連絡先（任意）";
 "feedback.direct.contactPlaceholder" = "メールアドレスまたは連絡先";
+"feedback.direct.imagesLabel" = "画像";
+"feedback.direct.addImage" = "画像を追加";
+"feedback.direct.removeImage" = "画像を削除";
 "feedback.direct.submit" = "送信";
 "feedback.toast.submitted" = "フィードバックを送信しました。ありがとうございます。";
 "feedback.error.emptyContent" = "フィードバック内容を入力してください。";
+"feedback.error.invalidImage" = "この画像を読み込めません。";
 "feedback.error.server" = "フィードバックの送信に失敗しました。";
 "feedback.error.invalidResponse" = "フィードバックの応答が無効です。";
 

--- a/Sources/Typeflux/Resources/ko.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/ko.lproj/Localizable.strings
@@ -34,9 +34,13 @@
 "feedback.direct.contentPlaceholder" = "겪은 문제나 개선되면 좋을 점을 간단히 적어 주세요.\n예: 단축키를 눌러도 받아쓰기가 시작되지 않고, 앱을 다시 열어도 그대로입니다.\n또는: 받아쓰기가 끝나면 텍스트가 자동으로 클립보드에 복사되면 좋겠습니다.";
 "feedback.direct.contactLabel" = "연락처(선택 사항)";
 "feedback.direct.contactPlaceholder" = "이메일 또는 기타 연락처";
+"feedback.direct.imagesLabel" = "이미지";
+"feedback.direct.addImage" = "이미지 추가";
+"feedback.direct.removeImage" = "이미지 제거";
 "feedback.direct.submit" = "제출";
 "feedback.toast.submitted" = "피드백이 제출되었습니다. 감사합니다.";
 "feedback.error.emptyContent" = "피드백 내용을 입력하세요.";
+"feedback.error.invalidImage" = "이 이미지를 읽을 수 없습니다.";
 "feedback.error.server" = "피드백 제출에 실패했습니다.";
 "feedback.error.invalidResponse" = "피드백 응답이 올바르지 않습니다.";
 

--- a/Sources/Typeflux/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/zh-Hans.lproj/Localizable.strings
@@ -34,9 +34,13 @@
 "feedback.direct.contentPlaceholder" = "请简单说说你遇到的问题或想法。\n例如：我按下快捷键后没有开始转写，重启应用后还是一样。\n也可以写：我希望转写完成后自动复制到剪贴板。";
 "feedback.direct.contactLabel" = "联系方式（可选）";
 "feedback.direct.contactPlaceholder" = "邮箱或其他联系方式";
+"feedback.direct.imagesLabel" = "图片";
+"feedback.direct.addImage" = "添加图片";
+"feedback.direct.removeImage" = "移除图片";
 "feedback.direct.submit" = "提交";
 "feedback.toast.submitted" = "反馈已提交，谢谢。";
 "feedback.error.emptyContent" = "请输入反馈内容。";
+"feedback.error.invalidImage" = "无法读取这张图片。";
 "feedback.error.server" = "提交反馈失败。";
 "feedback.error.invalidResponse" = "收到的反馈响应无效。";
 

--- a/Sources/Typeflux/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/zh-Hant.lproj/Localizable.strings
@@ -34,9 +34,13 @@
 "feedback.direct.contentPlaceholder" = "請簡單說說你遇到的問題或想法。\n例如：我按下快捷鍵後沒有開始轉寫，重新啟動 App 後還是一樣。\n也可以寫：我希望轉寫完成後自動複製到剪貼簿。";
 "feedback.direct.contactLabel" = "聯絡方式（選填）";
 "feedback.direct.contactPlaceholder" = "電子郵件或其他聯絡方式";
+"feedback.direct.imagesLabel" = "圖片";
+"feedback.direct.addImage" = "新增圖片";
+"feedback.direct.removeImage" = "移除圖片";
 "feedback.direct.submit" = "提交";
 "feedback.toast.submitted" = "回饋已提交，謝謝。";
 "feedback.error.emptyContent" = "請輸入回饋內容。";
+"feedback.error.invalidImage" = "無法讀取這張圖片。";
 "feedback.error.server" = "提交回饋失敗。";
 "feedback.error.invalidResponse" = "收到的回饋回應無效。";
 

--- a/Sources/Typeflux/Settings/SettingsView.swift
+++ b/Sources/Typeflux/Settings/SettingsView.swift
@@ -1,5 +1,6 @@
 import AppKit
 import SwiftUI
+import UniformTypeIdentifiers
 
 // swiftlint:disable file_length
 private enum VocabularyFilter: String, CaseIterable, Identifiable {
@@ -200,6 +201,8 @@ struct StudioView: View {
     @State private var isDirectFeedbackPresented = false
     @State private var feedbackContent = ""
     @State private var feedbackContact = ""
+    @State private var feedbackImages: [FeedbackImageAttachment] = []
+    @State private var feedbackImageUploadTasks: [FeedbackImageAttachment.ID: Task<Void, Never>] = [:]
     @State private var isSubmittingFeedback = false
     @State private var feedbackSubmissionError: String?
     @State private var agentConfigurationTab: AgentConfigurationTab = .general
@@ -369,7 +372,10 @@ struct StudioView: View {
         .sheet(isPresented: $viewModel.showingJobsPage) {
             agentJobsSheet
         }
-        .sheet(isPresented: $isDirectFeedbackPresented) {
+        .sheet(
+            isPresented: $isDirectFeedbackPresented,
+            onDismiss: cancelAllFeedbackImageUploads
+        ) {
             directFeedbackSheet
         }
     }
@@ -378,9 +384,13 @@ struct StudioView: View {
         DirectFeedbackSheet(
             content: $feedbackContent,
             contact: $feedbackContact,
+            images: $feedbackImages,
             isSubmitting: isSubmittingFeedback,
             errorMessage: feedbackSubmissionError,
+            onAddImages: selectFeedbackImages,
+            onRemoveImage: removeFeedbackImage,
             onCancel: {
+                cancelAllFeedbackImageUploads()
                 isDirectFeedbackPresented = false
             },
             onSubmit: submitDirectFeedback
@@ -388,8 +398,11 @@ struct StudioView: View {
     }
 
     private func openDirectFeedback() {
+        cancelAllFeedbackImageUploads()
         feedbackContent = ""
         feedbackContact = authState.userProfile?.email ?? ""
+        feedbackImages = []
+        feedbackImageUploadTasks = [:]
         feedbackSubmissionError = nil
         isSubmittingFeedback = false
         isDirectFeedbackPresented = true
@@ -418,23 +431,132 @@ struct StudioView: View {
     private func submitDirectFeedback() {
         let content = feedbackContent
         let contact = feedbackContact
+        let imageURLs = feedbackImages.compactMap(\.state.uploadedURL)
         let token = authState.accessToken
         isSubmittingFeedback = true
         feedbackSubmissionError = nil
 
         Task { @MainActor in
             do {
-                _ = try await FeedbackAPIService.submit(content: content, contact: contact, token: token)
+                _ = try await FeedbackAPIService.submit(
+                    content: content,
+                    contact: contact,
+                    imageURLs: imageURLs,
+                    token: token
+                )
                 isSubmittingFeedback = false
                 isDirectFeedbackPresented = false
                 feedbackContent = ""
                 feedbackContact = ""
+                feedbackImages = []
                 viewModel.showToast(L("feedback.toast.submitted"))
             } catch {
                 isSubmittingFeedback = false
                 feedbackSubmissionError = error.localizedDescription
             }
         }
+    }
+
+    private func selectFeedbackImages() {
+        let remainingSlots = max(0, 4 - feedbackImages.count)
+        guard remainingSlots > 0 else { return }
+
+        let panel = NSOpenPanel()
+        panel.allowsMultipleSelection = true
+        panel.canChooseDirectories = false
+        panel.canChooseFiles = true
+        panel.allowedContentTypes = [.jpeg, .png, .webP, .gif]
+
+        guard panel.runModal() == .OK else { return }
+        let selectedURLs = Array(panel.urls.prefix(remainingSlots))
+        for url in selectedURLs {
+            enqueueFeedbackImageUpload(from: url)
+        }
+    }
+
+    private func removeFeedbackImage(id: FeedbackImageAttachment.ID) {
+        feedbackImageUploadTasks.removeValue(forKey: id)?.cancel()
+        feedbackImages.removeAll { $0.id == id }
+    }
+
+    private func enqueueFeedbackImageUpload(from url: URL) {
+        let id = UUID()
+        feedbackImages.append(
+            FeedbackImageAttachment(
+                id: id,
+                filename: url.lastPathComponent,
+                state: .preparing
+            )
+        )
+
+        let token = authState.accessToken
+        let task = Task.detached(priority: .utility) {
+            do {
+                try Task.checkCancellation()
+                let prepared = try FeedbackImageProcessor.prepare(url: url)
+                try Task.checkCancellation()
+                await updateFeedbackImage(id: id) { image in
+                    image.filename = prepared.filename
+                    image.thumbnail = prepared.thumbnail
+                    image.state = .uploading
+                }
+                try Task.checkCancellation()
+
+                let target = try await FeedbackAPIService.createImageUploadTarget(
+                    filename: prepared.filename,
+                    contentType: prepared.contentType,
+                    sizeBytes: Int64(prepared.data.count),
+                    token: token
+                )
+                try Task.checkCancellation()
+                try await FeedbackAPIService.uploadImage(
+                    data: prepared.data,
+                    filename: prepared.filename,
+                    contentType: prepared.contentType,
+                    to: target
+                )
+                try Task.checkCancellation()
+
+                await updateFeedbackImage(id: id) { image in
+                    image.state = .uploaded(target.imageURL)
+                }
+            } catch is CancellationError {
+                await clearFeedbackImageUploadTask(id: id)
+                return
+            } catch {
+                guard !Task.isCancelled else {
+                    await clearFeedbackImageUploadTask(id: id)
+                    return
+                }
+                await updateFeedbackImage(id: id) { image in
+                    image.state = .failed(error.localizedDescription)
+                }
+            }
+            await clearFeedbackImageUploadTask(id: id)
+        }
+        feedbackImageUploadTasks[id] = task
+    }
+
+    @MainActor
+    private func updateFeedbackImage(
+        id: FeedbackImageAttachment.ID,
+        mutate: (inout FeedbackImageAttachment) -> Void
+    ) {
+        guard let index = feedbackImages.firstIndex(where: { $0.id == id }) else {
+            return
+        }
+        mutate(&feedbackImages[index])
+    }
+
+    @MainActor
+    private func clearFeedbackImageUploadTask(id: FeedbackImageAttachment.ID) {
+        feedbackImageUploadTasks.removeValue(forKey: id)
+    }
+
+    @MainActor
+    private func cancelAllFeedbackImageUploads() {
+        feedbackImageUploadTasks.values.forEach { $0.cancel() }
+        feedbackImageUploadTasks = [:]
     }
 
     private func handleAccountAction() {

--- a/Tests/TypefluxTests/FeedbackAPIServiceTests.swift
+++ b/Tests/TypefluxTests/FeedbackAPIServiceTests.swift
@@ -32,6 +32,7 @@ final class FeedbackAPIServiceTests: XCTestCase {
             let dict = try JSONSerialization.jsonObject(with: body) as? [String: Any]
             XCTAssertEqual(dict?["content"] as? String, "Please fix this")
             XCTAssertEqual(dict?["contact"] as? String, "user@example.com")
+            XCTAssertEqual(dict?["image_urls"] as? [String], ["https://cdn.example/image.jpg"])
 
             let payload = Data(#"{"code":"OK","data":{"id":"feedback-1","status":"pending"}}"#.utf8)
             return (payload, Self.httpResponse(url: request.url!, status: 200))
@@ -41,6 +42,7 @@ final class FeedbackAPIServiceTests: XCTestCase {
         let response = try await FeedbackAPIService.submit(
             content: "  Please fix this  ",
             contact: " user@example.com ",
+            imageURLs: ["https://cdn.example/image.jpg"],
             token: "token-1",
             executor: executor
         )
@@ -71,6 +73,124 @@ final class FeedbackAPIServiceTests: XCTestCase {
         )
 
         XCTAssertEqual(response, FeedbackSubmissionResponse(id: "feedback-2", status: "pending"))
+    }
+
+    func testCreateImageUploadTargetPostsPresignRequest() async throws {
+        let session = FeedbackStubSession()
+        await session.setHandler { request in
+            XCTAssertEqual(request.url?.absoluteString, "https://api.example/api/v1/feedback/uploads/presign")
+            XCTAssertEqual(request.httpMethod, "POST")
+            XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "application/json")
+            XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer token-1")
+
+            let body = try XCTUnwrap(request.httpBody)
+            let dict = try JSONSerialization.jsonObject(with: body) as? [String: Any]
+            XCTAssertEqual(dict?["filename"] as? String, "screen.jpg")
+            XCTAssertEqual(dict?["content_type"] as? String, "image/jpeg")
+            XCTAssertEqual(dict?["size_bytes"] as? Int, 123)
+
+            let payload = Data(
+                """
+                {"code":"OK","data":{"type":"s3_presigned_post","method":"POST","url":"https://s3.example/upload","bucket":"bucket","region":"us-east-1","key":"feedback/screen.jpg","expires_at":1777960800,"max_size_bytes":5242880,"headers":{"x-test":"1"},"fields":{"key":"feedback/screen.jpg","policy":"abc"},"image_url":"https://cdn.example/feedback/screen.jpg","upload_id":"upload-1"}}
+                """.utf8
+            )
+            return (payload, Self.httpResponse(url: request.url!, status: 200))
+        }
+        let executor = makeExecutor(session: session)
+
+        let target = try await FeedbackAPIService.createImageUploadTarget(
+            filename: "screen.jpg",
+            contentType: "image/jpeg",
+            sizeBytes: 123,
+            token: "token-1",
+            executor: executor
+        )
+
+        XCTAssertEqual(target.url, "https://s3.example/upload")
+        XCTAssertEqual(target.fields["policy"], "abc")
+        XCTAssertEqual(target.imageURL, "https://cdn.example/feedback/screen.jpg")
+    }
+
+    func testUploadImagePostsMultipartFieldsAndFileToPresignedTarget() async throws {
+        let session = FeedbackStubSession()
+        await session.setHandler { request in
+            XCTAssertEqual(request.url?.absoluteString, "https://s3.example/upload")
+            XCTAssertEqual(request.httpMethod, "POST")
+            XCTAssertEqual(request.value(forHTTPHeaderField: "x-amz-meta-purpose"), "feedback")
+            XCTAssertTrue(request.value(forHTTPHeaderField: "Content-Type")?.contains("multipart/form-data; boundary=") == true)
+
+            let body = String(data: try XCTUnwrap(request.httpBody), encoding: .utf8)
+            XCTAssertTrue(body?.contains("name=\"key\"") == true)
+            XCTAssertTrue(body?.contains("feedback/screen.jpg") == true)
+            XCTAssertTrue(body?.contains("name=\"file\"; filename=\"screen.jpg\"") == true)
+            XCTAssertTrue(body?.contains("Content-Type: image/jpeg") == true)
+            XCTAssertTrue(body?.contains("image-data") == true)
+
+            return (Data(), Self.httpResponse(url: request.url!, status: 204))
+        }
+
+        try await FeedbackAPIService.uploadImage(
+            data: Data("image-data".utf8),
+            filename: "screen.jpg",
+            contentType: "image/jpeg",
+            to: FeedbackUploadTarget(
+                type: "s3_presigned_post",
+                method: "POST",
+                url: "https://s3.example/upload",
+                bucket: "bucket",
+                region: "us-east-1",
+                key: "feedback/screen.jpg",
+                expiresAt: 1_777_960_800,
+                maxSizeBytes: 5_242_880,
+                headers: ["x-amz-meta-purpose": "feedback"],
+                fields: ["key": "feedback/screen.jpg", "policy": "abc"],
+                imageURL: "https://cdn.example/feedback/screen.jpg",
+                uploadID: "upload-1"
+            ),
+            session: session
+        )
+    }
+
+    func testUploadImagePropagatesTaskCancellation() async throws {
+        let session = FeedbackStubSession()
+        await session.setHandler { request in
+            try await Task.sleep(nanoseconds: 5_000_000_000)
+            return (Data(), Self.httpResponse(url: request.url!, status: 204))
+        }
+
+        let task = Task {
+            try await FeedbackAPIService.uploadImage(
+                data: Data("image-data".utf8),
+                filename: "screen.jpg",
+                contentType: "image/jpeg",
+                to: FeedbackUploadTarget(
+                    type: "s3_presigned_post",
+                    method: "POST",
+                    url: "https://s3.example/upload",
+                    bucket: "bucket",
+                    region: "us-east-1",
+                    key: "feedback/screen.jpg",
+                    expiresAt: 1_777_960_800,
+                    maxSizeBytes: 5_242_880,
+                    headers: [:],
+                    fields: ["key": "feedback/screen.jpg", "policy": "abc"],
+                    imageURL: "https://cdn.example/feedback/screen.jpg",
+                    uploadID: "upload-1"
+                ),
+                session: session
+            )
+        }
+
+        try await Task.sleep(nanoseconds: 10_000_000)
+        task.cancel()
+
+        do {
+            try await task.value
+            XCTFail("Expected cancelled upload to throw CancellationError")
+        } catch is CancellationError {
+            let callCount = await session.callCount
+            XCTAssertEqual(callCount, 1)
+        }
     }
 
     func testSubmitRejectsEmptyContentBeforeNetworkRequest() async throws {

--- a/Tests/TypefluxTests/FeedbackImageProcessorTests.swift
+++ b/Tests/TypefluxTests/FeedbackImageProcessorTests.swift
@@ -1,0 +1,37 @@
+@testable import Typeflux
+import AppKit
+import XCTest
+
+final class FeedbackImageProcessorTests: XCTestCase {
+    func testPrepareCompressesImageToJPEGWithinMaxDimension() throws {
+        let imageURL = try makeTemporaryPNG(width: 2_400, height: 1_200)
+        defer { try? FileManager.default.removeItem(at: imageURL.deletingLastPathComponent()) }
+
+        let prepared = try FeedbackImageProcessor.prepare(url: imageURL)
+
+        XCTAssertEqual(prepared.filename, "feedback-source.jpg")
+        XCTAssertEqual(prepared.contentType, "image/jpeg")
+        XCTAssertFalse(prepared.data.isEmpty)
+
+        let rep = try XCTUnwrap(NSBitmapImageRep(data: prepared.data))
+        XCTAssertLessThanOrEqual(max(rep.pixelsWide, rep.pixelsHigh), FeedbackImageProcessor.maxPixelDimension)
+    }
+
+    private func makeTemporaryPNG(width: Int, height: Int) throws -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("typeflux-feedback-image-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+
+        let image = NSImage(size: NSSize(width: width, height: height))
+        image.lockFocus()
+        NSColor.systemBlue.setFill()
+        NSRect(x: 0, y: 0, width: width, height: height).fill()
+        image.unlockFocus()
+
+        let rep = try XCTUnwrap(NSBitmapImageRep(data: try XCTUnwrap(image.tiffRepresentation)))
+        let data = try XCTUnwrap(rep.representation(using: .png, properties: [:]))
+        let url = directory.appendingPathComponent("feedback-source.png")
+        try data.write(to: url)
+        return url
+    }
+}


### PR DESCRIPTION
## Summary

为问题反馈功能增加图片附件上传支持。

- 通过 S3 presigned URL 实现图片直传
- 本地压缩（长边 1600px、JPEG 质量 0.78）后上传
- 直接反馈对话框使用 68×68 正方形缩略图展示，支持删除
- 单次最多 4 张，所有图片上传完成前提交按钮不可点击
- 5 种语言本地化资源完整

Closes TYP-78

## Test plan

- [x] `swift test --filter TypefluxTests.FeedbackImageProcessorTests` → 通过
- [x] `swift test --filter TypefluxTests.FeedbackAPIServiceTests` → 通过
- [x] `swift build` → 编译成功
- [ ] 建议合入前手动走一遍完整 UI 路径（端到端）

## Changes

| 文件 | 说明 |
|------|------|
| `FeedbackImageProcessor.swift` | 新增：本地压缩 + S3 presigned 上传 |
| `DirectFeedbackSheet.swift` | 缩略图网格、删除、上传状态联动 |
| `FeedbackAPIService.swift` | 增加 presign 接口和 multipart 上传 |
| `CloudRequestExecutor.swift` | 暴露 `baseURL` 供 presign 接口使用 |
| `SettingsView.swift` | 增加设置项 |
| `Localizable.strings` (×5) | 新增本地化文案 |
| `FeedbackAPIServiceTests.swift` | 补充 presign + upload 测试 |
| `FeedbackImageProcessorTests.swift` | 新增：压缩和取消链路测试 |