### PR TITLE
fix: constrain feedback menu hit area

### DIFF
--- a/Sources/Typeflux/UI/StudioComponents.swift
+++ b/Sources/Typeflux/UI/StudioComponents.swift
@@ -870,6 +870,11 @@ private struct StudioSidebarIconMenuButton<MenuContent: View>: View {
         .menuIndicator(.hidden)
         .buttonStyle(StudioInteractiveButtonStyle())
         .tint(StudioTheme.textSecondary)
+        .frame(
+            width: StudioTheme.ControlSize.sidebarUtilityButton,
+            height: StudioTheme.ControlSize.sidebarUtilityButton,
+        )
+        .contentShape(Circle())
         .accessibilityLabel(accessibilityLabel)
         .studioTooltip(accessibilityLabel, yOffset: 34)
         .onHover { isHovered = $0 }


### PR DESCRIPTION
References TYP-80

## Summary
- Constrain the sidebar feedback `Menu` control to the same 28x28 frame as the visible utility icon.
- Add a circular content shape so the hidden menu indicator area does not create an extra clickable blank region between sidebar icons.

## How to test
- `swift build`

## Screenshots
- Not applicable; style-only hit-area fix.