### PR TITLE
Fix vocabulary menu and feedback UI on macOS 14.1

### DIFF
--- a/Sources/Typeflux/Feedback/DirectFeedbackSheet.swift
+++ b/Sources/Typeflux/Feedback/DirectFeedbackSheet.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 
 enum FeedbackImageUploadState: Equatable {
@@ -56,9 +57,6 @@ struct DirectFeedbackSheet: View {
     let onCancel: () -> Void
     let onSubmit: () -> Void
 
-    @FocusState private var isContentFocused: Bool
-
-    private let contentEditorPadding: CGFloat = 10
     private let contentPlaceholderHorizontalPadding: CGFloat = 13
     private let contentPlaceholderVerticalPadding: CGFloat = 15
 
@@ -87,10 +85,8 @@ struct DirectFeedbackSheet: View {
                     .foregroundStyle(StudioTheme.textSecondary)
 
                 ZStack(alignment: .topLeading) {
-                    TextEditor(text: $content)
+                    FeedbackContentTextView(text: $content)
                         .font(.studioBody(13))
-                        .scrollContentBackground(.hidden)
-                        .padding(contentEditorPadding)
                         .frame(minHeight: 160)
                         .background(StudioTheme.controlSurface)
                         .clipShape(RoundedRectangle(cornerRadius: StudioTheme.CornerRadius.medium, style: .continuous))
@@ -98,7 +94,6 @@ struct DirectFeedbackSheet: View {
                             RoundedRectangle(cornerRadius: StudioTheme.CornerRadius.medium, style: .continuous)
                                 .stroke(StudioTheme.border.opacity(0.72), lineWidth: 1)
                         }
-                        .focused($isContentFocused)
 
                     if content.isEmpty {
                         Text(L("feedback.direct.contentPlaceholder"))
@@ -192,8 +187,79 @@ struct DirectFeedbackSheet: View {
         }
         .padding(24)
         .frame(width: 480)
-        .onAppear {
-            isContentFocused = true
+    }
+}
+
+private struct FeedbackContentTextView: NSViewRepresentable {
+    @Binding var text: String
+
+    func makeNSView(context: Context) -> NSScrollView {
+        let scrollView = NSScrollView()
+        scrollView.borderType = .noBorder
+        scrollView.drawsBackground = false
+        scrollView.hasVerticalScroller = true
+        scrollView.autohidesScrollers = true
+        scrollView.scrollerStyle = .overlay
+
+        let textView = NSTextView()
+        textView.delegate = context.coordinator
+        textView.drawsBackground = false
+        textView.isRichText = false
+        textView.isAutomaticQuoteSubstitutionEnabled = false
+        textView.isAutomaticDashSubstitutionEnabled = false
+        textView.isAutomaticTextReplacementEnabled = false
+        textView.allowsUndo = true
+        textView.font = NSFont.systemFont(ofSize: 13)
+        textView.textColor = NSColor.labelColor
+        textView.string = text
+        textView.textContainerInset = NSSize(width: 10, height: 10)
+        textView.minSize = NSSize(width: 0, height: 0)
+        textView.maxSize = NSSize(width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude)
+        textView.isVerticallyResizable = true
+        textView.isHorizontallyResizable = false
+        textView.autoresizingMask = [.width]
+        textView.textContainer?.containerSize = NSSize(
+            width: scrollView.contentSize.width,
+            height: CGFloat.greatestFiniteMagnitude
+        )
+        textView.textContainer?.widthTracksTextView = true
+
+        scrollView.documentView = textView
+
+        DispatchQueue.main.async {
+            textView.window?.makeFirstResponder(textView)
+        }
+
+        return scrollView
+    }
+
+    func updateNSView(_ scrollView: NSScrollView, context: Context) {
+        scrollView.autohidesScrollers = true
+        scrollView.scrollerStyle = .overlay
+
+        guard let textView = scrollView.documentView as? NSTextView else { return }
+        textView.font = NSFont.systemFont(ofSize: 13)
+        textView.textColor = NSColor.labelColor
+
+        if textView.string != text {
+            textView.string = text
+        }
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(text: $text)
+    }
+
+    final class Coordinator: NSObject, NSTextViewDelegate {
+        @Binding private var text: String
+
+        init(text: Binding<String>) {
+            _text = text
+        }
+
+        func textDidChange(_ notification: Notification) {
+            guard let textView = notification.object as? NSTextView else { return }
+            text = textView.string
         }
     }
 }

--- a/Sources/Typeflux/Settings/SettingsView.swift
+++ b/Sources/Typeflux/Settings/SettingsView.swift
@@ -620,6 +620,8 @@ struct StudioView: View {
                         vocabularyMoreMenuLabel
                     }
                     .menuStyle(.borderlessButton)
+                    .menuIndicator(.hidden)
+                    .fixedSize(horizontal: true, vertical: false)
                     .disabled(viewModel.isSynchronizingVocabulary)
                 }
             } else if viewModel.currentSection == .agent {
@@ -3427,9 +3429,16 @@ struct StudioView: View {
     }
 
     private var vocabularyMoreMenuLabel: some View {
-        Text(L("vocabulary.action.more"))
-            .font(.studioBody(StudioTheme.Typography.body, weight: .semibold))
-            .foregroundStyle(StudioTheme.textSecondary)
+        HStack(spacing: StudioTheme.Spacing.xSmall) {
+            Text(L("vocabulary.action.more"))
+                .font(.studioBody(StudioTheme.Typography.body, weight: .semibold))
+                .foregroundStyle(StudioTheme.textSecondary)
+                .lineLimit(1)
+
+            Image(systemName: "chevron.down")
+                .font(.system(size: StudioTheme.Typography.iconXSmall, weight: .semibold))
+                .foregroundStyle(StudioTheme.textSecondary)
+        }
             .padding(.horizontal, StudioTheme.Insets.buttonHorizontal)
             .padding(.vertical, StudioTheme.Insets.buttonVertical)
             .background(
@@ -3443,6 +3452,8 @@ struct StudioView: View {
                         lineWidth: StudioTheme.BorderWidth.thin,
                     ),
             )
+            .clipShape(RoundedRectangle(cornerRadius: StudioTheme.CornerRadius.xLarge, style: .continuous))
+            .contentShape(RoundedRectangle(cornerRadius: StudioTheme.CornerRadius.xLarge, style: .continuous))
     }
 
     private func vocabularyMenuItemIcon(for source: VocabularySource) -> some View {

--- a/Sources/Typeflux/UI/StudioComponents.swift
+++ b/Sources/Typeflux/UI/StudioComponents.swift
@@ -811,7 +811,7 @@ struct StudioSidebar: View {
 
     private var feedbackMenuButton: some View {
         StudioSidebarIconMenuButton(
-            systemImage: "envelope.stack",
+            systemImage: "envelope.fill",
             accessibilityLabel: L("sidebar.feedbackAccessibility"),
         ) {
             Button(L("sidebar.feedback.directOption"), action: onSendDirectFeedback)


### PR DESCRIPTION
## Summary
- Fix the vocabulary page “More” menu so it stays compact on macOS 14.1 instead of stretching wide.
- Replace the sidebar feedback menu symbol with a compatible SF Symbol so the icon renders correctly again.
- Rework the direct feedback content editor to hide the scrollbar until the text actually overflows.

## Testing
- `swift build`
- `git diff --check`
- Manual UI-oriented validation of the affected SwiftUI/AppKit surfaces based on the implemented layout and scroll behavior changes