### PR TITLE
fix: apply glass background to about window

### DIFF
--- a/Sources/Typeflux/App/AboutView.swift
+++ b/Sources/Typeflux/App/AboutView.swift
@@ -12,7 +12,7 @@ struct AboutView: View {
 
     var body: some View {
         ZStack {
-            StudioTheme.windowBackground
+            StudioGlassBackground(tintOpacity: StudioTheme.Opacity.glassBackgroundTint)
                 .ignoresSafeArea()
 
             ScrollView {

--- a/Sources/Typeflux/App/AboutWindowController.swift
+++ b/Sources/Typeflux/App/AboutWindowController.swift
@@ -1,6 +1,12 @@
 import AppKit
 import SwiftUI
 
+private final class TransparentAboutHostingView<Content: View>: NSHostingView<Content> {
+    override var isOpaque: Bool {
+        false
+    }
+}
+
 @MainActor
 final class AboutWindowController: NSObject {
     static let shared = AboutWindowController()
@@ -50,7 +56,7 @@ final class AboutWindowController: NSObject {
             return
         }
 
-        let hosting = NSHostingView(rootView: rootView)
+        let hosting = TransparentAboutHostingView(rootView: rootView)
         let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 520, height: 620),
             styleMask: [.titled, .closable, .miniaturizable, .fullSizeContentView],
@@ -60,8 +66,11 @@ final class AboutWindowController: NSObject {
         window.title = L("window.about")
         window.titleVisibility = .hidden
         window.titlebarAppearsTransparent = true
+        window.titlebarSeparatorStyle = .none
         window.isMovableByWindowBackground = true
-        window.backgroundColor = NSColor(StudioTheme.windowBackground)
+        window.isOpaque = false
+        window.backgroundColor = .clear
+        window.hasShadow = true
         window.contentView = hosting
         window.center()
         window.isReleasedWhenClosed = false


### PR DESCRIPTION
References TYP-81

Summary:
- Update the About dialog to use the shared Studio glass background instead of a flat translucent color.
- Make the About window and hosting view non-opaque with a clear backing, matching the app's glass-window presentation pattern.
- Hide the titlebar separator so the glass surface reads as one continuous panel.

How to test:
- swift build
- Open the About Typeflux dialog and confirm the background renders as a macOS material/glass surface rather than an unintended transparent panel.

Screenshots:
- Not captured in this headless heartbeat.