### PR TITLE
feat(stt): improve local model download experience (TYP-91)

### DIFF
--- a/Sources/Typeflux/App/AppCoordinator.swift
+++ b/Sources/Typeflux/App/AppCoordinator.swift
@@ -57,7 +57,6 @@ final class AppCoordinator {
             settingsStore: di.settingsStore,
             historyStore: di.historyStore,
             agentJobStore: di.agentJobStore,
-            autoModelDownloadService: di.autoModelDownloadService,
             notificationService: di.notificationService,
             onRetryHistory: { [weak self] record in
                 self?.workflowController?.retry(record: record)

--- a/Sources/Typeflux/App/StatusBarController.swift
+++ b/Sources/Typeflux/App/StatusBarController.swift
@@ -28,7 +28,6 @@ final class StatusBarController: NSObject {
     private let settingsStore: SettingsStore
     private let historyStore: HistoryStore
     private let agentJobStore: AgentJobStore
-    private let autoModelDownloadService: AutoModelDownloadService?
     private let notificationService: LocalNotificationSending
     private let onRetryHistory: (HistoryRecord) -> Void
     private let onOpenOnboarding: () -> Void
@@ -44,7 +43,7 @@ final class StatusBarController: NSObject {
     private var historyObserver: NSObjectProtocol?
     private var personaSelectionObserver: NSObjectProtocol?
     private var autoUpdateStateObserver: NSObjectProtocol?
-    private var autoModelDownloadObserver: NSObjectProtocol?
+    private var localModelDownloadProgressObserver: NSObjectProtocol?
     private var runningJobDurationTimer: Timer?
     private var runningAgentJobs: [AgentJob] = []
 
@@ -53,7 +52,6 @@ final class StatusBarController: NSObject {
         settingsStore: SettingsStore,
         historyStore: HistoryStore,
         agentJobStore: AgentJobStore,
-        autoModelDownloadService: AutoModelDownloadService? = nil,
         notificationService: LocalNotificationSending = NoopLocalNotificationService(),
         onRetryHistory: @escaping (HistoryRecord) -> Void = { _ in },
         onOpenOnboarding: @escaping () -> Void = {},
@@ -64,7 +62,6 @@ final class StatusBarController: NSObject {
         self.settingsStore = settingsStore
         self.historyStore = historyStore
         self.agentJobStore = agentJobStore
-        self.autoModelDownloadService = autoModelDownloadService
         self.notificationService = notificationService
         self.onRetryHistory = onRetryHistory
         self.onOpenOnboarding = onOpenOnboarding
@@ -132,8 +129,8 @@ final class StatusBarController: NSObject {
                 self?.rebuildMenu()
             }
         }
-        autoModelDownloadObserver = NotificationCenter.default.addObserver(
-            forName: .autoModelDownloadStateDidChange,
+        localModelDownloadProgressObserver = NotificationCenter.default.addObserver(
+            forName: .localModelDownloadProgressDidChange,
             object: nil,
             queue: .main,
         ) { [weak self] _ in
@@ -182,10 +179,10 @@ final class StatusBarController: NSObject {
             NotificationCenter.default.removeObserver(autoUpdateStateObserver)
         }
         autoUpdateStateObserver = nil
-        if let autoModelDownloadObserver {
-            NotificationCenter.default.removeObserver(autoModelDownloadObserver)
+        if let localModelDownloadProgressObserver {
+            NotificationCenter.default.removeObserver(localModelDownloadProgressObserver)
         }
-        autoModelDownloadObserver = nil
+        localModelDownloadProgressObserver = nil
         stopRunningJobDurationTimer()
         cancellables.removeAll()
     }
@@ -245,7 +242,7 @@ final class StatusBarController: NSObject {
         menu.addItem(appearanceItem)
         menu.addItem(makeSettingsItem())
         menu.addItem(makeUpdateMenuItem())
-        if let downloadItem = makeAutoModelDownloadMenuItem() {
+        if let downloadItem = makeLocalModelDownloadMenuItem() {
             menu.addItem(downloadItem)
         }
         menu.addItem(NSMenuItem.separator())
@@ -379,12 +376,12 @@ final class StatusBarController: NSObject {
     }
 
     /// Returns a menu item showing local model download progress, or nil when there is nothing to display.
-    private func makeAutoModelDownloadMenuItem() -> NSMenuItem? {
-        guard let service = autoModelDownloadService else { return nil }
-        if case .downloading(let progress) = service.status {
-            let percent = Int(progress * 100)
+    private func makeLocalModelDownloadMenuItem() -> NSMenuItem? {
+        if let title = StatusBarMenuSupport.localModelDownloadTitle(
+            for: LocalModelDownloadProgressCenter.shared.status,
+        ) {
             let item = NSMenuItem(
-                title: L("menu.downloadingLocalModel", percent),
+                title: title,
                 action: nil,
                 keyEquivalent: "",
             )
@@ -629,6 +626,12 @@ extension StatusBarController: NSMenuDelegate {
 
 enum StatusBarMenuSupport {
     private static let titleTextLimit = 42
+
+    static func localModelDownloadTitle(for status: LocalModelDownloadProgressStatus) -> String? {
+        guard case .downloading(let model, let progress) = status else { return nil }
+        let percent = Int((progress * 100).rounded())
+        return L("menu.downloadingLocalModelNamed", model.displayName, percent)
+    }
 
     static func recentTranscriptionRecords(from records: [HistoryRecord], limit: Int = 10) -> [HistoryRecord] {
         records

--- a/Sources/Typeflux/Resources/en.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/en.lproj/Localizable.strings
@@ -124,7 +124,7 @@
 "menu.checkForUpdates" = "Check for Updates";
 "menu.downloadingUpdate" = "Downloading Update…";
 "menu.installingUpdate" = "Installing Update…";
-"menu.downloadingLocalModel" = "Downloading Local Model… %d%%";
+"menu.downloadingLocalModelNamed" = "Downloading %@… %d%%";
 "menu.quit" = "Quit";
 "menu.status.ready" = "Ready";
 "menu.status.recording" = "Recording in progress…";
@@ -753,6 +753,7 @@
 "settings.models.localSTT.readyNamed" = "%@ is ready.";
 "settings.models.localSTT.prepareFailed" = "Local speech model preparation failed.";
 "settings.models.localSTT.deleted" = "Model files deleted.";
+"settings.models.localSTT.transferProgress" = "%@ downloaded (%@ of %@)";
 "notification.localModelReady.title" = "Typeflux";
 "notification.localModelReady.body" = "Local model is ready.";
 "cloud.autoSwitch.title" = "Typeflux Cloud is ready";
@@ -761,6 +762,8 @@
 "settings.models.deleteModelFiles" = "Delete Model Files";
 "settings.models.redownloadDialog.title" = "Re-download %@?";
 "settings.models.redownloadDialog.message" = "The existing model files will be deleted before re-downloading.";
+"settings.models.downloadDialog.title" = "Download %@?";
+"settings.models.downloadDialog.message" = "This local speech model needs to be downloaded before it can be selected for use.";
 "settings.models.deleteDialog.title" = "Delete %@?";
 "settings.models.deleteDialog.message" = "Model files will be deleted. You'll need to re-download before next use.";
 "settings.advanced.autoVocabulary.title" = "Auto-add corrected vocabulary";

--- a/Sources/Typeflux/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/ja.lproj/Localizable.strings
@@ -124,7 +124,7 @@
 "menu.checkForUpdates" = "アップデートを確認";
 "menu.downloadingUpdate" = "アップデートをダウンロード中…";
 "menu.installingUpdate" = "アップデートをインストール中…";
-"menu.downloadingLocalModel" = "ローカルモデルをダウンロード中… %d%%";
+"menu.downloadingLocalModelNamed" = "%@をダウンロード中… %d%%";
 "menu.quit" = "やめる";
 "menu.status.ready" = "準備完了";
 "menu.status.recording" = "録音中です…";
@@ -746,6 +746,7 @@
 "settings.models.localSTT.readyNamed" = "%@ の準備ができました。";
 "settings.models.localSTT.prepareFailed" = "ローカル音声モデルの準備に失敗しました。";
 "settings.models.localSTT.deleted" = "モデルファイルが削除されました。";
+"settings.models.localSTT.transferProgress" = "%@ ダウンロード済み（%@ / %@）";
 "notification.localModelReady.title" = "Typeflux";
 "notification.localModelReady.body" = "ローカルモデルの準備ができました。";
 "cloud.autoSwitch.title" = "Typeflux Cloud が有効になりました";
@@ -754,6 +755,8 @@
 "settings.models.deleteModelFiles" = "モデルファイルの削除";
 "settings.models.redownloadDialog.title" = "%@ を再ダウンロードしますか?";
 "settings.models.redownloadDialog.message" = "既存のモデル ファイルは再ダウンロードする前に削除されます。";
+"settings.models.downloadDialog.title" = "%@ をダウンロードしますか?";
+"settings.models.downloadDialog.message" = "このローカル音声モデルは、ダウンロードが完了してから選択して使用できます。";
 "settings.models.deleteDialog.title" = "%@ を削除しますか?";
 "settings.models.deleteDialog.message" = "モデルファイルは削除されます。次回使用する前に再ダウンロードする必要があります。";
 "settings.advanced.autoVocabulary.title" = "修正された語彙を自動追加";

--- a/Sources/Typeflux/Resources/ko.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/ko.lproj/Localizable.strings
@@ -124,7 +124,7 @@
 "menu.checkForUpdates" = "업데이트 확인";
 "menu.downloadingUpdate" = "업데이트 다운로드 중…";
 "menu.installingUpdate" = "업데이트 설치 중…";
-"menu.downloadingLocalModel" = "로컬 모델 다운로드 중… %d%%";
+"menu.downloadingLocalModelNamed" = "%@ 다운로드 중… %d%%";
 "menu.quit" = "종료";
 "menu.status.ready" = "준비";
 "menu.status.recording" = "녹음 진행 중…";
@@ -746,6 +746,7 @@
 "settings.models.localSTT.readyNamed" = "%@이 준비되었습니다.";
 "settings.models.localSTT.prepareFailed" = "로컬 음성 모델 준비에 실패했습니다.";
 "settings.models.localSTT.deleted" = "모델 파일이 삭제되었습니다.";
+"settings.models.localSTT.transferProgress" = "%@ 다운로드됨(%@ / %@)";
 "notification.localModelReady.title" = "Typeflux";
 "notification.localModelReady.body" = "로컬 모델이 준비되었습니다.";
 "cloud.autoSwitch.title" = "Typeflux Cloud이(가) 활성화되었습니다";
@@ -754,6 +755,8 @@
 "settings.models.deleteModelFiles" = "모델 파일 삭제";
 "settings.models.redownloadDialog.title" = "%@을(를) 다시 다운로드하시겠습니까?";
 "settings.models.redownloadDialog.message" = "다시 다운로드하기 전에 기존 모델 파일이 삭제됩니다.";
+"settings.models.downloadDialog.title" = "%@을(를) 다운로드하시겠습니까?";
+"settings.models.downloadDialog.message" = "이 로컬 음성 모델은 다운로드가 완료된 뒤 선택하여 사용할 수 있습니다.";
 "settings.models.deleteDialog.title" = "%@을 삭제하시겠습니까?";
 "settings.models.deleteDialog.message" = "모델 파일이 삭제됩니다. 다음번 사용 전에 다시 다운로드해야 합니다.";
 "settings.advanced.autoVocabulary.title" = "수정된 어휘 자동 추가";

--- a/Sources/Typeflux/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/zh-Hans.lproj/Localizable.strings
@@ -124,7 +124,7 @@
 "menu.checkForUpdates" = "检查更新";
 "menu.downloadingUpdate" = "正在下载更新…";
 "menu.installingUpdate" = "正在安装更新…";
-"menu.downloadingLocalModel" = "正在下载本地模型… %d%%";
+"menu.downloadingLocalModelNamed" = "正在下载 %@… %d%%";
 "menu.quit" = "退出";
 "menu.status.ready" = "已就绪";
 "menu.status.recording" = "录音中…";
@@ -753,6 +753,7 @@
 "settings.models.localSTT.readyNamed" = "%@ 已就绪。";
 "settings.models.localSTT.prepareFailed" = "本地语音模型准备失败。";
 "settings.models.localSTT.deleted" = "模型文件已删除。";
+"settings.models.localSTT.transferProgress" = "已下载 %@（%@ / %@）";
 "notification.localModelReady.title" = "Typeflux";
 "notification.localModelReady.body" = "本地模型已就绪。";
 "cloud.autoSwitch.title" = "已启用 Typeflux Cloud";
@@ -761,6 +762,8 @@
 "settings.models.deleteModelFiles" = "删除模型文件";
 "settings.models.redownloadDialog.title" = "重新下载 %@？";
 "settings.models.redownloadDialog.message" = "本地模型文件已存在，将先删除已有文件再重新下载。";
+"settings.models.downloadDialog.title" = "下载 %@？";
+"settings.models.downloadDialog.message" = "该本地语音模型需要先下载完成，才能被选中并用于识别。";
 "settings.models.deleteDialog.title" = "删除 %@？";
 "settings.models.deleteDialog.message" = "模型文件将被删除，下次使用时需要重新下载。";
 "settings.advanced.autoVocabulary.title" = "自动添加修正生词";

--- a/Sources/Typeflux/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/zh-Hant.lproj/Localizable.strings
@@ -124,7 +124,7 @@
 "menu.checkForUpdates" = "檢查更新";
 "menu.downloadingUpdate" = "正在下載更新…";
 "menu.installingUpdate" = "正在安裝更新…";
-"menu.downloadingLocalModel" = "正在下載本地模型… %d%%";
+"menu.downloadingLocalModelNamed" = "正在下載 %@… %d%%";
 "menu.quit" = "結束";
 "menu.status.ready" = "已就緒";
 "menu.status.recording" = "錄音中…";
@@ -749,6 +749,7 @@
 "settings.models.localSTT.readyNamed" = "%@ 已就緒。";
 "settings.models.localSTT.prepareFailed" = "本地語音模型準備失敗。";
 "settings.models.localSTT.deleted" = "模型檔案已刪除。";
+"settings.models.localSTT.transferProgress" = "已下載 %@（%@ / %@）";
 "notification.localModelReady.title" = "Typeflux";
 "notification.localModelReady.body" = "本地模型已就緒。";
 "cloud.autoSwitch.title" = "已啟用 Typeflux Cloud";
@@ -757,6 +758,8 @@
 "settings.models.deleteModelFiles" = "刪除模型檔案";
 "settings.models.redownloadDialog.title" = "重新下載 %@？";
 "settings.models.redownloadDialog.message" = "本地模型檔案已存在，將先刪除已有檔案再重新下載。";
+"settings.models.downloadDialog.title" = "下載 %@？";
+"settings.models.downloadDialog.message" = "此本地語音模型需要先下載完成，才能被選取並用於辨識。";
 "settings.models.deleteDialog.title" = "刪除 %@？";
 "settings.models.deleteDialog.message" = "模型檔案將被刪除，下次使用時需要重新下載。";
 "settings.advanced.autoVocabulary.title" = "自動加入修正生詞";

--- a/Sources/Typeflux/STT/AutoModelDownloadService.swift
+++ b/Sources/Typeflux/STT/AutoModelDownloadService.swift
@@ -97,6 +97,7 @@ final class AutoModelDownloadService {
     func triggerIfNeeded() {
         guard settingsStore.localOptimizationEnabled else {
             setStatus(.disabled)
+            LocalModelDownloadProgressCenter.shared.clear()
             return
         }
 
@@ -172,6 +173,7 @@ final class AutoModelDownloadService {
     private func performDownload() async {
         let config = Self.recommendedConfiguration()
         setStatus(.downloading(progress: 0))
+        LocalModelDownloadProgressCenter.shared.reportDownloading(model: config.model, progress: 0)
 
         var state = loadState()
         state.attemptCount += 1
@@ -185,6 +187,10 @@ final class AutoModelDownloadService {
                 configuration: config,
             ) { [weak self] update in
                 self?.setStatus(.downloading(progress: update.progress))
+                LocalModelDownloadProgressCenter.shared.reportDownloading(
+                    model: config.model,
+                    progress: update.progress,
+                )
             }
 
             guard modelManager.isStoragePathReady(storagePath, for: config.model) else {
@@ -202,9 +208,11 @@ final class AutoModelDownloadService {
             completedState.completedStoragePath = storagePath
             completedState.nextRetryDate = nil
             saveState(completedState)
+            LocalModelDownloadProgressCenter.shared.clear()
             await notifyLocalModelReady()
 
         } catch {
+            LocalModelDownloadProgressCenter.shared.clear()
             guard !Task.isCancelled else { return }
             NetworkDebugLogger.logError(context: "Auto model download failed", error: error)
             setStatus(.failed)
@@ -233,6 +241,7 @@ final class AutoModelDownloadService {
             _readyStoragePath = storagePath
             _status = .completed
         }
+        LocalModelDownloadProgressCenter.shared.clear()
         notifyStateChanged()
     }
 

--- a/Sources/Typeflux/STT/DownloadProgressReporter.swift
+++ b/Sources/Typeflux/STT/DownloadProgressReporter.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+enum DownloadProgressReporter {
+    static func download(
+        request: URLRequest,
+        session: URLSession = .shared,
+        onProgress: (@Sendable (Int64, Int64?) -> Void)? = nil,
+    ) async throws -> (URL, URLResponse) {
+        guard onProgress != nil else {
+            return try await session.download(for: request)
+        }
+
+        let delegate = ProgressDelegate(onProgress: onProgress)
+        let result = try await session.download(for: request, delegate: delegate)
+        return result
+    }
+}
+
+private final class ProgressDelegate: NSObject, URLSessionDownloadDelegate, @unchecked Sendable {
+    private let onProgress: (@Sendable (Int64, Int64?) -> Void)?
+
+    init(onProgress: (@Sendable (Int64, Int64?) -> Void)?) {
+        self.onProgress = onProgress
+    }
+
+    func urlSession(
+        _: URLSession,
+        downloadTask _: URLSessionDownloadTask,
+        didWriteData _: Int64,
+        totalBytesWritten: Int64,
+        totalBytesExpectedToWrite: Int64,
+    ) {
+        let totalBytes = totalBytesExpectedToWrite > 0 ? totalBytesExpectedToWrite : nil
+        onProgress?(totalBytesWritten, totalBytes)
+    }
+
+    func urlSession(
+        _: URLSession,
+        downloadTask _: URLSessionDownloadTask,
+        didFinishDownloadingTo _: URL,
+    ) {}
+}

--- a/Sources/Typeflux/STT/LocalModelDownloadProgressCenter.swift
+++ b/Sources/Typeflux/STT/LocalModelDownloadProgressCenter.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+extension Notification.Name {
+    static let localModelDownloadProgressDidChange = Notification.Name(
+        "LocalModelDownloadProgressCenter.progressDidChange",
+    )
+}
+
+enum LocalModelDownloadProgressStatus: Equatable {
+    case idle
+    case downloading(model: LocalSTTModel, progress: Double)
+}
+
+final class LocalModelDownloadProgressCenter {
+    static let shared = LocalModelDownloadProgressCenter()
+
+    private let lock = NSLock()
+    private var currentStatus: LocalModelDownloadProgressStatus = .idle
+
+    var status: LocalModelDownloadProgressStatus {
+        lock.withLock { currentStatus }
+    }
+
+    func reportDownloading(model: LocalSTTModel, progress: Double) {
+        let clampedProgress = min(max(progress, 0), 1)
+        updateStatus(.downloading(model: model, progress: clampedProgress))
+    }
+
+    func clear() {
+        updateStatus(.idle)
+    }
+
+    private func updateStatus(_ newStatus: LocalModelDownloadProgressStatus) {
+        let needsNotify = lock.withLock { () -> Bool in
+            let needsNotify = currentStatus != newStatus
+            currentStatus = newStatus
+            return needsNotify
+        }
+        if needsNotify {
+            DispatchQueue.main.async {
+                NotificationCenter.default.post(name: .localModelDownloadProgressDidChange, object: self)
+            }
+        }
+    }
+}

--- a/Sources/Typeflux/STT/LocalModelManager.swift
+++ b/Sources/Typeflux/STT/LocalModelManager.swift
@@ -18,6 +18,24 @@ struct LocalSTTPreparationUpdate {
     let progress: Double
     let storagePath: String
     let source: String?
+    let downloadedBytes: Int64?
+    let totalBytes: Int64?
+
+    init(
+        message: String,
+        progress: Double,
+        storagePath: String,
+        source: String?,
+        downloadedBytes: Int64? = nil,
+        totalBytes: Int64? = nil,
+    ) {
+        self.message = message
+        self.progress = progress
+        self.storagePath = storagePath
+        self.source = source
+        self.downloadedBytes = downloadedBytes
+        self.totalBytes = totalBytes
+    }
 }
 
 struct LocalSTTPreparedModelInfo {
@@ -68,10 +86,35 @@ protocol LocalSTTModelManaging {
         onUpdate: (@Sendable (LocalSTTPreparationUpdate) -> Void)?,
     ) async throws
 
+    func prepareModel(
+        configuration: LocalSTTConfiguration,
+        onUpdate: (@Sendable (LocalSTTPreparationUpdate) -> Void)?,
+    ) async throws
+
     func preparedModelInfo(settingsStore: SettingsStore) -> LocalSTTPreparedModelInfo?
     func isModelAvailable(_ model: LocalSTTModel) -> Bool
     func deleteModelFiles(_ model: LocalSTTModel) throws
     func storagePath(for configuration: LocalSTTConfiguration) -> String
+}
+
+extension LocalSTTModelManaging {
+    func prepareModel(
+        configuration: LocalSTTConfiguration,
+        onUpdate: (@Sendable (LocalSTTPreparationUpdate) -> Void)?,
+    ) async throws {
+        let suiteName = "LocalSTTPreparation-\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            throw CocoaError(.fileWriteUnknown)
+        }
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let settingsStore = SettingsStore(defaults: defaults)
+        settingsStore.localSTTModel = configuration.model
+        settingsStore.localSTTModelIdentifier = configuration.modelIdentifier
+        settingsStore.localSTTDownloadSource = configuration.downloadSource
+        settingsStore.localSTTAutoSetup = configuration.autoSetup
+        try await prepareModel(settingsStore: settingsStore, onUpdate: onUpdate)
+    }
 }
 
 final class LocalModelManager: LocalSTTModelManaging {
@@ -83,7 +126,7 @@ final class LocalModelManager: LocalSTTModelManaging {
     typealias LocalWhisperKitPreparerFactory = @Sendable (String, String, URL?) -> any WhisperKitPreparing
     typealias RemoteFileLoader = @Sendable (URL) async throws -> Data
     typealias RemoteRepositoryFileListLoader = @Sendable (URL) async throws -> [String]
-    typealias RemoteFileDownloader = @Sendable (URL, URL) async throws -> Void
+    typealias RemoteFileDownloader = @Sendable (URL, URL, (@Sendable (Int64, Int64?) -> Void)?) async throws -> Void
 
     private let fileManager: FileManager
     private let sherpaOnnxInstaller: SherpaOnnxModelInstalling
@@ -125,8 +168,12 @@ final class LocalModelManager: LocalSTTModelManaging {
         remoteRepositoryFileListLoader: @escaping RemoteRepositoryFileListLoader = { url in
             try await LocalModelManager.defaultRemoteRepositoryFileListLoader(from: url)
         },
-        remoteFileDownloader: @escaping RemoteFileDownloader = { sourceURL, destinationURL in
-            try await LocalModelManager.defaultRemoteFileDownloader(from: sourceURL, to: destinationURL)
+        remoteFileDownloader: @escaping RemoteFileDownloader = { sourceURL, destinationURL, onProgress in
+            try await LocalModelManager.defaultRemoteFileDownloader(
+                from: sourceURL,
+                to: destinationURL,
+                onProgress: onProgress,
+            )
         },
         downloadSourceResolver: LocalModelDownloadSourceResolving = NetworkLocalModelDownloadSourceResolver(),
         bundledModelsRootURL: URL? = nil,
@@ -160,8 +207,13 @@ final class LocalModelManager: LocalSTTModelManaging {
         settingsStore: SettingsStore,
         onUpdate: (@Sendable (LocalSTTPreparationUpdate) -> Void)? = nil,
     ) async throws {
-        let configuration = LocalSTTConfiguration(settingsStore: settingsStore)
+        try await prepareModel(configuration: LocalSTTConfiguration(settingsStore: settingsStore), onUpdate: onUpdate)
+    }
 
+    func prepareModel(
+        configuration: LocalSTTConfiguration,
+        onUpdate: (@Sendable (LocalSTTPreparationUpdate) -> Void)? = nil,
+    ) async throws {
         if let bundled = bundledModelInfo(for: configuration) {
             let installedPath = try installBundledModelIntoAppSupport(
                 configuration: configuration,
@@ -820,6 +872,7 @@ final class LocalModelManager: LocalSTTModelManaging {
             )
 
             let progressBase = Double(index) / Double(max(remoteFiles.count, 1))
+            let progressSpan = 0.6 / Double(max(remoteFiles.count, 1))
             onUpdate?(LocalSTTPreparationUpdate(
                 message: L("localSTT.prepare.whisperDownloading", modelName),
                 progress: 0.2 + progressBase * 0.6,
@@ -829,7 +882,22 @@ final class LocalModelManager: LocalSTTModelManaging {
             NetworkDebugLogger.logMessage(
                 "[Local Model Download] kind=whisper-model-file source=\(downloadSource.displayName) model=\(modelName) path=\(relativePath) url=\(sourceURL.absoluteString)"
             )
-            try await downloadRemoteFileWithRetry(sourceURL, to: destinationFileURL, operationName: "WhisperKit model file download")
+            try await downloadRemoteFileWithRetry(
+                sourceURL,
+                to: destinationFileURL,
+                operationName: "WhisperKit model file download",
+            ) { receivedBytes, totalBytes in
+                guard let totalBytes, totalBytes > 0 else { return }
+                let fileProgress = min(max(Double(receivedBytes) / Double(totalBytes), 0), 1)
+                onUpdate?(LocalSTTPreparationUpdate(
+                    message: L("localSTT.prepare.whisperDownloading", modelName),
+                    progress: 0.2 + progressBase * 0.6 + fileProgress * progressSpan,
+                    storagePath: modelFolderURL.path,
+                    source: downloadSource.displayName,
+                    downloadedBytes: receivedBytes,
+                    totalBytes: totalBytes,
+                ))
+            }
         }
 
         guard isUsableWhisperKitModelFolder(modelFolderURL.path) else {
@@ -946,9 +1014,14 @@ final class LocalModelManager: LocalSTTModelManaging {
         }
     }
 
-    private func downloadRemoteFileWithRetry(_ sourceURL: URL, to destinationURL: URL, operationName: String) async throws {
+    private func downloadRemoteFileWithRetry(
+        _ sourceURL: URL,
+        to destinationURL: URL,
+        operationName: String,
+        onProgress: (@Sendable (Int64, Int64?) -> Void)? = nil,
+    ) async throws {
         try await RequestRetry.perform(operationName: "\(operationName) \(sourceURL.absoluteString)") { [self] in
-            try await remoteFileDownloader(sourceURL, destinationURL)
+            try await remoteFileDownloader(sourceURL, destinationURL, onProgress)
         }
     }
 
@@ -985,10 +1058,14 @@ final class LocalModelManager: LocalSTTModelManaging {
         return payload.siblings.map(\.rfilename)
     }
 
-    private static func defaultRemoteFileDownloader(from sourceURL: URL, to destinationURL: URL) async throws {
+    private static func defaultRemoteFileDownloader(
+        from sourceURL: URL,
+        to destinationURL: URL,
+        onProgress: (@Sendable (Int64, Int64?) -> Void)? = nil,
+    ) async throws {
         var request = URLRequest(url: sourceURL)
         request.timeoutInterval = 300
-        let (temporaryURL, response) = try await URLSession.shared.download(for: request)
+        let (temporaryURL, response) = try await DownloadProgressReporter.download(request: request, onProgress: onProgress)
         guard let http = response as? HTTPURLResponse, (200 ..< 300).contains(http.statusCode) else {
             throw NSError(
                 domain: "LocalModelManager",

--- a/Sources/Typeflux/STT/LocalModelTranscriber.swift
+++ b/Sources/Typeflux/STT/LocalModelTranscriber.swift
@@ -12,6 +12,8 @@ protocol LocalWhisperKitTranscribing: AnyObject {
 final class LocalModelTranscriber: Transcriber {
     static let defaultWhisperKitKeepAliveDuration: TimeInterval = 30 * 60
     static let persistentWhisperKitKeepAliveDuration: TimeInterval? = nil
+    static let notPreparedErrorDomain = "LocalModelTranscriber"
+    static let notPreparedErrorCode = 1
 
     private let settingsStore: SettingsStore
     private let modelManager: LocalSTTModelManaging
@@ -185,8 +187,8 @@ final class LocalModelTranscriber: Transcriber {
 
     private func notPreparedError() -> NSError {
         NSError(
-            domain: "LocalModelTranscriber",
-            code: 1,
+            domain: Self.notPreparedErrorDomain,
+            code: Self.notPreparedErrorCode,
             userInfo: [NSLocalizedDescriptionKey: L("localSTT.error.notPrepared")],
         )
     }

--- a/Sources/Typeflux/STT/SherpaOnnxSupport.swift
+++ b/Sources/Typeflux/STT/SherpaOnnxSupport.swift
@@ -631,7 +631,11 @@ protocol SherpaOnnxArchiveDownloading {
     func downloadArchive(from url: URL) async throws -> URL
 }
 
-final class URLSessionSherpaOnnxArchiveDownloader: SherpaOnnxArchiveDownloading {
+protocol SherpaOnnxArchiveProgressDownloading: SherpaOnnxArchiveDownloading {
+    func downloadArchive(from url: URL, onProgress: (@Sendable (Int64, Int64?) -> Void)?) async throws -> URL
+}
+
+final class URLSessionSherpaOnnxArchiveDownloader: SherpaOnnxArchiveProgressDownloading {
     private let urlSession: URLSession
 
     init(urlSession: URLSession = .shared) {
@@ -639,7 +643,15 @@ final class URLSessionSherpaOnnxArchiveDownloader: SherpaOnnxArchiveDownloading 
     }
 
     func downloadArchive(from url: URL) async throws -> URL {
-        let (downloadedURL, response) = try await urlSession.download(from: url)
+        try await downloadArchive(from: url, onProgress: nil)
+    }
+
+    func downloadArchive(from url: URL, onProgress: (@Sendable (Int64, Int64?) -> Void)?) async throws -> URL {
+        let (downloadedURL, response) = try await DownloadProgressReporter.download(
+            request: URLRequest(url: url),
+            session: urlSession,
+            onProgress: onProgress,
+        )
         guard let http = response as? HTTPURLResponse, (200 ..< 300).contains(http.statusCode) else {
             throw NSError(
                 domain: "URLSessionSherpaOnnxArchiveDownloader",
@@ -716,6 +728,12 @@ final class SherpaOnnxModelInstaller: SherpaOnnxModelInstalling {
                 destinationURL: runtimeStorageURL,
                 extractedRootDirectoryName: layout.runtimeRootDirectory,
                 archiveFileName: "\(layout.runtimeRootDirectory).tar.bz2",
+                progressStart: 0.15,
+                progressEnd: 0.45,
+                storagePath: storageURL.path,
+                source: downloadSource.displayName,
+                message: L("localSTT.prepare.runtimeDownloading"),
+                onUpdate: onUpdate,
             )
             try pruneRuntimePayload(in: runtimeStorageURL.appendingPathComponent(layout.runtimeRootDirectory, isDirectory: true))
         }
@@ -734,6 +752,12 @@ final class SherpaOnnxModelInstaller: SherpaOnnxModelInstalling {
                 layout.modelArtifact,
                 destinationURL: storageURL,
                 extractedRootDirectoryName: layout.modelRootDirectory,
+                progressStart: 0.55,
+                progressEnd: 0.9,
+                storagePath: storageURL.path,
+                source: downloadSource.displayName,
+                message: L("localSTT.prepare.modelDownloading", model.displayName),
+                onUpdate: onUpdate,
             )
         }
 
@@ -882,6 +906,12 @@ final class SherpaOnnxModelInstaller: SherpaOnnxModelInstalling {
         destinationURL: URL,
         extractedRootDirectoryName: String,
         archiveFileName: String,
+        progressStart: Double,
+        progressEnd: Double,
+        storagePath: String,
+        source: String?,
+        message: String,
+        onUpdate: (@Sendable (LocalSTTPreparationUpdate) -> Void)?,
     ) async throws {
         let extractedRootURL = destinationURL.appendingPathComponent(
             extractedRootDirectoryName,
@@ -904,7 +934,16 @@ final class SherpaOnnxModelInstaller: SherpaOnnxModelInstalling {
             try fileManager.removeItem(at: localArchiveURL)
         }
 
-        try await downloadArchive(from: archiveURL, to: localArchiveURL)
+        try await downloadArchive(
+            from: archiveURL,
+            to: localArchiveURL,
+            progressStart: progressStart,
+            progressEnd: progressEnd,
+            storagePath: storagePath,
+            source: source,
+            message: message,
+            onUpdate: onUpdate,
+        )
 
         _ = try await processRunner.run(
             executablePath: "/usr/bin/tar",
@@ -1016,6 +1055,12 @@ final class SherpaOnnxModelInstaller: SherpaOnnxModelInstalling {
         _ artifact: SherpaOnnxModelArtifact,
         destinationURL: URL,
         extractedRootDirectoryName: String,
+        progressStart: Double,
+        progressEnd: Double,
+        storagePath: String,
+        source: String?,
+        message: String,
+        onUpdate: (@Sendable (LocalSTTPreparationUpdate) -> Void)?,
     ) async throws {
         switch artifact {
         case let .archive(url, fileName):
@@ -1024,12 +1069,24 @@ final class SherpaOnnxModelInstaller: SherpaOnnxModelInstalling {
                 destinationURL: destinationURL,
                 extractedRootDirectoryName: extractedRootDirectoryName,
                 archiveFileName: fileName,
+                progressStart: progressStart,
+                progressEnd: progressEnd,
+                storagePath: storagePath,
+                source: source,
+                message: message,
+                onUpdate: onUpdate,
             )
         case let .files(files):
             try await downloadExtractedFiles(
                 files,
                 destinationURL: destinationURL,
                 extractedRootDirectoryName: extractedRootDirectoryName,
+                progressStart: progressStart,
+                progressEnd: progressEnd,
+                storagePath: storagePath,
+                source: source,
+                message: message,
+                onUpdate: onUpdate,
             )
         }
     }
@@ -1038,6 +1095,12 @@ final class SherpaOnnxModelInstaller: SherpaOnnxModelInstalling {
         _ files: [SherpaOnnxModelFile],
         destinationURL: URL,
         extractedRootDirectoryName: String,
+        progressStart: Double,
+        progressEnd: Double,
+        storagePath: String,
+        source: String?,
+        message: String,
+        onUpdate: (@Sendable (LocalSTTPreparationUpdate) -> Void)?,
     ) async throws {
         let extractedRootURL = destinationURL.appendingPathComponent(
             extractedRootDirectoryName,
@@ -1049,21 +1112,56 @@ final class SherpaOnnxModelInstaller: SherpaOnnxModelInstalling {
 
         try fileManager.createDirectory(at: extractedRootURL, withIntermediateDirectories: true)
 
-        for file in files {
+        for (index, file) in files.enumerated() {
             let destinationFileURL = destinationURL.appendingPathComponent(file.relativePath, isDirectory: false)
             try fileManager.createDirectory(
                 at: destinationFileURL.deletingLastPathComponent(),
                 withIntermediateDirectories: true,
             )
-            try await downloadArchive(from: file.url, to: destinationFileURL)
+            let fileStart = progressStart + (progressEnd - progressStart) * Double(index) / Double(max(files.count, 1))
+            let fileEnd = progressStart + (progressEnd - progressStart) * Double(index + 1) / Double(max(files.count, 1))
+            try await downloadArchive(
+                from: file.url,
+                to: destinationFileURL,
+                progressStart: fileStart,
+                progressEnd: fileEnd,
+                storagePath: storagePath,
+                source: source,
+                message: message,
+                onUpdate: onUpdate,
+            )
         }
     }
 
-    private func downloadArchive(from archiveURL: URL, to localArchiveURL: URL) async throws {
+    private func downloadArchive(
+        from archiveURL: URL,
+        to localArchiveURL: URL,
+        progressStart: Double,
+        progressEnd: Double,
+        storagePath: String,
+        source: String?,
+        message: String,
+        onUpdate: (@Sendable (LocalSTTPreparationUpdate) -> Void)?,
+    ) async throws {
         let downloadedURL = try await RequestRetry.perform(
             operationName: "Sherpa-ONNX file download \(archiveURL.absoluteString)",
         ) { [self] in
-            try await archiveDownloader.downloadArchive(from: archiveURL)
+            if let progressDownloader = archiveDownloader as? SherpaOnnxArchiveProgressDownloading {
+                try await progressDownloader.downloadArchive(from: archiveURL) { receivedBytes, totalBytes in
+                    guard let totalBytes, totalBytes > 0 else { return }
+                    let fileProgress = min(max(Double(receivedBytes) / Double(totalBytes), 0), 1)
+                    onUpdate?(LocalSTTPreparationUpdate(
+                        message: message,
+                        progress: progressStart + fileProgress * (progressEnd - progressStart),
+                        storagePath: storagePath,
+                        source: source,
+                        downloadedBytes: receivedBytes,
+                        totalBytes: totalBytes,
+                    ))
+                }
+            } else {
+                try await archiveDownloader.downloadArchive(from: archiveURL)
+            }
         }
         if fileManager.fileExists(atPath: localArchiveURL.path) {
             try fileManager.removeItem(at: localArchiveURL)

--- a/Sources/Typeflux/STT/Transcriber.swift
+++ b/Sources/Typeflux/STT/Transcriber.swift
@@ -79,6 +79,7 @@ final class STTRouter {
     private let groq: Transcriber
     private let typefluxOfficial: Transcriber
     private let autoModelDownloadService: AutoModelDownloadService?
+    private let isTypefluxCloudLoggedIn: @Sendable () async -> Bool
 
     init(
         settingsStore: SettingsStore,
@@ -93,6 +94,9 @@ final class STTRouter {
         groq: Transcriber,
         typefluxOfficial: Transcriber,
         autoModelDownloadService: AutoModelDownloadService? = nil,
+        isTypefluxCloudLoggedIn: @escaping @Sendable () async -> Bool = {
+            await MainActor.run { AuthState.shared.isLoggedIn }
+        },
     ) {
         self.settingsStore = settingsStore
         self.whisper = whisper
@@ -106,6 +110,7 @@ final class STTRouter {
         self.groq = groq
         self.typefluxOfficial = typefluxOfficial
         self.autoModelDownloadService = autoModelDownloadService
+        self.isTypefluxCloudLoggedIn = isTypefluxCloudLoggedIn
     }
 
     func transcribe(
@@ -131,6 +136,33 @@ final class STTRouter {
             return nil
         }
         return try? await transcriber.transcribeStream(audioFile: audioFile, onUpdate: onUpdate)
+    }
+
+    private func transcribeWithTypefluxOfficial(
+        audioFile: AudioFile,
+        scenario: TypefluxCloudScenario,
+        onUpdate: @escaping @Sendable (TranscriptionSnapshot) async -> Void,
+    ) async throws -> String {
+        try await RequestRetry.perform(operationName: "Typeflux Official STT request") { [self] in
+            if let scenarioAware = typefluxOfficial as? TypefluxCloudScenarioAwareTranscriber {
+                return try await scenarioAware.transcribeStream(
+                    audioFile: audioFile,
+                    scenario: scenario,
+                    onUpdate: onUpdate,
+                )
+            }
+            return try await typefluxOfficial.transcribeStream(audioFile: audioFile, onUpdate: onUpdate)
+        }
+    }
+
+    private func shouldUseTypefluxCloudForUnavailableLocalModel(error: Error) async -> Bool {
+        let nsError = error as NSError
+        guard nsError.domain == LocalModelTranscriber.notPreparedErrorDomain,
+              nsError.code == LocalModelTranscriber.notPreparedErrorCode
+        else {
+            return false
+        }
+        return await isTypefluxCloudLoggedIn()
     }
 
     func prepareForRecording() async {
@@ -271,6 +303,27 @@ final class STTRouter {
                     NetworkDebugLogger.logMessage("Auto local model succeeded after local STT failure")
                     return localResult
                 }
+                if await shouldUseTypefluxCloudForUnavailableLocalModel(error: error) {
+                    do {
+                        NetworkDebugLogger.logMessage(
+                            "Falling back to Typeflux Cloud while local STT model downloads",
+                        )
+                        return try await transcribeWithTypefluxOfficial(
+                            audioFile: audioFile,
+                            scenario: scenario,
+                            onUpdate: onUpdate,
+                        )
+                    } catch {
+                        NetworkDebugLogger.logError(context: "Typeflux Cloud fallback failed", error: error)
+                        if settingsStore.useAppleSpeechFallback {
+                            NetworkDebugLogger.logMessage(
+                                "Falling back to Apple Speech after Typeflux Cloud fallback failure",
+                            )
+                            return try await appleSpeech.transcribeStream(audioFile: audioFile, onUpdate: onUpdate)
+                        }
+                        throw error
+                    }
+                }
                 if settingsStore.useAppleSpeechFallback {
                     NetworkDebugLogger.logMessage("Falling back to Apple Speech after local STT failure")
                     return try await appleSpeech.transcribeStream(audioFile: audioFile, onUpdate: onUpdate)
@@ -378,16 +431,11 @@ final class STTRouter {
                 return localResult
             }
             do {
-                return try await RequestRetry.perform(operationName: "Typeflux Official STT request") { [self] in
-                    if let scenarioAware = typefluxOfficial as? TypefluxCloudScenarioAwareTranscriber {
-                        return try await scenarioAware.transcribeStream(
-                            audioFile: audioFile,
-                            scenario: scenario,
-                            onUpdate: onUpdate,
-                        )
-                    }
-                    return try await typefluxOfficial.transcribeStream(audioFile: audioFile, onUpdate: onUpdate)
-                }
+                return try await transcribeWithTypefluxOfficial(
+                    audioFile: audioFile,
+                    scenario: scenario,
+                    onUpdate: onUpdate,
+                )
             } catch {
                 NetworkDebugLogger.logError(context: "Typeflux Official STT failed", error: error)
                 if let localResult = await transcribeWithAutoModelIfReady(audioFile: audioFile, onUpdate: onUpdate) {

--- a/Sources/Typeflux/Settings/SettingsView.swift
+++ b/Sources/Typeflux/Settings/SettingsView.swift
@@ -227,6 +227,7 @@ struct StudioView: View {
     @State private var hasLoadedPersonaAppInstalledCandidates = false
     @State private var personaAppCandidateLoadToken = UUID()
     @State private var localSTTPendingDelete: LocalSTTModel? = nil
+    @State private var localSTTPendingDownload: LocalSTTModel? = nil
 
     @State private var localSTTPendingRedownload: LocalSTTModel? = nil
     @State private var llmActivationMissingAPIKeyProviderName: String?
@@ -4622,35 +4623,6 @@ struct StudioView: View {
 
                 if viewModel.focusedModelProvider == .localSTT {
                     VStack(alignment: .leading, spacing: StudioTheme.Spacing.small) {
-                        if viewModel.localSTTNeedsRetry {
-                            StudioButton(
-                                title: viewModel.localSTTPreparationProgress > 0
-                                    ? L("common.retry") : L("settings.models.prepareLocalModel"),
-                                systemImage: viewModel.localSTTPreparationProgress > 0
-                                    ? "arrow.clockwise" : "arrow.down.circle",
-                                variant: .primary,
-                            ) {
-                                viewModel.prepareLocalSTTModel()
-                            }
-                        }
-
-                        HStack(alignment: .center, spacing: StudioTheme.Spacing.small) {
-                            ProgressView(value: viewModel.localSTTPreparationProgress, total: 1)
-                                .progressViewStyle(.linear)
-                                .tint(viewModel.localSTTPreparationTint)
-
-                            Text(viewModel.localSTTPreparationPercentText)
-                                .font(
-                                    .studioBody(StudioTheme.Typography.caption, weight: .semibold),
-                                )
-                                .foregroundStyle(StudioTheme.textSecondary)
-                                .frame(width: 40, alignment: .trailing)
-                        }
-
-                        Text(viewModel.localSTTPreparationDetail)
-                            .font(.studioBody(StudioTheme.Typography.caption))
-                            .foregroundStyle(StudioTheme.textSecondary)
-
                         VStack(alignment: .leading, spacing: StudioTheme.Spacing.xxxSmall) {
                             HStack(alignment: .center, spacing: StudioTheme.Spacing.small) {
                                 Text(L("settings.models.storagePath"))
@@ -4779,6 +4751,28 @@ struct StudioView: View {
                     ForEach(LocalSTTModel.displayOrder, id: \.self) { model in
                         localSTTModelOptionCard(model)
                     }
+                }
+                .confirmationDialog(
+                    localSTTPendingDownload.map {
+                        L("settings.models.downloadDialog.title", $0.displayName)
+                    } ?? "",
+                    isPresented: Binding(
+                        get: { localSTTPendingDownload != nil },
+                        set: { if !$0 { localSTTPendingDownload = nil } },
+                    ),
+                    titleVisibility: .visible,
+                ) {
+                    Button(L("settings.models.prepareLocalModel")) {
+                        if let model = localSTTPendingDownload {
+                            viewModel.prepareLocalSTTModel(model)
+                            localSTTPendingDownload = nil
+                        }
+                    }
+                    Button(L("common.cancel"), role: .cancel) {
+                        localSTTPendingDownload = nil
+                    }
+                } message: {
+                    Text(L("settings.models.downloadDialog.message"))
                 }
                 .confirmationDialog(
                     localSTTPendingRedownload.map {
@@ -5355,72 +5349,94 @@ struct StudioView: View {
     }
 
     private func localSTTModelOptionCard(_ model: LocalSTTModel) -> some View {
-        let isSelected = viewModel.localSTTModel == model
+        let isFocused = viewModel.localSTTFocusedModel == model
+        let isDownloaded = viewModel.isModelAvailable(model)
+        let isActive = viewModel.localSTTModel == model && isDownloaded
         let specs = model.specs
 
-        return Button {
-            viewModel.setLocalSTTModel(model)
-        } label: {
-            VStack(alignment: .leading, spacing: StudioTheme.Spacing.small) {
-                HStack(alignment: .top, spacing: StudioTheme.Spacing.small) {
-                    VStack(alignment: .leading, spacing: StudioTheme.Spacing.xxxSmall) {
-                        HStack(spacing: StudioTheme.Spacing.xSmall) {
-                            Text(model.displayName)
-                                .font(.studioBody(StudioTheme.Typography.bodyLarge, weight: .semibold))
-                                .foregroundStyle(StudioTheme.textPrimary)
+        return VStack(alignment: .leading, spacing: StudioTheme.Spacing.small) {
+            HStack(alignment: .top, spacing: StudioTheme.Spacing.small) {
+                VStack(alignment: .leading, spacing: StudioTheme.Spacing.xxxSmall) {
+                    HStack(spacing: StudioTheme.Spacing.xSmall) {
+                        Text(model.displayName)
+                            .font(.studioBody(StudioTheme.Typography.bodyLarge, weight: .semibold))
+                            .foregroundStyle(StudioTheme.textPrimary)
 
-                            if let recommendationBadgeTitle = model.recommendationBadgeTitle {
-                                localSTTRecommendationPill(recommendationBadgeTitle)
-                            }
+                        if let recommendationBadgeTitle = model.recommendationBadgeTitle {
+                            localSTTRecommendationPill(recommendationBadgeTitle)
                         }
-
-                        Text(specs.summary)
-                            .font(.studioBody(StudioTheme.Typography.bodySmall))
-                            .foregroundStyle(StudioTheme.textSecondary)
-                            .fixedSize(horizontal: false, vertical: true)
                     }
 
-                    Spacer(minLength: 0)
-
-                    if isSelected {
-                        StudioPill(
-                            title: L("settings.models.selected"),
-                            tone: StudioTheme.accent,
-                            fill: StudioTheme.accentSoft,
-                        )
-                    }
+                    Text(specs.summary)
+                        .font(.studioBody(StudioTheme.Typography.bodySmall))
+                        .foregroundStyle(StudioTheme.textSecondary)
+                        .fixedSize(horizontal: false, vertical: true)
                 }
 
-                HStack(spacing: StudioTheme.Spacing.xSmall) {
-                    localSTTSpecPill(model.displayName)
-                    localSTTSpecPill("\(specs.parameterValue) parameters")
-                    localSTTSpecPill(specs.sizeValue)
+                Spacer(minLength: 0)
+
+                if isActive {
+                    StudioPill(
+                        title: L("settings.models.selected"),
+                        tone: StudioTheme.accent,
+                        fill: StudioTheme.accentSoft,
+                    )
                 }
             }
-            .padding(StudioTheme.Insets.cardCompact)
-            .background(
-                RoundedRectangle(cornerRadius: StudioTheme.CornerRadius.hero, style: .continuous)
-                    .fill(isSelected ? StudioTheme.selectionSurfaceRaised : StudioTheme.localModelOptionSurface),
-            )
-            .overlay(
-                RoundedRectangle(cornerRadius: StudioTheme.CornerRadius.hero, style: .continuous)
-                    .stroke(
-                        StudioTheme.border.opacity(0.75),
-                        lineWidth: StudioTheme.BorderWidth.thin,
-                    ),
-            )
+
+            HStack(spacing: StudioTheme.Spacing.xSmall) {
+                localSTTSpecPill(model.displayName)
+                localSTTSpecPill("\(specs.parameterValue) parameters")
+                localSTTSpecPill(specs.sizeValue)
+            }
+
+            if isFocused {
+                localSTTModelProgressRow(model)
+
+                if !isDownloaded {
+                    Text(viewModel.localSTTPreparationDetail)
+                        .font(.studioBody(StudioTheme.Typography.caption))
+                        .foregroundStyle(StudioTheme.textSecondary)
+                }
+
+                if !viewModel.localSTTTransferDetail.isEmpty {
+                    Text(viewModel.localSTTTransferDetail)
+                        .font(.studioBody(StudioTheme.Typography.caption))
+                        .foregroundStyle(StudioTheme.textSecondary)
+                }
+            }
         }
-        .buttonStyle(StudioInteractiveButtonStyle())
+        .padding(StudioTheme.Insets.cardCompact)
+        .background(
+            RoundedRectangle(cornerRadius: StudioTheme.CornerRadius.hero, style: .continuous)
+                .fill(isFocused ? StudioTheme.selectionSurfaceRaised : StudioTheme.localModelOptionSurface),
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: StudioTheme.CornerRadius.hero, style: .continuous)
+                .stroke(
+                    StudioTheme.border.opacity(0.75),
+                    lineWidth: StudioTheme.BorderWidth.thin,
+                ),
+        )
+        .contentShape(RoundedRectangle(cornerRadius: StudioTheme.CornerRadius.hero, style: .continuous))
+        .onTapGesture {
+            selectLocalSTTModelCard(model)
+        }
         .contextMenu {
             Button {
-                if viewModel.isModelAvailable(model) {
+                let isAvailable = viewModel.isModelAvailable(model)
+                if isAvailable {
                     localSTTPendingRedownload = model
                 } else {
-                    viewModel.setLocalSTTModel(model)
-                    viewModel.prepareLocalSTTModel()
+                    viewModel.focusLocalSTTModel(model)
+                    localSTTPendingDownload = model
                 }
             } label: {
-                Label(L("settings.models.redownload"), systemImage: "arrow.clockwise")
+                let isAvailable = viewModel.isModelAvailable(model)
+                Label(
+                    isAvailable ? L("settings.models.redownload") : L("settings.models.prepareLocalModel"),
+                    systemImage: isAvailable ? "arrow.clockwise" : "arrow.down",
+                )
             }
 
             if viewModel.isModelAvailable(model) {
@@ -5431,6 +5447,56 @@ struct StudioView: View {
                     Label(L("settings.models.deleteModelFiles"), systemImage: "trash")
                 }
             }
+        }
+    }
+
+    private func localSTTModelProgressRow(_ model: LocalSTTModel) -> some View {
+        HStack(alignment: .center, spacing: StudioTheme.Spacing.small) {
+            ProgressView(value: viewModel.localSTTPreparationProgress, total: 1)
+                .progressViewStyle(.linear)
+                .tint(viewModel.localSTTPreparationTint)
+
+            Text(viewModel.localSTTPreparationPercentText)
+                .font(.studioBody(StudioTheme.Typography.caption, weight: .semibold))
+                .foregroundStyle(StudioTheme.textSecondary)
+                .frame(width: 40, alignment: .trailing)
+
+            localSTTModelDownloadIconButton(model)
+        }
+    }
+
+    private func localSTTModelDownloadIconButton(_ model: LocalSTTModel) -> some View {
+        let isDownloaded = viewModel.isModelAvailable(model)
+        let title = viewModel.isPreparingLocalSTT
+            ? L("settings.models.preparing")
+            : (isDownloaded ? L("settings.models.redownload") : L("settings.models.prepareLocalModel"))
+        let systemImage = isDownloaded ? "arrow.clockwise" : "arrow.down"
+
+        return Button {
+            guard !viewModel.isPreparingLocalSTT else { return }
+            viewModel.focusLocalSTTModel(model)
+            if isDownloaded {
+                localSTTPendingRedownload = model
+            } else {
+                localSTTPendingDownload = model
+            }
+        } label: {
+            Image(systemName: systemImage)
+                .font(.system(size: StudioTheme.Typography.iconSmall, weight: .semibold))
+                .foregroundStyle(viewModel.isPreparingLocalSTT ? StudioTheme.textTertiary : StudioTheme.textSecondary)
+                .frame(width: 28, height: 28)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(StudioInteractiveButtonStyle())
+        .disabled(viewModel.isPreparingLocalSTT)
+        .help(title)
+        .accessibilityLabel(title)
+    }
+
+    private func selectLocalSTTModelCard(_ model: LocalSTTModel) {
+        viewModel.focusLocalSTTModel(model)
+        if !viewModel.isModelAvailable(model) {
+            localSTTPendingDownload = model
         }
     }
 

--- a/Sources/Typeflux/Settings/SettingsViewModel.swift
+++ b/Sources/Typeflux/Settings/SettingsViewModel.swift
@@ -138,12 +138,14 @@ final class StudioViewModel: ObservableObject {
     @Published var groqSTTModel: String
 
     @Published var localSTTModel: LocalSTTModel
+    @Published var localSTTFocusedModel: LocalSTTModel
     @Published var localSTTModelIdentifier: String
     @Published var localSTTDownloadSource: ModelDownloadSource
     @Published var localSTTAutoSetup: Bool
     @Published var localSTTStatus = L("settings.models.localSTT.notPrepared")
     @Published var localSTTPreparationProgress: Double = 0
     @Published var localSTTPreparationDetail = L("settings.models.localSTT.autoPrepareHint")
+    @Published var localSTTTransferDetail = ""
     @Published var localSTTStoragePath: String
     @Published var localSTTPreparedSource = L("common.automatic")
     @Published var isLocalSTTPrepared = false
@@ -238,6 +240,8 @@ final class StudioViewModel: ObservableObject {
     private var sttTestTask: Task<Void, Never>?
     private var mcpTestTask: Task<Void, Never>?
     private var historyRefreshTask: Task<Void, Never>?
+    private var localSTTPreparationTask: Task<Void, Never>?
+    private var localSTTPreparationID: UUID?
     private var historyRefreshGeneration = 0
     private let audioPreviewPlayer: HistoryAudioPreviewPlaying
 
@@ -327,6 +331,7 @@ final class StudioViewModel: ObservableObject {
         groqSTTAPIKey = settingsStore.groqSTTAPIKey
         groqSTTModel = settingsStore.groqSTTModel
         localSTTModel = settingsStore.localSTTModel
+        localSTTFocusedModel = settingsStore.localSTTModel
         localSTTModelIdentifier = settingsStore.localSTTModelIdentifier
         localSTTDownloadSource = settingsStore.localSTTDownloadSource
         localSTTAutoSetup = true
@@ -490,6 +495,23 @@ final class StudioViewModel: ObservableObject {
 
     var localSTTPreparationPercentText: String {
         "\(Int((localSTTPreparationProgress * 100).rounded()))%"
+    }
+
+    static func localSTTTransferText(downloadedBytes: Int64?, totalBytes: Int64?) -> String {
+        guard let downloadedBytes, let totalBytes, totalBytes > 0 else {
+            return ""
+        }
+
+        let formatter = ByteCountFormatter()
+        formatter.allowedUnits = [.useMB, .useGB]
+        formatter.countStyle = .file
+        let percentage = Int((Double(downloadedBytes) / Double(totalBytes) * 100).rounded())
+        return L(
+            "settings.models.localSTT.transferProgress",
+            "\(min(max(percentage, 0), 100))%",
+            formatter.string(fromByteCount: downloadedBytes),
+            formatter.string(fromByteCount: totalBytes),
+        )
     }
 
     var localSTTPreparationTint: Color {
@@ -936,9 +958,6 @@ final class StudioViewModel: ObservableObject {
             focusedModelProvider = .localSTT
             settingsStore.localSTTAutoSetup = true
             localSTTAutoSetup = true
-            if !isLocalSTTPrepared, !isPreparingLocalSTT {
-                prepareLocalSTTModel()
-            }
         case .whisperAPI:
             focusedModelProvider = .whisperAPI
         case .multimodalLLM:
@@ -988,7 +1007,40 @@ final class StudioViewModel: ObservableObject {
     }
 
     func setLocalSTTModel(_ value: LocalSTTModel) {
+        commitLocalSTTModel(value)
+    }
+
+    func focusLocalSTTModel(_ value: LocalSTTModel) {
+        if isPreparingLocalSTT, value != localSTTFocusedModel {
+            cancelLocalSTTPreparation()
+        }
+
+        localSTTFocusedModel = value
+        if localModelManager.isModelAvailable(value) {
+            commitLocalSTTModel(value)
+            return
+        }
+
+        let configuration = localSTTConfiguration(for: value)
+        localSTTModelIdentifier = configuration.modelIdentifier
+        localSTTDownloadSource = configuration.downloadSource
+        localSTTAutoSetup = configuration.autoSetup
+        localSTTStoragePath = localModelManager.storagePath(for: configuration)
+        localSTTPreparedSource = L("common.automatic")
+        localSTTStatus = L("settings.models.localSTT.notPrepared")
+        localSTTPreparationDetail = L("settings.models.localSTT.autoPrepareHint")
+        localSTTTransferDetail = ""
+        localSTTPreparationProgress = 0
+        isLocalSTTPrepared = false
+    }
+
+    private func commitLocalSTTModel(_ value: LocalSTTModel) {
+        if isPreparingLocalSTT, value != localSTTFocusedModel {
+            cancelLocalSTTPreparation()
+        }
+
         localSTTModel = value
+        localSTTFocusedModel = value
         settingsStore.localSTTModel = value
 
         let recommendedIdentifier = value.defaultModelIdentifier
@@ -1002,6 +1054,14 @@ final class StudioViewModel: ObservableObject {
         settingsStore.localSTTAutoSetup = true
         refreshLocalSTTStoragePath()
         refreshLocalSTTPreparedState()
+    }
+
+    private func cancelLocalSTTPreparation() {
+        localSTTPreparationID = nil
+        localSTTPreparationTask?.cancel()
+        localSTTPreparationTask = nil
+        isPreparingLocalSTT = false
+        LocalModelDownloadProgressCenter.shared.clear()
     }
 
     func setLLMModelSelection(_ provider: LLMProvider, suggestedModel: String) {
@@ -1887,58 +1947,98 @@ final class StudioViewModel: ObservableObject {
         }
     }
 
-    func prepareLocalSTTModel() {
+    func prepareLocalSTTModel(_ model: LocalSTTModel? = nil) {
         guard !isPreparingLocalSTT else { return }
 
-        setLocalSTTModelIdentifier(localSTTModel.defaultModelIdentifier)
+        let targetModel = model ?? localSTTFocusedModel
+        let configuration = localSTTConfiguration(for: targetModel)
+        localSTTFocusedModel = targetModel
+        localSTTModelIdentifier = configuration.modelIdentifier
+        localSTTDownloadSource = configuration.downloadSource
         localSTTAutoSetup = true
-        settingsStore.localSTTAutoSetup = true
 
-        if localModelManager.preparedModelInfo(settingsStore: settingsStore) != nil {
-            refreshLocalSTTPreparedState()
-            showToast(L("settings.models.localSTT.ready"))
+        if localModelManager.isModelAvailable(targetModel) {
+            commitLocalSTTModel(targetModel)
             return
         }
 
+        let preparationID = UUID()
+        localSTTPreparationID = preparationID
         isPreparingLocalSTT = true
         localSTTStatus = L("settings.models.localSTT.preparing")
         localSTTPreparationProgress = 0.02
         localSTTPreparationDetail = L("settings.models.localSTT.preparing")
+        localSTTTransferDetail = ""
         isLocalSTTPrepared = false
         localSTTPreparedSource = L("common.automatic")
-        refreshLocalSTTStoragePath()
+        localSTTStoragePath = localModelManager.storagePath(for: configuration)
+        LocalModelDownloadProgressCenter.shared.reportDownloading(
+            model: targetModel,
+            progress: localSTTPreparationProgress,
+        )
 
-        settingsStore.localSTTModel = localSTTModel
-        settingsStore.localSTTModelIdentifier = localSTTModelIdentifier
-        settingsStore.localSTTDownloadSource = localSTTDownloadSource
-        settingsStore.localSTTAutoSetup = localSTTAutoSetup
-
-        Task {
+        localSTTPreparationTask = Task { @MainActor [weak self] in
+            guard let self else { return }
             do {
-                try await localModelManager.prepareModel(settingsStore: settingsStore) { [weak self] update in
+                try await localModelManager.prepareModel(configuration: configuration) { [weak self] update in
                     Task { @MainActor in
+                        guard self?.localSTTPreparationID == preparationID,
+                              self?.localSTTFocusedModel == targetModel
+                        else {
+                            return
+                        }
+                        LocalModelDownloadProgressCenter.shared.reportDownloading(
+                            model: targetModel,
+                            progress: update.progress,
+                        )
                         self?.localSTTPreparationProgress = update.progress
                         self?.localSTTPreparationDetail = update.message
+                        self?.localSTTTransferDetail = Self.localSTTTransferText(
+                            downloadedBytes: update.downloadedBytes,
+                            totalBytes: update.totalBytes,
+                        )
                         self?.localSTTStoragePath = update.storagePath
                         if let source = update.source {
                             self?.localSTTPreparedSource = source
                         }
                     }
                 }
-                localSTTStatus = L("settings.models.localSTT.readyNamed", localSTTModel.displayName)
+
+                guard !Task.isCancelled,
+                      localSTTPreparationID == preparationID,
+                      localSTTFocusedModel == targetModel
+                else {
+                    return
+                }
+
+                commitLocalSTTModel(targetModel)
+                localSTTStatus = L("settings.models.localSTT.readyNamed", targetModel.displayName)
                 localSTTPreparationProgress = 1
                 localSTTPreparationDetail = L("settings.models.localSTT.downloadComplete")
+                localSTTTransferDetail = ""
                 isLocalSTTPrepared = true
-                refreshLocalSTTPreparedState()
-                showToast(L("settings.models.localSTT.ready"))
+                LocalModelDownloadProgressCenter.shared.clear()
                 await notifyLocalModelReady()
             } catch {
+                guard !Task.isCancelled,
+                      localSTTPreparationID == preparationID,
+                      localSTTFocusedModel == targetModel
+                else {
+                    return
+                }
+
                 localSTTStatus = L("common.failedWithReason", error.localizedDescription)
                 localSTTPreparationDetail = L("settings.models.localSTT.prepareFailed")
+                localSTTTransferDetail = ""
                 isLocalSTTPrepared = false
+                LocalModelDownloadProgressCenter.shared.clear()
                 showToast(L("settings.models.localSTT.prepareFailed"))
             }
-            isPreparingLocalSTT = false
+            if localSTTPreparationID == preparationID {
+                isPreparingLocalSTT = false
+                localSTTPreparationID = nil
+                localSTTPreparationTask = nil
+            }
         }
     }
 
@@ -1950,8 +2050,9 @@ final class StudioViewModel: ObservableObject {
         do {
             try localModelManager.deleteModelFiles(model)
             if model == localSTTModel {
-                refreshLocalSTTStoragePath()
-                refreshLocalSTTPreparedState()
+                selectLocalSTTFallbackAfterDeleting(model)
+            } else if model == localSTTFocusedModel {
+                focusLocalSTTModel(localSTTModel)
             }
             let toastKey = localModelManager.isModelAvailable(model)
                 ? "settings.models.localSTT.ready"
@@ -1962,15 +2063,23 @@ final class StudioViewModel: ObservableObject {
         }
     }
 
+    private func selectLocalSTTFallbackAfterDeleting(_ deletedModel: LocalSTTModel) {
+        let fallback = LocalSTTModel.displayOrder.first { model in
+            model != deletedModel && localModelManager.isModelAvailable(model)
+        } ?? LocalSTTModel.defaultModel
+
+        commitLocalSTTModel(fallback)
+        refreshLocalSTTPreparedState()
+    }
+
     func redownloadLocalSTTModel(_ model: LocalSTTModel) {
         try? localModelManager.deleteModelFiles(model)
-        if localSTTModel != model {
-            setLocalSTTModel(model)
-        } else {
+        localSTTFocusedModel = model
+        if localSTTModel == model {
             isLocalSTTPrepared = false
             localSTTPreparationProgress = 0
         }
-        prepareLocalSTTModel()
+        prepareLocalSTTModel(model)
     }
 
     func exportHistory() {
@@ -2592,6 +2701,15 @@ final class StudioViewModel: ObservableObject {
         localSTTStoragePath = localModelManager.storagePath(for: configuration)
     }
 
+    private func localSTTConfiguration(for model: LocalSTTModel) -> LocalSTTConfiguration {
+        LocalSTTConfiguration(
+            model: model,
+            modelIdentifier: model.defaultModelIdentifier,
+            downloadSource: model.recommendedDownloadSource,
+            autoSetup: true,
+        )
+    }
+
     private func refreshLocalSTTPreparedState() {
         if let prepared = localModelManager.preparedModelInfo(settingsStore: settingsStore) {
             isLocalSTTPrepared = true
@@ -2599,12 +2717,14 @@ final class StudioViewModel: ObservableObject {
             localSTTStoragePath = prepared.storagePath
             localSTTStatus = L("settings.models.localSTT.readyNamed", localSTTModel.displayName)
             localSTTPreparationDetail = L("settings.models.localSTT.downloadComplete")
+            localSTTTransferDetail = ""
             localSTTPreparationProgress = 1
         } else {
             isLocalSTTPrepared = false
             localSTTPreparedSource = L("common.automatic")
             localSTTStatus = L("settings.models.localSTT.notPrepared")
             localSTTPreparationDetail = L("settings.models.localSTT.autoPrepareHint")
+            localSTTTransferDetail = ""
             localSTTPreparationProgress = 0
         }
     }

--- a/Tests/TypefluxTests/LocalModelTranscriberTests.swift
+++ b/Tests/TypefluxTests/LocalModelTranscriberTests.swift
@@ -503,6 +503,7 @@ final class LocalModelTranscriberTests: XCTestCase {
             "openai_whisper-medium/TextDecoder.mlmodelc/weights/weight.bin",
         ])
         let fileDownloader = CapturingWhisperFileDownloader()
+        let updates = PreparationUpdateRecorder()
         let manager = LocalModelManager(
             fileManager: .default,
             sherpaOnnxInstaller: FakeSherpaOnnxInstaller(),
@@ -516,8 +517,9 @@ final class LocalModelTranscriberTests: XCTestCase {
             remoteRepositoryFileListLoader: { url in
                 try await repositoryLoader.load(from: url)
             },
-            remoteFileDownloader: { sourceURL, destinationURL in
+            remoteFileDownloader: { sourceURL, destinationURL, onProgress in
                 try await fileDownloader.download(from: sourceURL, to: destinationURL)
+                onProgress?(1, 1)
             },
             downloadSourceResolver: FixedLocalModelDownloadSourceResolver(sources: [.modelScope]),
         )
@@ -529,6 +531,9 @@ final class LocalModelTranscriberTests: XCTestCase {
                 downloadSource: .modelScope,
                 autoSetup: true,
             ),
+            onUpdate: { update in
+                updates.append(update)
+            },
         )
 
         XCTAssertEqual(
@@ -552,6 +557,7 @@ final class LocalModelTranscriberTests: XCTestCase {
             "https://hf-mirror.com/argmaxinc/whisperkit-coreml/resolve/main/openai_whisper-medium/MelSpectrogram.mlmodelc/weights/weight.bin",
             "https://hf-mirror.com/argmaxinc/whisperkit-coreml/resolve/main/openai_whisper-medium/TextDecoder.mlmodelc/weights/weight.bin",
         ])
+        XCTAssertTrue(updates.values().contains { $0.downloadedBytes == 1 && $0.totalBytes == 1 })
         let tokenizerRoot = URL(fileURLWithPath: downloadBasePath, isDirectory: true)
             .appendingPathComponent("models/openai/whisper-medium", isDirectory: true)
         XCTAssertTrue(FileManager.default.fileExists(atPath: tokenizerRoot.appendingPathComponent("tokenizer.json").path))
@@ -580,8 +586,9 @@ final class LocalModelTranscriberTests: XCTestCase {
             remoteRepositoryFileListLoader: { url in
                 try await repositoryLoader.load(from: url)
             },
-            remoteFileDownloader: { sourceURL, destinationURL in
+            remoteFileDownloader: { sourceURL, destinationURL, onProgress in
                 try await fileDownloader.download(from: sourceURL, to: destinationURL)
+                onProgress?(1, 1)
             },
             downloadSourceResolver: FixedLocalModelDownloadSourceResolver(sources: [.modelScope]),
         )

--- a/Tests/TypefluxTests/PromptCatalogTests.swift
+++ b/Tests/TypefluxTests/PromptCatalogTests.swift
@@ -208,7 +208,7 @@ final class PromptCatalogTests: XCTestCase {
         XCTAssertTrue(debugPrompt.contains("You are Typeflux AI, a writing assistant centered on voice input, responsible for organizing the original spoken content into directly usable text."))
         XCTAssertTrue(debugPrompt.contains("You convert dictated speech into directly usable text."))
         XCTAssertTrue(debugPrompt.contains("PRIMARY OBJECTIVE\nPreserve the user's intended meaning while applying the user's persona instructions."))
-        XCTAssertTrue(debugPrompt.contains("INSTRUCTION PRIORITY\n1. Follow explicit user instructions in the current request."))
+        XCTAssertTrue(debugPrompt.contains("INSTRUCTION PRIORITY\n1. Never try to answer the user's questions in `<raw_transcript/>`."))
         XCTAssertTrue(debugPrompt.contains("PERSONA HANDLING\npersona_definition is an active instruction, not source content."))
         XCTAssertTrue(debugPrompt.contains("LANGUAGE\nLanguage resolution policy:"))
         XCTAssertTrue(debugPrompt.contains("User environment context:"))

--- a/Tests/TypefluxTests/STTRouterTests.swift
+++ b/Tests/TypefluxTests/STTRouterTests.swift
@@ -139,6 +139,7 @@ final class STTRouterTests: XCTestCase {
     private func makeRouter(
         localModelOverride: Transcriber? = nil,
         doubaoRealtimeOverride: Transcriber? = nil,
+        isTypefluxCloudLoggedIn: @escaping @Sendable () async -> Bool = { false },
     ) -> STTRouter {
         STTRouter(
             settingsStore: settings,
@@ -152,6 +153,7 @@ final class STTRouterTests: XCTestCase {
             googleCloud: googleCloud,
             groq: groq,
             typefluxOfficial: typefluxOfficial,
+            isTypefluxCloudLoggedIn: isTypefluxCloudLoggedIn,
         )
     }
 
@@ -277,6 +279,41 @@ final class STTRouterTests: XCTestCase {
             XCTFail("Expected error")
         } catch {
             XCTAssertEqual((error as NSError).domain, "test")
+        }
+    }
+
+    func testFallsBackToTypefluxCloudWhenSelectedLocalModelIsNotPreparedAndLoggedIn() async throws {
+        settings.sttProvider = .localModel
+        settings.useAppleSpeechFallback = false
+        localModel.errorToThrow = NSError(
+            domain: LocalModelTranscriber.notPreparedErrorDomain,
+            code: LocalModelTranscriber.notPreparedErrorCode,
+        )
+        typefluxOfficial.resultToReturn = "cloud fallback"
+        let router = makeRouter(isTypefluxCloudLoggedIn: { true })
+
+        let result = try await router.transcribe(audioFile: dummyAudioFile())
+
+        XCTAssertEqual(result, "cloud fallback")
+        XCTAssertEqual(typefluxOfficial.transcribeCallCount, 1)
+        XCTAssertEqual(appleSpeech.transcribeCallCount, 0)
+    }
+
+    func testDoesNotUseTypefluxCloudForUnpreparedLocalModelWhenLoggedOut() async {
+        settings.sttProvider = .localModel
+        settings.useAppleSpeechFallback = false
+        localModel.errorToThrow = NSError(
+            domain: LocalModelTranscriber.notPreparedErrorDomain,
+            code: LocalModelTranscriber.notPreparedErrorCode,
+        )
+        let router = makeRouter(isTypefluxCloudLoggedIn: { false })
+
+        do {
+            _ = try await router.transcribe(audioFile: dummyAudioFile())
+            XCTFail("Expected local model not prepared error")
+        } catch {
+            XCTAssertEqual((error as NSError).domain, LocalModelTranscriber.notPreparedErrorDomain)
+            XCTAssertEqual(typefluxOfficial.transcribeCallCount, 0)
         }
     }
 

--- a/Tests/TypefluxTests/SettingsViewModelCloudDefaultsTests.swift
+++ b/Tests/TypefluxTests/SettingsViewModelCloudDefaultsTests.swift
@@ -32,6 +32,183 @@ final class SettingsViewModelCloudDefaultsTests: XCTestCase {
         XCTAssertEqual(viewModel.llmRemoteProvider, .typefluxCloud)
         XCTAssertEqual(viewModel.focusedModelProvider, .typefluxCloud)
     }
+
+    func testUnavailableLocalSTTModelFocusDoesNotCommitUntilPrepareSucceeds() async throws {
+        let suiteName = "SettingsViewModelCloudDefaultsTests.localSTT.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let settingsStore = SettingsStore(defaults: defaults)
+        settingsStore.localSTTModel = .senseVoiceSmall
+        let localModelManager = CapturingLocalSTTModelManager()
+        let viewModel = StudioViewModel(
+            settingsStore: settingsStore,
+            historyStore: EmptyHistoryStore(),
+            initialSection: .models,
+            modelManager: NoopOllamaModelManager(),
+            localModelManager: localModelManager,
+            notificationService: NoopLocalNotificationService(),
+        )
+
+        viewModel.focusLocalSTTModel(LocalSTTModel.qwen3ASR)
+
+        XCTAssertEqual(viewModel.localSTTFocusedModel, LocalSTTModel.qwen3ASR)
+        XCTAssertEqual(viewModel.localSTTModel, LocalSTTModel.senseVoiceSmall)
+        XCTAssertEqual(settingsStore.localSTTModel, LocalSTTModel.senseVoiceSmall)
+
+        viewModel.prepareLocalSTTModel(LocalSTTModel.qwen3ASR)
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        XCTAssertEqual(localModelManager.preparedModel, LocalSTTModel.qwen3ASR)
+        XCTAssertEqual(viewModel.localSTTModel, LocalSTTModel.qwen3ASR)
+        XCTAssertEqual(settingsStore.localSTTModel, LocalSTTModel.qwen3ASR)
+    }
+
+    func testManualLocalSTTPreparationPublishesMenuBarDownloadProgress() async throws {
+        LocalModelDownloadProgressCenter.shared.clear()
+        defer { LocalModelDownloadProgressCenter.shared.clear() }
+
+        let suiteName = "SettingsViewModelCloudDefaultsTests.menuProgress.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let settingsStore = SettingsStore(defaults: defaults)
+        settingsStore.localSTTModel = .senseVoiceSmall
+        let localModelManager = CapturingLocalSTTModelManager()
+        let viewModel = StudioViewModel(
+            settingsStore: settingsStore,
+            historyStore: EmptyHistoryStore(),
+            initialSection: .models,
+            modelManager: NoopOllamaModelManager(),
+            localModelManager: localModelManager,
+            notificationService: NoopLocalNotificationService(),
+        )
+        let progressExpectation = expectation(description: "manual local model download progress")
+        let observer = NotificationCenter.default.addObserver(
+            forName: .localModelDownloadProgressDidChange,
+            object: nil,
+            queue: .main,
+        ) { _ in
+            if case .downloading(model: .qwen3ASR, progress: let progress) =
+                LocalModelDownloadProgressCenter.shared.status,
+               progress > 0 {
+                progressExpectation.fulfill()
+            }
+        }
+        defer { NotificationCenter.default.removeObserver(observer) }
+
+        viewModel.prepareLocalSTTModel(LocalSTTModel.qwen3ASR)
+
+        await fulfillment(of: [progressExpectation], timeout: 2)
+    }
+
+    func testFocusingDifferentLocalSTTModelDuringPreparationPreventsStaleCommit() async throws {
+        let suiteName = "SettingsViewModelCloudDefaultsTests.stalePreparation.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let settingsStore = SettingsStore(defaults: defaults)
+        settingsStore.localSTTModel = .senseVoiceSmall
+        let preparationStarted = expectation(description: "local model preparation started")
+        let localModelManager = SuspendedLocalSTTModelManager(started: preparationStarted)
+        let viewModel = StudioViewModel(
+            settingsStore: settingsStore,
+            historyStore: EmptyHistoryStore(),
+            initialSection: .models,
+            modelManager: NoopOllamaModelManager(),
+            localModelManager: localModelManager,
+            notificationService: NoopLocalNotificationService(),
+        )
+
+        viewModel.prepareLocalSTTModel(.qwen3ASR)
+        await fulfillment(of: [preparationStarted], timeout: 2)
+
+        viewModel.focusLocalSTTModel(.funASR)
+        localModelManager.finishPreparation()
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        XCTAssertEqual(viewModel.localSTTModel, .senseVoiceSmall)
+        XCTAssertEqual(viewModel.localSTTFocusedModel, .funASR)
+        XCTAssertEqual(settingsStore.localSTTModel, .senseVoiceSmall)
+        XCTAssertFalse(viewModel.isPreparingLocalSTT)
+    }
+
+    func testDeletingSelectedLocalSTTModelSelectsFirstDownloadedFallback() {
+        let suiteName = "SettingsViewModelCloudDefaultsTests.deleteFallback.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let settingsStore = SettingsStore(defaults: defaults)
+        settingsStore.localSTTModel = .qwen3ASR
+        let localModelManager = MutableAvailabilityLocalSTTModelManager(
+            availableModels: [.qwen3ASR, .funASR, .whisperLocal],
+        )
+        let viewModel = StudioViewModel(
+            settingsStore: settingsStore,
+            historyStore: EmptyHistoryStore(),
+            initialSection: .models,
+            modelManager: NoopOllamaModelManager(),
+            localModelManager: localModelManager,
+            notificationService: NoopLocalNotificationService(),
+        )
+
+        viewModel.deleteLocalSTTModel(.qwen3ASR)
+
+        XCTAssertEqual(viewModel.localSTTModel, .funASR)
+        XCTAssertEqual(viewModel.localSTTFocusedModel, .funASR)
+        XCTAssertEqual(settingsStore.localSTTModel, .funASR)
+        XCTAssertTrue(viewModel.isLocalSTTPrepared)
+        XCTAssertEqual(viewModel.localSTTStatus, L("settings.models.localSTT.readyNamed", LocalSTTModel.funASR.displayName))
+    }
+
+    func testDeletingOnlyDownloadedLocalSTTModelFallsBackToUndownloadedSenseVoice() {
+        let suiteName = "SettingsViewModelCloudDefaultsTests.deleteDefaultFallback.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let settingsStore = SettingsStore(defaults: defaults)
+        settingsStore.localSTTModel = .qwen3ASR
+        let localModelManager = MutableAvailabilityLocalSTTModelManager(availableModels: [.qwen3ASR])
+        let viewModel = StudioViewModel(
+            settingsStore: settingsStore,
+            historyStore: EmptyHistoryStore(),
+            initialSection: .models,
+            modelManager: NoopOllamaModelManager(),
+            localModelManager: localModelManager,
+            notificationService: NoopLocalNotificationService(),
+        )
+
+        viewModel.deleteLocalSTTModel(.qwen3ASR)
+
+        XCTAssertEqual(viewModel.localSTTModel, .senseVoiceSmall)
+        XCTAssertEqual(viewModel.localSTTFocusedModel, .senseVoiceSmall)
+        XCTAssertEqual(settingsStore.localSTTModel, .senseVoiceSmall)
+        XCTAssertFalse(viewModel.isLocalSTTPrepared)
+        XCTAssertEqual(viewModel.localSTTStatus, L("settings.models.localSTT.notPrepared"))
+        XCTAssertEqual(viewModel.localSTTPreparationProgress, 0)
+    }
+
+    func testDeletingFocusedUnselectedLocalSTTModelKeepsCurrentSelection() {
+        let suiteName = "SettingsViewModelCloudDefaultsTests.deleteFocused.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let settingsStore = SettingsStore(defaults: defaults)
+        settingsStore.localSTTModel = .senseVoiceSmall
+        let localModelManager = MutableAvailabilityLocalSTTModelManager(
+            availableModels: [.senseVoiceSmall, .qwen3ASR],
+        )
+        let viewModel = StudioViewModel(
+            settingsStore: settingsStore,
+            historyStore: EmptyHistoryStore(),
+            initialSection: .models,
+            modelManager: NoopOllamaModelManager(),
+            localModelManager: localModelManager,
+            notificationService: NoopLocalNotificationService(),
+        )
+        viewModel.focusLocalSTTModel(.qwen3ASR)
+
+        viewModel.deleteLocalSTTModel(.qwen3ASR)
+
+        XCTAssertEqual(viewModel.localSTTModel, .senseVoiceSmall)
+        XCTAssertEqual(viewModel.localSTTFocusedModel, .senseVoiceSmall)
+        XCTAssertEqual(settingsStore.localSTTModel, .senseVoiceSmall)
+        XCTAssertTrue(viewModel.isLocalSTTPrepared)
+    }
 }
 
 private final class NoopOllamaModelManager: OllamaModelManaging {
@@ -56,6 +233,118 @@ private final class NoopLocalSTTModelManager: LocalSTTModelManaging {
 
     func storagePath(for _: LocalSTTConfiguration) -> String {
         "/tmp/typeflux-local-model"
+    }
+}
+
+private final class CapturingLocalSTTModelManager: LocalSTTModelManaging {
+    private(set) var preparedModel: LocalSTTModel?
+
+    func prepareModel(
+        settingsStore: SettingsStore,
+        onUpdate: (@Sendable (LocalSTTPreparationUpdate) -> Void)?,
+    ) async throws {
+        preparedModel = settingsStore.localSTTModel
+        onUpdate?(LocalSTTPreparationUpdate(
+            message: "ready",
+            progress: 1,
+            storagePath: "/tmp/typeflux-local-model",
+            source: "test",
+        ))
+    }
+
+    func preparedModelInfo(settingsStore _: SettingsStore) -> LocalSTTPreparedModelInfo? {
+        nil
+    }
+
+    func isModelAvailable(_: LocalSTTModel) -> Bool {
+        false
+    }
+
+    func deleteModelFiles(_: LocalSTTModel) throws {}
+
+    func storagePath(for _: LocalSTTConfiguration) -> String {
+        "/tmp/typeflux-local-model"
+    }
+}
+
+private struct NoopLocalNotificationService: LocalNotificationSending {
+    func sendLocalNotification(title _: String, body _: String, identifier _: String) async {}
+}
+
+private final class SuspendedLocalSTTModelManager: LocalSTTModelManaging {
+    private let started: XCTestExpectation
+    private var continuation: CheckedContinuation<Void, Error>?
+
+    init(started: XCTestExpectation) {
+        self.started = started
+    }
+
+    func prepareModel(
+        settingsStore _: SettingsStore,
+        onUpdate: (@Sendable (LocalSTTPreparationUpdate) -> Void)?,
+    ) async throws {
+        started.fulfill()
+        onUpdate?(LocalSTTPreparationUpdate(
+            message: "downloading",
+            progress: 0.25,
+            storagePath: "/tmp/typeflux-local-model",
+            source: "test",
+        ))
+        try await withCheckedThrowingContinuation { continuation in
+            self.continuation = continuation
+        }
+    }
+
+    func finishPreparation() {
+        continuation?.resume()
+        continuation = nil
+    }
+
+    func preparedModelInfo(settingsStore _: SettingsStore) -> LocalSTTPreparedModelInfo? {
+        nil
+    }
+
+    func isModelAvailable(_: LocalSTTModel) -> Bool {
+        false
+    }
+
+    func deleteModelFiles(_: LocalSTTModel) throws {}
+
+    func storagePath(for _: LocalSTTConfiguration) -> String {
+        "/tmp/typeflux-local-model"
+    }
+}
+
+private final class MutableAvailabilityLocalSTTModelManager: LocalSTTModelManaging {
+    private var availableModels: Set<LocalSTTModel>
+
+    init(availableModels: Set<LocalSTTModel>) {
+        self.availableModels = availableModels
+    }
+
+    func prepareModel(
+        settingsStore _: SettingsStore,
+        onUpdate _: (@Sendable (LocalSTTPreparationUpdate) -> Void)?,
+    ) async throws {}
+
+    func preparedModelInfo(settingsStore: SettingsStore) -> LocalSTTPreparedModelInfo? {
+        guard availableModels.contains(settingsStore.localSTTModel) else { return nil }
+        return LocalSTTPreparedModelInfo(
+            storagePath: storagePath(for: LocalSTTConfiguration(settingsStore: settingsStore)),
+            sourceDisplayName: "test",
+        )
+    }
+
+    func isModelAvailable(_ model: LocalSTTModel) -> Bool {
+        availableModels.contains(model)
+    }
+
+    func deleteModelFiles(_ model: LocalSTTModel) throws {
+        availableModels.remove(model)
+    }
+
+    func storagePath(for configuration: LocalSTTConfiguration) -> String {
+        "/tmp/typeflux-local-model/\(configuration.model.rawValue)"
     }
 }
 

--- a/Tests/TypefluxTests/StatusBarMenuSupportTests.swift
+++ b/Tests/TypefluxTests/StatusBarMenuSupportTests.swift
@@ -9,6 +9,15 @@ final class StatusBarMenuSupportTests: XCTestCase {
         XCTAssertLessThanOrEqual(StatusBarController.IconLayout.pointSize, 16)
     }
 
+    func testLocalModelDownloadTitleIncludesModelAndProgress() {
+        let title = StatusBarMenuSupport.localModelDownloadTitle(
+            for: .downloading(model: .qwen3ASR, progress: 0.42),
+        )
+
+        XCTAssertEqual(title, L("menu.downloadingLocalModelNamed", LocalSTTModel.qwen3ASR.displayName, 42))
+        XCTAssertNil(StatusBarMenuSupport.localModelDownloadTitle(for: .idle))
+    }
+
     @MainActor
     func testStatusBarMenuIncludesSettingsItemNearAppearanceControls() throws {
         if ProcessInfo.processInfo.environment["CI"] == "true" {


### PR DESCRIPTION
## Summary

Resolves [TYP-91](https://github.com/mylxsw/typeflux) — improves the visibility and ergonomics of downloading local speech-to-text models so the user always knows what is happening, without it disrupting the model that is currently in use.

- Per-model download progress (percentage + transferred bytes) shown directly on the model card in **Settings → Models**
- Status bar menu now shows the model name plus percentage while a download is running
- New confirmation dialog before downloading a not-yet-installed model from the Studio panel
- "Focused model" decoupled from the active selection: the active model only switches after a successful download, so the in-use model never breaks while the user is browsing or downloading another one
- Switching focus mid-download cancels the in-flight preparation and resets transient state
- Smart fallback: when the selected local model is still downloading and the user is logged in, transcription temporarily falls back to Typeflux Cloud (then Apple Speech if Cloud also fails)

New surfaces wiring this up:

- `Sources/Typeflux/STT/DownloadProgressReporter.swift` — URLSession download wrapper that emits byte-level progress
- `Sources/Typeflux/STT/LocalModelDownloadProgressCenter.swift` — singleton that broadcasts download status to the menu bar
- Updates threaded into `LocalModelManager`, `AutoModelDownloadService`, `SherpaOnnxModelInstaller`, `STTRouter`, `StatusBarController`, and `StudioViewModel`

## Test plan

- [x] `swift test --filter TypefluxTests.SettingsViewModelCloudDefaultsTests` (7/7 pass — new coverage for focus-vs-commit, stale preparation, deletion fallback, and menu-bar progress publishing)
- [x] `swift test --filter TypefluxTests.STTRouterTests` (22/22 pass — new tests for the cloud fallback when the local model is not yet prepared)
- [x] `swift test --filter TypefluxTests.LocalModelTranscriberTests` (34/34 pass — extended download-progress assertions)
- [x] `swift test --filter TypefluxTests.StatusBarMenuSupportTests` (5/5 pass — new menu title formatter test)
- [x] `swift test --filter TypefluxTests.LocalizationResourceTests` (7/7 pass — verifies localization keys for all five languages)
- [x] `swift build` (project still compiles cleanly)
- [x] Verified the unrelated `PromptCatalogTests.testRewritePromptDebugDescriptionShowsFinalAssembledPrompt` failure is **pre-existing on `main`** (reproduced on a clean checkout without these changes)