### PR TITLE
同步 onboarding 与设置页的快捷键状态

### DIFF
--- a/Sources/Typeflux/Settings/SettingsStore.swift
+++ b/Sources/Typeflux/Settings/SettingsStore.swift
@@ -5,6 +5,7 @@ extension Notification.Name {
     static let personaSelectionDidChange = Notification.Name(
         "SettingsStore.personaSelectionDidChange",
     )
+    static let hotkeySettingsDidChange = Notification.Name("SettingsStore.hotkeySettingsDidChange")
     static let appearanceModeDidChange = Notification.Name("SettingsStore.appearanceModeDidChange")
     static let agentConfigurationDidChange = Notification.Name("SettingsStore.agentConfigurationDidChange")
     static let localOptimizationDidEnable = Notification.Name("SettingsStore.localOptimizationDidEnable")
@@ -709,6 +710,7 @@ final class SettingsStore {
                 activationHotkeyJSON = "__unset__"
             }
             defaults.removeObject(forKey: "hotkey.custom.json")
+            NotificationCenter.default.post(name: .hotkeySettingsDidChange, object: self)
         }
     }
 
@@ -733,6 +735,7 @@ final class SettingsStore {
             } else {
                 askHotkeyJSON = "__unset__"
             }
+            NotificationCenter.default.post(name: .hotkeySettingsDidChange, object: self)
         }
     }
 
@@ -757,6 +760,7 @@ final class SettingsStore {
             } else {
                 personaHotkeyJSON = "__unset__"
             }
+            NotificationCenter.default.post(name: .hotkeySettingsDidChange, object: self)
         }
     }
 

--- a/Sources/Typeflux/Settings/SettingsViewModel.swift
+++ b/Sources/Typeflux/Settings/SettingsViewModel.swift
@@ -229,6 +229,7 @@ final class StudioViewModel: ObservableObject {
     private let historyRefreshQueue = DispatchQueue(label: "typeflux.settings.history-refresh", qos: .userInitiated)
     private var historyObserver: NSObjectProtocol?
     private var personaSelectionObserver: NSObjectProtocol?
+    private var hotkeySettingsObserver: NSObjectProtocol?
     private var appearanceObserver: NSObjectProtocol?
     private var vocabularyObserver: NSObjectProtocol?
     private var agentJobObserver: NSObjectProtocol?
@@ -390,6 +391,15 @@ final class StudioViewModel: ObservableObject {
                 self?.syncPersonaSelectionFromStore()
             }
         }
+        hotkeySettingsObserver = NotificationCenter.default.addObserver(
+            forName: .hotkeySettingsDidChange,
+            object: settingsStore,
+            queue: .main,
+        ) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                self?.syncHotkeysFromStore()
+            }
+        }
         appearanceObserver = NotificationCenter.default.addObserver(
             forName: .appearanceModeDidChange,
             object: settingsStore,
@@ -436,6 +446,9 @@ final class StudioViewModel: ObservableObject {
         }
         if let personaSelectionObserver {
             NotificationCenter.default.removeObserver(personaSelectionObserver)
+        }
+        if let hotkeySettingsObserver {
+            NotificationCenter.default.removeObserver(hotkeySettingsObserver)
         }
         if let appearanceObserver {
             NotificationCenter.default.removeObserver(appearanceObserver)
@@ -1585,6 +1598,12 @@ final class StudioViewModel: ObservableObject {
         personaHotkey = nil
         settingsStore.personaHotkey = nil
         showToast(L("settings.shortcuts.personaUnset"))
+    }
+
+    private func syncHotkeysFromStore() {
+        activationHotkey = settingsStore.activationHotkey
+        askHotkey = settingsStore.askHotkey
+        personaHotkey = settingsStore.personaHotkey
     }
 
     func applyPersonaSelection(_ id: UUID?) {

--- a/Tests/TypefluxTests/SettingsViewModelHotkeyTests.swift
+++ b/Tests/TypefluxTests/SettingsViewModelHotkeyTests.swift
@@ -1,0 +1,62 @@
+@testable import Typeflux
+import XCTest
+
+@MainActor
+final class SettingsViewModelHotkeyTests: XCTestCase {
+    func testHotkeysRefreshWhenSettingsStoreChangesExternally() async throws {
+        let suiteName = "SettingsViewModelHotkeyTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        let settingsStore = SettingsStore(defaults: defaults)
+        let viewModel = StudioViewModel(
+            settingsStore: settingsStore,
+            historyStore: HotkeyTestHistoryStore(),
+            initialSection: .settings,
+        )
+
+        XCTAssertEqual(
+            viewModel.activationHotkey?.signature,
+            HotkeyBinding.defaultActivation.signature,
+        )
+        XCTAssertEqual(
+            viewModel.askHotkey?.signature,
+            HotkeyBinding.defaultAsk.signature,
+        )
+
+        settingsStore.activationHotkey = .rightCommandActivation
+        settingsStore.askHotkey = .rightCommandAsk
+
+        try await waitForHotkeys(
+            in: viewModel,
+            activation: .rightCommandActivation,
+            ask: .rightCommandAsk,
+        )
+    }
+
+    private func waitForHotkeys(
+        in viewModel: StudioViewModel,
+        activation: HotkeyBinding,
+        ask: HotkeyBinding,
+    ) async throws {
+        for _ in 0 ..< 50 {
+            if viewModel.activationHotkey?.signature == activation.signature,
+               viewModel.askHotkey?.signature == ask.signature {
+                return
+            }
+            try await Task.sleep(nanoseconds: 20_000_000)
+        }
+        XCTFail("Timed out waiting for hotkey settings to refresh")
+    }
+}
+
+private final class HotkeyTestHistoryStore: HistoryStore {
+    func save(record _: HistoryRecord) {}
+    func list() -> [HistoryRecord] { [] }
+    func list(limit _: Int, offset _: Int, searchQuery _: String?) -> [HistoryRecord] { [] }
+    func record(id _: UUID) -> HistoryRecord? { nil }
+    func delete(id _: UUID) {}
+    func purge(olderThanDays _: Int) {}
+    func clear() {}
+    func exportMarkdown() throws -> URL {
+        URL(fileURLWithPath: "/tmp/typeflux-history.md")
+    }
+}


### PR DESCRIPTION
**Summary**
- 为 `SettingsStore` 的快捷键写入增加统一变更通知，覆盖语音输入、随便问和人设快捷键。
- 让 `StudioViewModel` 监听该通知，并在外部修改后重新从 store 同步当前快捷键，避免 settings 页继续显示旧的 Fn。
- 增加回归测试，验证设置页已打开时，onboarding 触发的右 Command 快捷键会及时反映到视图模型。

**Testing**
- `swift test --filter TypefluxTests.SettingsViewModelHotkeyTests`
- `swift test --filter TypefluxTests.OnboardingViewModelTests`