### PR TITLE
Add architecture parameter to auto-update requests

### DIFF
--- a/Sources/Typeflux/App/AutoUpdater.swift
+++ b/Sources/Typeflux/App/AutoUpdater.swift
@@ -78,7 +78,7 @@ final class AutoUpdater {
             do {
                 let (data, _) = try await executor.execute(apiPath: "/api/v1/app/update") { baseURL in
                     var components = URLComponents(url: AuthEndpointResolver.resolve(baseURL: baseURL, path: "/api/v1/app/update"), resolvingAgainstBaseURL: false) ?? URLComponents()
-                    components.queryItems = [URLQueryItem(name: "version", value: currentVersion)]
+                    components.queryItems = AutoUpdateRequestSupport.queryItems(currentVersion: currentVersion)
                     let url = components.url ?? AuthEndpointResolver.resolve(baseURL: baseURL, path: "/api/v1/app/update")
                     var request = URLRequest(url: url)
                     request.httpMethod = "GET"
@@ -495,6 +495,29 @@ enum GitHubProxyDownloadURL {
     static func proxyURL(for url: URL) -> URL? {
         guard url.host?.lowercased() == "github.com" else { return nil }
         return URL(string: "\(proxyBaseURL.absoluteString)/\(url.absoluteString)")
+    }
+}
+
+enum AutoUpdateRequestSupport {
+    static func queryItems(
+        currentVersion: String,
+        architecture: String? = packageArchitecture()
+    ) -> [URLQueryItem] {
+        var items = [URLQueryItem(name: "version", value: currentVersion)]
+        if let architecture, !architecture.isEmpty {
+            items.append(URLQueryItem(name: "arch", value: architecture))
+        }
+        return items
+    }
+
+    static func packageArchitecture() -> String {
+        #if arch(arm64)
+            "arm64"
+        #elseif arch(x86_64)
+            "amd64"
+        #else
+            "unknown"
+        #endif
     }
 }
 

--- a/Tests/TypefluxTests/AutoUpdateArchiveInstallerTests.swift
+++ b/Tests/TypefluxTests/AutoUpdateArchiveInstallerTests.swift
@@ -2,6 +2,24 @@
 import XCTest
 
 final class AutoUpdateArchiveInstallerTests: XCTestCase {
+    func testUpdateQueryItemsIncludeVersionAndArchitecture() {
+        let items = AutoUpdateRequestSupport.queryItems(currentVersion: "1.2.0", architecture: "amd64")
+
+        XCTAssertEqual(items.map(\.name), ["version", "arch"])
+        XCTAssertEqual(items.first(where: { $0.name == "version" })?.value, "1.2.0")
+        XCTAssertEqual(items.first(where: { $0.name == "arch" })?.value, "amd64")
+    }
+
+    func testUpdateQueryItemsOmitEmptyArchitecture() {
+        let items = AutoUpdateRequestSupport.queryItems(currentVersion: "1.2.0", architecture: "")
+
+        XCTAssertEqual(items.map(\.name), ["version"])
+    }
+
+    func testPackageArchitectureUsesSupportedUpdateAPIValue() {
+        XCTAssertTrue(["arm64", "amd64", "unknown"].contains(AutoUpdateRequestSupport.packageArchitecture()))
+    }
+
     func testArchiveKindDetectsDMGCaseInsensitively() throws {
         let url = try XCTUnwrap(URL(string: "https://example.com/releases/Typeflux.DMG?download=1"))
 


### PR DESCRIPTION
## Summary
- Add `arch` to the auto-update request query string alongside the existing `version` parameter
- Map the build architecture to the server-supported values (`arm64` for Apple Silicon, `amd64` for Intel)
- Add unit coverage for query item construction and architecture selection

## Testing
- Ran `swift test --filter TypefluxTests.AutoUpdateArchiveInstallerTests`
- Verified the new auto-update request helper tests and existing installer tests pass