### PR TITLE
TYP-87 Improve history row action discoverability

### DIFF
--- a/Sources/Typeflux/Resources/en.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/en.lproj/Localizable.strings
@@ -352,6 +352,7 @@
 
 "history.action.copyResult" = "Copy result";
 "history.action.copyTranscript" = "Copy transcript";
+"history.action.more" = "More actions";
 "history.action.downloadAudio" = "Download audio";
 "history.action.playAudio" = "Play audio";
 "history.action.stopAudio" = "Stop audio";

--- a/Sources/Typeflux/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/ja.lproj/Localizable.strings
@@ -350,6 +350,7 @@
 
 "history.action.copyResult" = "結果をコピー";
 "history.action.copyTranscript" = "トランスクリプトをコピーする";
+"history.action.more" = "その他の操作";
 "history.action.downloadAudio" = "音声をダウンロードする";
 "history.action.playAudio" = "音声を再生";
 "history.action.stopAudio" = "音声を停止";

--- a/Sources/Typeflux/Resources/ko.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/ko.lproj/Localizable.strings
@@ -350,6 +350,7 @@
 
 "history.action.copyResult" = "결과 복사";
 "history.action.copyTranscript" = "성적표 복사";
+"history.action.more" = "추가 작업";
 "history.action.downloadAudio" = "오디오 다운로드";
 "history.action.playAudio" = "오디오 재생";
 "history.action.stopAudio" = "오디오 정지";

--- a/Sources/Typeflux/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/zh-Hans.lproj/Localizable.strings
@@ -352,6 +352,7 @@
 
 "history.action.copyResult" = "复制结果";
 "history.action.copyTranscript" = "复制转写";
+"history.action.more" = "更多操作";
 "history.action.downloadAudio" = "下载音频";
 "history.action.playAudio" = "播放音频";
 "history.action.stopAudio" = "停止音频";

--- a/Sources/Typeflux/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/zh-Hant.lproj/Localizable.strings
@@ -350,6 +350,7 @@
 
 "history.action.copyResult" = "複製結果";
 "history.action.copyTranscript" = "複製轉寫";
+"history.action.more" = "更多操作";
 "history.action.downloadAudio" = "下載音訊";
 "history.action.playAudio" = "播放音訊";
 "history.action.stopAudio" = "停止音訊";

--- a/Sources/Typeflux/UI/StudioComponents.swift
+++ b/Sources/Typeflux/UI/StudioComponents.swift
@@ -1534,6 +1534,11 @@ struct StudioHistoryRow: View {
                             .animation(.easeOut(duration: 0.12), value: isHovered)
                     }
 
+                    historyActionsMenuButton
+                        .opacity(isHovered ? 1 : 0)
+                        .allowsHitTesting(isHovered)
+                        .animation(.easeOut(duration: 0.12), value: isHovered)
+
                     historyIconButton(
                         systemImage: isExpanded ? "chevron.up" : "chevron.down",
                         helpText: isExpanded ? L("common.collapse") : L("common.expand"),
@@ -1571,27 +1576,47 @@ struct StudioHistoryRow: View {
         .contentShape(Rectangle())
         .onHover { isHovered = $0 }
         .contextMenu {
-            if let onCopyResult, record.hasTranscriptToCopy {
-                Button(L("history.action.copyResult"), systemImage: "doc.on.doc", action: onCopyResult)
-            }
-            if let onCopyTranscript, !(record.transcriptText?.isEmpty ?? true) {
-                Button(L("history.action.copyTranscript"), systemImage: "doc.on.doc", action: onCopyTranscript)
-            }
-            if (onCopyResult != nil && record.hasTranscriptToCopy) || !(record.transcriptText?.isEmpty ?? true) {
-                Divider()
-            }
-            if let onRetry {
-                Button(L("common.retry"), systemImage: "arrow.clockwise", action: onRetry)
-                    .disabled(!record.canRetry)
-            }
-            if let onDownloadAudio {
-                Button(L("history.action.downloadAudio"), systemImage: "arrow.down.circle", action: onDownloadAudio)
-                    .disabled(record.audioFilePath == nil)
-            }
+            historyActionsMenuContent
+        }
+    }
+
+    private var historyActionsMenuButton: some View {
+        Menu {
+            historyActionsMenuContent
+        } label: {
+            Image(systemName: "ellipsis")
+                .font(.system(size: StudioTheme.Typography.iconRegular, weight: .medium))
+                .frame(width: 32, height: 32)
+                .contentShape(RoundedRectangle(cornerRadius: StudioTheme.CornerRadius.xLarge, style: .continuous))
+        }
+        .menuStyle(.borderlessButton)
+        .menuIndicator(.hidden)
+        .studioTooltip(L("history.action.more"), yOffset: 42)
+        .accessibilityLabel(L("history.action.more"))
+    }
+
+    @ViewBuilder
+    private var historyActionsMenuContent: some View {
+        if let onCopyResult, record.hasTranscriptToCopy {
+            Button(L("history.action.copyResult"), systemImage: "doc.on.doc", action: onCopyResult)
+        }
+        if let onCopyTranscript, !(record.transcriptText?.isEmpty ?? true) {
+            Button(L("history.action.copyTranscript"), systemImage: "doc.on.doc", action: onCopyTranscript)
+        }
+        if (onCopyResult != nil && record.hasTranscriptToCopy) || !(record.transcriptText?.isEmpty ?? true) {
             Divider()
-            if let onDelete {
-                Button(L("history.action.deleteTranscript"), systemImage: "trash", role: .destructive, action: onDelete)
-            }
+        }
+        if let onRetry {
+            Button(L("common.retry"), systemImage: "arrow.clockwise", action: onRetry)
+                .disabled(!record.canRetry)
+        }
+        if let onDownloadAudio {
+            Button(L("history.action.downloadAudio"), systemImage: "arrow.down.circle", action: onDownloadAudio)
+                .disabled(record.audioFilePath == nil)
+        }
+        Divider()
+        if let onDelete {
+            Button(L("history.action.deleteTranscript"), systemImage: "trash", role: .destructive, action: onDelete)
         }
     }
 

--- a/Tests/TypefluxTests/LocalizationResourceTests.swift
+++ b/Tests/TypefluxTests/LocalizationResourceTests.swift
@@ -93,6 +93,20 @@ final class LocalizationResourceTests: XCTestCase {
         }
     }
 
+    func testHistoryActionMenuDiscoverabilityCopyExistsForAllSupportedLanguages() throws {
+        for language in AppLanguage.allCases {
+            let bundle = try localizationBundle(for: language)
+            let localized = bundle.localizedString(forKey: "history.action.more", value: nil, table: nil)
+
+            XCTAssertNotEqual(
+                localized,
+                "history.action.more",
+                "Missing localized history actions menu label for \(language.rawValue)",
+            )
+            XCTAssertFalse(localized.isEmpty)
+        }
+    }
+
     func testAgentClarificationTranscribingHintUsesThinkingCopyForAllSupportedLanguages() throws {
         let expectedValues: [AppLanguage: String] = [
             .english: "Thinking...",


### PR DESCRIPTION
## Summary
- Add a visible ellipsis action menu to history rows so users can discover retry/download/delete actions without right-clicking.
- Reuse the same action content for the explicit menu and the existing context menu.
- Add localized “More actions” copy across supported languages and a localization coverage test.

## How to test
- swift test --filter TypefluxTests.LocalizationResourceTests

## Screenshots
- Not included; small menu affordance change.