### PR TITLE
fix: recover silent microphone input startup

### DIFF
--- a/Sources/Typeflux/Audio/AVFoundationAudioRecorder.swift
+++ b/Sources/Typeflux/Audio/AVFoundationAudioRecorder.swift
@@ -5,6 +5,7 @@ final class AVFoundationAudioRecorder: AudioRecorder {
     private static let outputMuteDelayWithStartCue: Duration = .milliseconds(1_225)
     private static let outputMuteDelayWithoutStartCue: Duration = .milliseconds(180)
     private static let silentInputRecoveryDelay: Duration = .milliseconds(1_000)
+    private static let silentInputRecoveryPeakPowerThreshold: Float = -58
     private static let audioStartupTimeout: DispatchTimeInterval = .seconds(5)
 
     enum RecorderError: LocalizedError, Equatable {
@@ -41,6 +42,7 @@ final class AVFoundationAudioRecorder: AudioRecorder {
     private var activeRecordingID: UUID?
     private var activeBufferCallbacks = 0
     private var inputBufferCallbackCount = 0
+    private var peakInputPowerSinceStart: Float = -.infinity
 
     init(
         settingsStore: SettingsStore,
@@ -109,6 +111,7 @@ final class AVFoundationAudioRecorder: AudioRecorder {
         activeRecordingID = preparedSession.id
         isRecording = true
         let callbackCountAtStart = inputBufferCallbackCount
+        peakInputPowerSinceStart = -.infinity
         stateCondition.unlock()
         scheduleSilentInputRecoveryIfNeeded(callbackCountAtStart: callbackCountAtStart)
         if settingsStore.muteSystemOutputDuringRecording {
@@ -151,6 +154,7 @@ final class AVFoundationAudioRecorder: AudioRecorder {
         audioBufferHandler = nil
         isRecording = false
         activeRecordingID = nil
+        peakInputPowerSinceStart = -.infinity
         stateCondition.unlock()
         muteTask?.cancel()
         muteTask = nil
@@ -187,6 +191,7 @@ final class AVFoundationAudioRecorder: AudioRecorder {
         audioBufferHandler = nil
         isRecording = false
         activeRecordingID = nil
+        peakInputPowerSinceStart = -.infinity
         stateCondition.unlock()
         muteTask?.cancel()
         muteTask = nil
@@ -323,12 +328,17 @@ final class AVFoundationAudioRecorder: AudioRecorder {
         defer { lifecycleLock.unlock() }
 
         stateCondition.lock()
-        let shouldRecover = isRecording && inputBufferCallbackCount == callbackCountAtStart
+        let shouldRecover = Self.shouldRecoverSilentInput(
+            isRecording: isRecording,
+            callbackCountAtStart: callbackCountAtStart,
+            currentCallbackCount: inputBufferCallbackCount,
+            peakInputPowerSinceStart: peakInputPowerSinceStart,
+        )
         stateCondition.unlock()
         guard shouldRecover else { return }
 
         NetworkDebugLogger.logMessage(
-            "[Audio Recorder] No input buffers received after start; rebuilding audio engine.",
+            "[Audio Recorder] Microphone input is silent after start; rebuilding audio engine.",
         )
 
         do {
@@ -508,7 +518,12 @@ final class AVFoundationAudioRecorder: AudioRecorder {
             do {
                 let monoBuffer = try makeMonoPCMBuffer(from: buffer)
                 let previewBuffer = clone(buffer: monoBuffer)
-                let normalizedLevel = normalizePower(rmsPower(for: monoBuffer))
+                let inputPower = rmsPower(for: monoBuffer)
+                let normalizedLevel = normalizePower(inputPower)
+
+                stateCondition.lock()
+                peakInputPowerSinceStart = max(peakInputPowerSinceStart, inputPower)
+                stateCondition.unlock()
 
                 writeCoordinator.enqueue {
                     do {
@@ -644,6 +659,17 @@ final class AVFoundationAudioRecorder: AudioRecorder {
         let minDb: Float = -60
         let clamped = max(minDb, power)
         return (clamped - minDb) / -minDb
+    }
+
+    static func shouldRecoverSilentInput(
+        isRecording: Bool,
+        callbackCountAtStart: Int,
+        currentCallbackCount: Int,
+        peakInputPowerSinceStart: Float,
+    ) -> Bool {
+        guard isRecording else { return false }
+        guard currentCallbackCount > callbackCountAtStart else { return true }
+        return peakInputPowerSinceStart <= silentInputRecoveryPeakPowerThreshold
     }
 }
 

--- a/Tests/TypefluxTests/AVFoundationAudioRecorderTests.swift
+++ b/Tests/TypefluxTests/AVFoundationAudioRecorderTests.swift
@@ -288,6 +288,51 @@ final class AVFoundationAudioRecorderTests: XCTestCase {
 
         XCTAssertEqual(recorder.values, [1, 2])
     }
+
+    func testSilentInputRecoveryTriggersWhenNoStartupBuffersArrive() {
+        XCTAssertTrue(AVFoundationAudioRecorder.shouldRecoverSilentInput(
+            isRecording: true,
+            callbackCountAtStart: 4,
+            currentCallbackCount: 4,
+            peakInputPowerSinceStart: -.infinity,
+        ))
+    }
+
+    func testSilentInputRecoveryTriggersWhenStartupBuffersAreSilent() {
+        XCTAssertTrue(AVFoundationAudioRecorder.shouldRecoverSilentInput(
+            isRecording: true,
+            callbackCountAtStart: 4,
+            currentCallbackCount: 7,
+            peakInputPowerSinceStart: -60,
+        ))
+    }
+
+    func testSilentInputRecoveryDoesNotTriggerAfterAudibleStartupInput() {
+        XCTAssertFalse(AVFoundationAudioRecorder.shouldRecoverSilentInput(
+            isRecording: true,
+            callbackCountAtStart: 4,
+            currentCallbackCount: 7,
+            peakInputPowerSinceStart: -30,
+        ))
+    }
+
+    func testSilentInputRecoveryDoesNotTriggerForLowButNonZeroStartupInput() {
+        XCTAssertFalse(AVFoundationAudioRecorder.shouldRecoverSilentInput(
+            isRecording: true,
+            callbackCountAtStart: 4,
+            currentCallbackCount: 7,
+            peakInputPowerSinceStart: -56,
+        ))
+    }
+
+    func testSilentInputRecoveryDoesNotTriggerAfterRecordingStops() {
+        XCTAssertFalse(AVFoundationAudioRecorder.shouldRecoverSilentInput(
+            isRecording: false,
+            callbackCountAtStart: 4,
+            currentCallbackCount: 4,
+            peakInputPowerSinceStart: -.infinity,
+        ))
+    }
 }
 
 private final class MockAudioDeviceManager: AudioDeviceManaging {


### PR DESCRIPTION
## Summary
- Fixes TYP-84 by treating zero-filled startup microphone buffers as a stale AVAudioEngine input path.
- Rebuilds the audio engine when startup input remains silent, not only when no callbacks arrive.
- Adds unit coverage for the silent-input recovery decision.

## How to test
- swift test --filter TypefluxTests.AVFoundationAudioRecorderTests

## Screenshots
- Not applicable; audio capture fix.