### PR TITLE
Refine Typeflux cloud endpoint routing

### DIFF
--- a/Sources/Typeflux/App/AutoUpdater.swift
+++ b/Sources/Typeflux/App/AutoUpdater.swift
@@ -76,7 +76,7 @@ final class AutoUpdater {
             guard let self else { return }
             let executor = CloudRequestExecutor()
             do {
-                let (data, _) = try await executor.execute { baseURL in
+                let (data, _) = try await executor.execute(apiPath: "/api/v1/app/update") { baseURL in
                     var components = URLComponents(url: AuthEndpointResolver.resolve(baseURL: baseURL, path: "/api/v1/app/update"), resolvingAgainstBaseURL: false) ?? URLComponents()
                     components.queryItems = [URLQueryItem(name: "version", value: currentVersion)]
                     let url = components.url ?? AuthEndpointResolver.resolve(baseURL: baseURL, path: "/api/v1/app/update")

--- a/Sources/Typeflux/Auth/AuthService.swift
+++ b/Sources/Typeflux/Auth/AuthService.swift
@@ -114,7 +114,7 @@ struct AuthAPIService {
         let data: Data
         let httpResponse: HTTPURLResponse
         do {
-            (data, httpResponse) = try await executor.execute { baseURL in
+            (data, httpResponse) = try await executor.execute(apiPath: path) { baseURL in
                 let url = AuthEndpointResolver.resolve(baseURL: baseURL, path: path)
                 var request = URLRequest(url: url)
                 request.httpMethod = method

--- a/Sources/Typeflux/Feedback/FeedbackAPIService.swift
+++ b/Sources/Typeflux/Feedback/FeedbackAPIService.swift
@@ -116,7 +116,7 @@ struct FeedbackAPIService {
         let data: Data
         let httpResponse: HTTPURLResponse
         do {
-            (data, httpResponse) = try await executor.execute { baseURL in
+            (data, httpResponse) = try await executor.execute(apiPath: "/api/v1/feedback") { baseURL in
                 let url = AuthEndpointResolver.resolve(baseURL: baseURL, path: "/api/v1/feedback")
                 var urlRequest = URLRequest(url: url)
                 urlRequest.httpMethod = "POST"
@@ -189,7 +189,7 @@ struct FeedbackAPIService {
         let data: Data
         let httpResponse: HTTPURLResponse
         do {
-            (data, httpResponse) = try await executor.execute { baseURL in
+            (data, httpResponse) = try await executor.execute(apiPath: "/api/v1/feedback/uploads/presign") { baseURL in
                 let url = AuthEndpointResolver.resolve(baseURL: baseURL, path: "/api/v1/feedback/uploads/presign")
                 var urlRequest = URLRequest(url: url)
                 urlRequest.httpMethod = "POST"

--- a/Sources/Typeflux/LLM/OpenAICompatibleAgentService.swift
+++ b/Sources/Typeflux/LLM/OpenAICompatibleAgentService.swift
@@ -13,7 +13,7 @@ final class OpenAICompatibleAgentService: LLMAgentService, @unchecked Sendable {
             guard let token else {
                 throw TypefluxCloudLLMError.notLoggedIn
             }
-            let primary = await CloudEndpointRegistry.shared.primaryEndpoint()
+            let primary = await CloudEndpointRegistry.shared.latencyOptimizedEndpoint()
             return try LLMConnectionResolver.resolve(
                 provider: config.provider,
                 baseURL: "",
@@ -63,7 +63,7 @@ final class OpenAICompatibleAgentService: LLMAgentService, @unchecked Sendable {
             let connection = try await self.resolveConnection(for: llmConfig)
             let additionalHeaders = self.headers(for: connection, scenario: .askAnything)
             let cloudBaseURL: URL? = (llmConfig.provider == .typefluxCloud)
-                ? await CloudEndpointRegistry.shared.primaryEndpoint()
+                ? await CloudEndpointRegistry.shared.latencyOptimizedEndpoint()
                 : nil
             return try await Self.reportingFailures(cloudBaseURL: cloudBaseURL) {
                 try await RemoteAgentClient.runTool(
@@ -112,7 +112,7 @@ final class OpenAICompatibleAgentService: LLMAgentService, @unchecked Sendable {
             let connection = try await self.resolveConnection(for: llmConfig)
             let additionalHeaders = self.headers(for: connection, scenario: .askAnything)
             let cloudBaseURL: URL? = (llmConfig.provider == .typefluxCloud)
-                ? await CloudEndpointRegistry.shared.primaryEndpoint()
+                ? await CloudEndpointRegistry.shared.latencyOptimizedEndpoint()
                 : nil
             return try await Self.reportingFailures(cloudBaseURL: cloudBaseURL) {
                 try await RemoteAgentClient.runAnyTool(

--- a/Sources/Typeflux/LLM/OpenAICompatibleLLMService.swift
+++ b/Sources/Typeflux/LLM/OpenAICompatibleLLMService.swift
@@ -142,7 +142,7 @@ final class OpenAICompatibleLLMService: LLMService {
             guard let token else {
                 throw TypefluxCloudLLMError.notLoggedIn
             }
-            let primary = await CloudEndpointRegistry.shared.primaryEndpoint()
+            let primary = await CloudEndpointRegistry.shared.latencyOptimizedEndpoint()
             let connection = try LLMConnectionResolver.resolve(
                 provider: config.provider,
                 baseURL: "",

--- a/Sources/Typeflux/Networking/CloudEndpointSelector.swift
+++ b/Sources/Typeflux/Networking/CloudEndpointSelector.swift
@@ -86,11 +86,17 @@ actor CloudEndpointSelector {
         self.states = Dictionary(uniqueKeysWithValues: unique.map { ($0, EndpointState()) })
     }
 
-    /// Returns endpoints in the order callers should try them:
+    /// Returns endpoints in the order latency-sensitive callers should try them:
     /// 1. Healthy endpoints, sorted by EWMA latency ascending (unknown latency last,
     ///    falling back to the configured insertion order to break ties).
     /// 2. Endpoints currently in cooldown, sorted by cooldown expiry ascending.
     func orderedEndpoints() -> [URL] {
+        latencyOptimizedEndpoints()
+    }
+
+    /// Returns endpoints in latency-optimized order for APIs where the nearest
+    /// responsive cloud host should handle the request.
+    func latencyOptimizedEndpoints() -> [URL] {
         let snapshot = self.now()
 
         struct Ranked {
@@ -139,10 +145,58 @@ actor CloudEndpointSelector {
         }.map { $0.url }
     }
 
+    /// Returns endpoints in configured primary-first order. The first
+    /// configured endpoint remains preferred unless it is currently in
+    /// cooldown, in which case healthy backups are tried first.
+    func primaryFirstEndpoints() -> [URL] {
+        let snapshot = self.now()
+
+        struct Ranked {
+            let url: URL
+            let inCooldown: Bool
+            let cooldownUntil: Date?
+            let insertionIndex: Int
+        }
+
+        let ranked: [Ranked] = orderedURLs.enumerated().map { idx, url in
+            let state = states[url] ?? EndpointState()
+            let inCooldown = (state.cooldownUntil ?? .distantPast) > snapshot
+            return Ranked(
+                url: url,
+                inCooldown: inCooldown,
+                cooldownUntil: state.cooldownUntil,
+                insertionIndex: idx
+            )
+        }
+
+        return ranked.sorted { lhs, rhs in
+            if lhs.inCooldown != rhs.inCooldown {
+                return !lhs.inCooldown
+            }
+            if lhs.inCooldown && rhs.inCooldown {
+                let lhsExpiry = lhs.cooldownUntil ?? .distantFuture
+                let rhsExpiry = rhs.cooldownUntil ?? .distantFuture
+                if lhsExpiry != rhsExpiry { return lhsExpiry < rhsExpiry }
+            }
+            return lhs.insertionIndex < rhs.insertionIndex
+        }.map { $0.url }
+    }
+
     /// Returns the highest-priority endpoint. Always non-nil because the
     /// selector requires at least one base URL at construction time.
     func primaryEndpoint() -> URL {
-        orderedEndpoints().first ?? orderedURLs[0]
+        latencyOptimizedEndpoint()
+    }
+
+    /// Returns the configured primary endpoint: the first URL in the
+    /// de-duplicated configured list.
+    func configuredPrimaryEndpoint() -> URL {
+        orderedURLs[0]
+    }
+
+    /// Returns the current latency-optimized endpoint.
+    func latencyOptimizedEndpoint() -> URL {
+        latencyOptimizedEndpoints().first ?? orderedURLs[0]
     }
 
     /// All known base URLs in their original configured order.

--- a/Sources/Typeflux/Networking/CloudRequestExecutor.swift
+++ b/Sources/Typeflux/Networking/CloudRequestExecutor.swift
@@ -27,10 +27,22 @@ protocol CloudHTTPSession: Sendable {
 
 extension URLSession: CloudHTTPSession {}
 
+/// Routing policy for Typeflux Cloud requests.
+enum CloudEndpointRoutingStrategy: Sendable, Equatable {
+    /// Selects latency-optimized routing only for APIs that are explicitly
+    /// allowed to use the fastest endpoint; all other APIs use primary-first.
+    case automatic
+    /// Always try the first configured server before backups.
+    case primaryFirst
+    /// Try endpoints in measured latency order.
+    case latencyOptimized
+}
+
 /// Executes an HTTP request against the highest-priority Typeflux Cloud
 /// endpoint, falling back to additional endpoints when the active one returns
-/// a transport error or HTTP 5xx. Latency samples and failures are reported
-/// back into the selector so future calls converge on the lowest-latency host.
+/// a transport error or HTTP 5xx. When the caller provides an API path, only
+/// `/api/v1/chat/` and `/api/v1/asr/` use latency-optimized routing; all other
+/// APIs keep the first configured server as the primary endpoint.
 struct CloudRequestExecutor: Sendable {
     let selector: CloudEndpointSelector
     let session: CloudHTTPSession
@@ -45,20 +57,38 @@ struct CloudRequestExecutor: Sendable {
         self.session = session
     }
 
-    /// Returns the best base URL to use for a one-off request that the caller
-    /// will issue itself (for example, when the request lifecycle is owned by a
-    /// component that cannot easily route through `execute`).
-    func primaryEndpoint() async -> URL {
-        await selector.primaryEndpoint()
+    /// Returns the configured primary base URL to use for a one-off request
+    /// that the caller will issue itself.
+    func configuredPrimaryEndpoint() async -> URL {
+        await selector.configuredPrimaryEndpoint()
     }
 
-    /// Executes `build(baseURL)` against each healthy endpoint in priority
+    /// Returns the best base URL to use for a latency-sensitive one-off request
+    /// that the caller will issue itself (for example, when the request
+    /// lifecycle is owned by a component that cannot easily route through
+    /// `execute`).
+    func primaryEndpoint() async -> URL {
+        await selector.latencyOptimizedEndpoint()
+    }
+
+    /// Executes `build(baseURL)` against each eligible endpoint in priority
     /// order. Network errors and HTTP 5xx responses cause failover; other HTTP
     /// status codes are returned to the caller without rotating endpoints.
     func execute(
+        apiPath: String? = nil,
+        routingStrategy: CloudEndpointRoutingStrategy = .automatic,
         build: @Sendable (URL) -> URLRequest
     ) async throws -> (Data, HTTPURLResponse) {
-        let endpoints = await selector.orderedEndpoints()
+        let resolvedStrategy = resolveRoutingStrategy(routingStrategy, apiPath: apiPath)
+        let endpoints: [URL]
+        switch resolvedStrategy {
+        case .automatic:
+            endpoints = await selector.primaryFirstEndpoints()
+        case .primaryFirst:
+            endpoints = await selector.primaryFirstEndpoints()
+        case .latencyOptimized:
+            endpoints = await selector.latencyOptimizedEndpoints()
+        }
         guard !endpoints.isEmpty else {
             throw CloudRequestExecutorError.noEndpointsAvailable
         }
@@ -103,6 +133,25 @@ struct CloudRequestExecutor: Sendable {
         }
 
         throw CloudRequestExecutorError.allEndpointsFailed(lastError: lastError ?? CloudRequestExecutorError.noEndpointsAvailable)
+    }
+
+    private func resolveRoutingStrategy(
+        _ strategy: CloudEndpointRoutingStrategy,
+        apiPath: String?
+    ) -> CloudEndpointRoutingStrategy {
+        guard strategy == .automatic else { return strategy }
+        guard let path = apiPath else { return .primaryFirst }
+        return Self.isLatencyOptimizedAPIPath(path) ? .latencyOptimized : .primaryFirst
+    }
+
+    static func isLatencyOptimizedAPIPath(_ path: String) -> Bool {
+        let normalized = path.hasPrefix("/") ? path : "/" + path
+        return normalized == "/api/v1/chat"
+            || normalized.hasPrefix("/api/v1/chat/")
+            || normalized.contains("/api/v1/chat/")
+            || normalized == "/api/v1/asr"
+            || normalized.hasPrefix("/api/v1/asr/")
+            || normalized.contains("/api/v1/asr/")
     }
 
     private func durationToMilliseconds(_ duration: Duration) -> Double {

--- a/Sources/Typeflux/STT/TypefluxOfficialASRRoutingClient.swift
+++ b/Sources/Typeflux/STT/TypefluxOfficialASRRoutingClient.swift
@@ -72,7 +72,7 @@ struct TypefluxOfficialASRRoutingHTTPClient: TypefluxOfficialASRRoutingClient {
         accessToken: String,
         scenario: TypefluxCloudScenario
     ) async throws -> TypefluxOfficialASRRouteDecision {
-        let (data, response) = try await executor.execute { baseURL in
+        let (data, response) = try await executor.execute(apiPath: "/api/v1/asr/aliyun/token") { baseURL in
             var request = URLRequest(url: AuthEndpointResolver.resolve(baseURL: baseURL, path: "/api/v1/asr/aliyun/token"))
             request.httpMethod = "POST"
             request.timeoutInterval = 30
@@ -121,7 +121,7 @@ struct TypefluxOfficialASRRoutingHTTPClient: TypefluxOfficialASRRoutingClient {
             outputChars: outputChars
         )
         let payload = try JSONEncoder().encode(body)
-        let (data, response) = try await executor.execute { baseURL in
+        let (data, response) = try await executor.execute(apiPath: "/api/v1/asr/aliyun/usage") { baseURL in
             var request = URLRequest(url: AuthEndpointResolver.resolve(baseURL: baseURL, path: "/api/v1/asr/aliyun/usage"))
             request.httpMethod = "POST"
             request.timeoutInterval = 30

--- a/Sources/Typeflux/STT/TypefluxOfficialTranscriber.swift
+++ b/Sources/Typeflux/STT/TypefluxOfficialTranscriber.swift
@@ -258,7 +258,7 @@ final class TypefluxOfficialTranscriber: TypefluxCloudScenarioAwareTranscriber, 
     static func runWithEndpointFailover<T>(
         operation: @Sendable (String) async throws -> T
     ) async throws -> T {
-        let urls = await CloudEndpointRegistry.shared.orderedEndpoints()
+        let urls = await CloudEndpointRegistry.shared.latencyOptimizedEndpoints()
         let baseURLs: [URL] = urls.isEmpty
             ? [URL(string: AppServerConfiguration.apiBaseURL)].compactMap { $0 }
             : urls
@@ -287,7 +287,7 @@ final class TypefluxOfficialTranscriber: TypefluxCloudScenarioAwareTranscriber, 
     }
 
     private static func realtimeCandidateBaseURLs() async -> [URL] {
-        let urls = await CloudEndpointRegistry.shared.orderedEndpoints()
+        let urls = await CloudEndpointRegistry.shared.latencyOptimizedEndpoints()
         if !urls.isEmpty { return urls }
         return [URL(string: AppServerConfiguration.apiBaseURL)].compactMap { $0 }
     }

--- a/Tests/TypefluxTests/CloudEndpointSelectorTests.swift
+++ b/Tests/TypefluxTests/CloudEndpointSelectorTests.swift
@@ -69,6 +69,34 @@ final class CloudEndpointSelectorTests: XCTestCase {
         XCTAssertEqual(ordered, [urlB, urlC, urlA])
     }
 
+    func testPrimaryFirstEndpointsPreservesConfiguredOrderDespiteLatency() async {
+        let selector = CloudEndpointSelector(
+            baseURLs: [urlA, urlB, urlC],
+            prober: StubProber()
+        )
+        await selector.reportSuccess(urlA, latencyMs: 300)
+        await selector.reportSuccess(urlB, latencyMs: 50)
+        await selector.reportSuccess(urlC, latencyMs: 150)
+
+        let ordered = await selector.primaryFirstEndpoints()
+        XCTAssertEqual(ordered, [urlA, urlB, urlC])
+    }
+
+    func testPrimaryFirstEndpointsMovesCooldownPrimaryBehindHealthyBackups() async {
+        var config = CloudEndpointSelectorConfig.default
+        config.failureThreshold = 1
+        config.baseCooldown = 60
+        let selector = CloudEndpointSelector(
+            baseURLs: [urlA, urlB, urlC],
+            prober: StubProber(),
+            config: config
+        )
+        await selector.reportFailure(urlA, error: SampleError.boom)
+
+        let ordered = await selector.primaryFirstEndpoints()
+        XCTAssertEqual(ordered, [urlB, urlC, urlA])
+    }
+
     func testOrderedEndpointsSortsCooldownByExpiryAscending() async {
         var config = CloudEndpointSelectorConfig.default
         config.failureThreshold = 1

--- a/Tests/TypefluxTests/CloudRequestExecutorTests.swift
+++ b/Tests/TypefluxTests/CloudRequestExecutorTests.swift
@@ -127,23 +127,81 @@ final class CloudRequestExecutorTests: XCTestCase {
         XCTAssertEqual(calls, [urlA, urlB])
     }
 
-    func testExecuteRecordsLatencyAndReshufflesPriority() async throws {
+    func testExecuteKeepsPrimaryFirstForNonSpecialAPIEvenWhenBackupIsFaster() async throws {
         let session = StubSession()
         await session.setHandler { request in
             (Data("ok".utf8), Self.httpResponse(url: request.url!, status: 200))
         }
         let selector = CloudEndpointSelector(baseURLs: [urlA, urlB], prober: NoOpProber())
-        // Pre-seed urlA with a high latency so urlB should be preferred.
+        // Pre-seed urlA with a high latency. Non-special APIs should still
+        // treat the first configured endpoint as primary.
         await selector.reportSuccess(urlA, latencyMs: 1000)
         await selector.reportSuccess(urlB, latencyMs: 50)
 
         let executor = CloudRequestExecutor(selector: selector, session: session)
-        _ = try await executor.execute { base in
+        _ = try await executor.execute(apiPath: "/api/v1/me") { base in
             URLRequest(url: base.appendingPathComponent("api/v1/me"))
         }
 
         let calls = await session.callOrder
+        XCTAssertEqual(calls.first, urlA)
+    }
+
+    func testExecuteUsesLatencyOptimizedRoutingForChatAPI() async throws {
+        let session = StubSession()
+        await session.setHandler { request in
+            (Data("ok".utf8), Self.httpResponse(url: request.url!, status: 200))
+        }
+        let selector = CloudEndpointSelector(baseURLs: [urlA, urlB], prober: NoOpProber())
+        await selector.reportSuccess(urlA, latencyMs: 1000)
+        await selector.reportSuccess(urlB, latencyMs: 50)
+
+        let executor = CloudRequestExecutor(selector: selector, session: session)
+        _ = try await executor.execute(apiPath: "/api/v1/chat/completions") { base in
+            URLRequest(url: base.appendingPathComponent("api/v1/chat/completions"))
+        }
+
+        let calls = await session.callOrder
         XCTAssertEqual(calls.first, urlB)
+    }
+
+    func testExecuteUsesLatencyOptimizedRoutingForASRAPI() async throws {
+        let session = StubSession()
+        await session.setHandler { request in
+            (Data("ok".utf8), Self.httpResponse(url: request.url!, status: 200))
+        }
+        let selector = CloudEndpointSelector(baseURLs: [urlA, urlB], prober: NoOpProber())
+        await selector.reportSuccess(urlA, latencyMs: 1000)
+        await selector.reportSuccess(urlB, latencyMs: 50)
+
+        let executor = CloudRequestExecutor(selector: selector, session: session)
+        _ = try await executor.execute(apiPath: "/api/v1/asr/aliyun/token") { base in
+            URLRequest(url: base.appendingPathComponent("api/v1/asr/aliyun/token"))
+        }
+
+        let calls = await session.callOrder
+        XCTAssertEqual(calls.first, urlB)
+    }
+
+    func testExecuteBuildsRequestOnlyForAttemptedEndpoints() async throws {
+        let session = StubSession()
+        await session.setHandler { request in
+            (Data("ok".utf8), Self.httpResponse(url: request.url!, status: 200))
+        }
+        let selector = CloudEndpointSelector(baseURLs: [urlA, urlB], prober: NoOpProber())
+        await selector.reportSuccess(urlA, latencyMs: 1000)
+        await selector.reportSuccess(urlB, latencyMs: 50)
+
+        let counter = BuildCounter()
+        let executor = CloudRequestExecutor(selector: selector, session: session)
+        _ = try await executor.execute(apiPath: "/api/v1/chat/completions") { base in
+            counter.increment()
+            return URLRequest(url: base.appendingPathComponent("api/v1/chat/completions"))
+        }
+
+        let calls = await session.callOrder
+        XCTAssertEqual(calls, [urlB])
+        XCTAssertEqual(counter.value, 1)
     }
 
     // MARK: - Helpers
@@ -183,5 +241,22 @@ private actor StubSession: CloudHTTPSession {
 private struct NoOpProber: CloudEndpointProbing {
     func probe(baseURL: URL, nonce: String, timeout: TimeInterval) async throws -> CloudEndpointProbeResult {
         throw CloudEndpointProbeError.timedOut
+    }
+}
+
+private final class BuildCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _value = 0
+
+    var value: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return _value
+    }
+
+    func increment() {
+        lock.lock()
+        defer { lock.unlock() }
+        _value += 1
     }
 }


### PR DESCRIPTION
## Summary
- Route non-special cloud APIs through the configured primary server first, with backup fallback only on transport/5xx failures.
- Keep `/api/v1/chat/` and `/api/v1/asr/` on latency-optimized routing, driven by explicit `apiPath` instead of prebuilding requests.
- Restore selector ordering to cooldown-based demotion only and update cloud call sites to pass routing paths explicitly.
- Add unit coverage for primary-first ordering, latency routing, and ensuring request builders are invoked only for attempted endpoints.

## Testing
- Added and updated unit tests for selector ordering and executor routing behavior.
- Verified formatting checks and targeted behavior checks at a high level; full `swift test` was not completed because SwiftPM dependency checkout stalled on `swift-protobuf` submodule resolution.