### PR TITLE
Retry microphone startup up to three times before failing

### DIFF
--- a/Sources/Typeflux/Workflow/WorkflowController+AudioRecorder.swift
+++ b/Sources/Typeflux/Workflow/WorkflowController+AudioRecorder.swift
@@ -1,0 +1,44 @@
+import AVFoundation
+import Foundation
+
+extension WorkflowController {
+    func startAudioRecorderWithStartupRetry(
+        levelHandler: @escaping (Float) -> Void,
+        audioBufferHandler: ((AVAudioPCMBuffer) -> Void)?,
+    ) async throws {
+        for attempt in 1 ... Self.audioStartupMaxAttemptCount {
+            do {
+                try audioRecorder.start(levelHandler: levelHandler, audioBufferHandler: audioBufferHandler)
+                return
+            } catch {
+                guard
+                    Self.isAudioStartupTimeout(error),
+                    isRecording,
+                    attempt < Self.audioStartupMaxAttemptCount
+                else {
+                    throw error
+                }
+
+                NetworkDebugLogger.logMessage(
+                    """
+                    [Audio Recorder] Microphone input startup timed out; retrying with a fresh startup attempt.
+                    attempt: \(attempt)
+                    maxAttempts: \(Self.audioStartupMaxAttemptCount)
+                    retryDelayMilliseconds: 250
+                    """,
+                )
+                await sleep(Self.audioStartupRetryDelay)
+                guard isRecording else {
+                    throw error
+                }
+            }
+        }
+    }
+
+    private static func isAudioStartupTimeout(_ error: Error) -> Bool {
+        guard let recorderError = error as? AVFoundationAudioRecorder.RecorderError else {
+            return false
+        }
+        return recorderError == .inputStartupTimedOut
+    }
+}

--- a/Sources/Typeflux/Workflow/WorkflowController.swift
+++ b/Sources/Typeflux/Workflow/WorkflowController.swift
@@ -28,6 +28,8 @@ final class WorkflowController {
     // still considered for analysis.
     static let automaticVocabularyEditRatioLimit: Double = 0.8
     static let localModelPreheatDebounce: Duration = .milliseconds(180)
+    static let audioStartupMaxAttemptCount = 3
+    static let audioStartupRetryDelay: Duration = .milliseconds(250)
     static let llmTimeoutAfterTranscriptionSeconds: TimeInterval = 120
     struct LLMRequestTimeoutError: LocalizedError {
         var errorDescription: String? {
@@ -783,7 +785,7 @@ final class WorkflowController {
             activeRealtimeTranscriptionSession = realtimeSession
             activeRealtimeAudioBufferPump = realtimeAudioBufferPump
             await realtimeSession?.start()
-            try audioRecorder.start(
+            try await startAudioRecorderWithStartupRetry(
                 levelHandler: { [weak self] level in
                     self?.overlayController.updateLevel(level)
                 },

--- a/Tests/TypefluxTests/WorkflowControllerProcessingTests.swift
+++ b/Tests/TypefluxTests/WorkflowControllerProcessingTests.swift
@@ -414,11 +414,30 @@ final class WorkflowControllerProcessingTests: XCTestCase {
         XCTAssertFalse(controller.shouldFinishRecordingAfterAudioStart)
         XCTAssertNil(controller.pendingRecordingStartID)
         XCTAssertEqual(controller.recordingMode, .holdToTalk)
-        XCTAssertEqual(audioRecorder.startCallCount, 1)
+        XCTAssertEqual(audioRecorder.startCallCount, 3)
         XCTAssertEqual(audioRecorder.stopCallCount, 0)
         await MainActor.run {
             controller.overlayController.dismissImmediately()
         }
+    }
+
+    func testBeginRecordingRetriesUntilAudioStartupSucceeds() async {
+        let audioRecorder = TransientTimeoutAudioRecorder(timeoutCount: 2)
+        let controller = makeWorkflowController(
+            audioRecorder: audioRecorder,
+            sleep: { _ in },
+        )
+
+        await controller.beginRecording(intent: .dictation, startLocked: false)
+        await waitForMainActorWork()
+
+        XCTAssertTrue(controller.isRecording)
+        XCTAssertTrue(controller.isAudioRecorderStarted)
+        XCTAssertFalse(controller.isAudioRecorderStarting)
+        XCTAssertEqual(audioRecorder.startCallCount, 3)
+
+        controller.cancelRecording()
+        await waitForMainActorWork()
     }
 
     func testReleasingAfterImmediateAudioStartStopsRecorder() async {
@@ -949,6 +968,44 @@ private final class ThrowingStartAudioRecorder: AudioRecorder {
         starts += 1
         lock.unlock()
         throw error
+    }
+
+    func stop() throws -> AudioFile {
+        lock.lock()
+        stops += 1
+        lock.unlock()
+        return AudioFile(fileURL: URL(fileURLWithPath: "/tmp/mock.wav"), duration: 1)
+    }
+}
+
+private final class TransientTimeoutAudioRecorder: AudioRecorder {
+    private let timeoutCount: Int
+    private let lock = NSLock()
+    private var starts = 0
+    private var stops = 0
+
+    init(timeoutCount: Int) {
+        self.timeoutCount = timeoutCount
+    }
+
+    var startCallCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return starts
+    }
+
+    func start(
+        levelHandler _: @escaping (Float) -> Void,
+        audioBufferHandler _: ((AVAudioPCMBuffer) -> Void)?,
+    ) throws {
+        lock.lock()
+        starts += 1
+        let shouldTimeout = starts <= timeoutCount
+        lock.unlock()
+
+        if shouldTimeout {
+            throw AVFoundationAudioRecorder.RecorderError.inputStartupTimedOut
+        }
     }
 
     func stop() throws -> AudioFile {


### PR DESCRIPTION
## Summary
- Retry `AudioRecorder.start` up to 3 times when microphone input startup times out.
- Add a short delay between retries to absorb transient AVAudioEngine/CoreAudio startup stalls.
- Keep the existing failure path after the third timeout so the user still sees the same error if the device never becomes ready.
- Add unit coverage for both the transient-success path and the final-failure path.

## Testing
- `swift test --filter TypefluxTests.WorkflowControllerProcessingTests/testBeginRecordingRetriesUntilAudioStartupSucceeds`
- `swift test --filter TypefluxTests.WorkflowControllerProcessingTests/testBeginRecordingResetsStateWhenAudioStartFails`