### PR TITLE
feat: add quick history picker

### DIFF
--- a/Sources/Typeflux/Hotkey/EventTapHotkeyService.swift
+++ b/Sources/Typeflux/Hotkey/EventTapHotkeyService.swift
@@ -1,5 +1,8 @@
 import AppKit
+import Carbon.HIToolbox
 import Foundation
+
+private let historySystemHotkeyID = EventHotKeyID(signature: 0x5459_4853, id: 1) // TYHS
 
 private func hotkeyEventTapCallback(
     proxy _: CGEventTapProxy,
@@ -12,8 +15,127 @@ private func hotkeyEventTapCallback(
     return service.handleEventTapEvent(type: type, event: event)
 }
 
+private func systemHotkeyCallback(
+    nextHandler _: EventHandlerCallRef?,
+    event: EventRef?,
+    userData: UnsafeMutableRawPointer?,
+) -> OSStatus {
+    guard let event, let userData else { return noErr }
+
+    var hotkeyID = EventHotKeyID()
+    let status = GetEventParameter(
+        event,
+        EventParamName(kEventParamDirectObject),
+        EventParamType(typeEventHotKeyID),
+        nil,
+        MemoryLayout<EventHotKeyID>.size,
+        nil,
+        &hotkeyID,
+    )
+    guard status == noErr, hotkeyID.signature == historySystemHotkeyID.signature, hotkeyID.id == historySystemHotkeyID.id
+    else {
+        return noErr
+    }
+
+    let registrar = Unmanaged<SystemHotkeyRegistrar>.fromOpaque(userData).takeUnretainedValue()
+    registrar.handlePressed()
+    return noErr
+}
+
+private final class SystemHotkeyRegistrar {
+    private var hotkeyRef: EventHotKeyRef?
+    private var eventHandlerRef: EventHandlerRef?
+
+    var onPressed: (() -> Void)?
+
+    var isRegistered: Bool {
+        hotkeyRef != nil
+    }
+
+    init() {
+        installEventHandler()
+    }
+
+    deinit {
+        unregister()
+        if let eventHandlerRef {
+            RemoveEventHandler(eventHandlerRef)
+        }
+    }
+
+    func register(_ binding: HotkeyBinding?) {
+        unregister()
+
+        guard let binding, (binding.pressCount ?? 1) == 1, !binding.isModifierOnlyTrigger else {
+            return
+        }
+
+        let hotkeyID = historySystemHotkeyID
+        var newHotkeyRef: EventHotKeyRef?
+        let status = RegisterEventHotKey(
+            UInt32(binding.keyCode),
+            carbonModifierFlags(from: binding.modifierFlags),
+            hotkeyID,
+            GetApplicationEventTarget(),
+            0,
+            &newHotkeyRef,
+        )
+        guard status == noErr else {
+            ErrorLogStore.shared.log("Hotkey: failed to register History system hotkey, status \(status)")
+            return
+        }
+
+        hotkeyRef = newHotkeyRef
+    }
+
+    func unregister() {
+        if let hotkeyRef {
+            UnregisterEventHotKey(hotkeyRef)
+        }
+        hotkeyRef = nil
+    }
+
+    fileprivate func handlePressed() {
+        DispatchQueue.main.async { [weak self] in
+            self?.onPressed?()
+        }
+    }
+
+    private func installEventHandler() {
+        guard eventHandlerRef == nil else { return }
+
+        var eventType = EventTypeSpec(
+            eventClass: OSType(kEventClassKeyboard),
+            eventKind: UInt32(kEventHotKeyPressed),
+        )
+        let userData = Unmanaged.passUnretained(self).toOpaque()
+        let status = InstallEventHandler(
+            GetApplicationEventTarget(),
+            systemHotkeyCallback,
+            1,
+            &eventType,
+            userData,
+            &eventHandlerRef,
+        )
+        if status != noErr {
+            ErrorLogStore.shared.log("Hotkey: failed to install History system hotkey handler, status \(status)")
+        }
+    }
+
+    private func carbonModifierFlags(from flags: UInt) -> UInt32 {
+        let modifierFlags = NSEvent.ModifierFlags(rawValue: flags)
+        var result: UInt32 = 0
+        if modifierFlags.contains(.command) { result |= UInt32(cmdKey) }
+        if modifierFlags.contains(.option) { result |= UInt32(optionKey) }
+        if modifierFlags.contains(.control) { result |= UInt32(controlKey) }
+        if modifierFlags.contains(.shift) { result |= UInt32(shiftKey) }
+        return result
+    }
+}
+
 final class EventTapHotkeyService: HotkeyService {
     private static let modifierActivationHoldDelay: TimeInterval = 0.22
+    private static let duplicateHistoryRequestSuppression: TimeInterval = 0.18
 
     var onActivationTap: (() -> Void)?
     var onActivationPressBegan: (() -> Void)?
@@ -22,6 +144,7 @@ final class EventTapHotkeyService: HotkeyService {
     var onAskPressBegan: (() -> Void)?
     var onAskPressEnded: (() -> Void)?
     var onPersonaPickerRequested: (() -> Void)?
+    var onHistoryRequested: (() -> Void)?
     var onError: ((String) -> Void)?
 
     private let settingsStore: SettingsStore
@@ -33,9 +156,16 @@ final class EventTapHotkeyService: HotkeyService {
     private var arbiter = HotkeyGestureArbiter()
     private var pendingModifierActivationWorkItem: DispatchWorkItem?
     private var accessibilityRetryWorkItem: DispatchWorkItem?
+    private let historySystemHotkey = SystemHotkeyRegistrar()
+    private var hotkeySettingsObserver: NSObjectProtocol?
+    private var lastHistoryRequestAt: Date?
 
     init(settingsStore: SettingsStore) {
         self.settingsStore = settingsStore
+        historySystemHotkey.onPressed = { [weak self] in
+            ErrorLogStore.shared.log("Hotkey(System): history")
+            self?.requestHistoryPicker()
+        }
     }
 
     func start() {
@@ -44,6 +174,14 @@ final class EventTapHotkeyService: HotkeyService {
         NSLog("[Hotkey] Starting event tap service...")
         ErrorLogStore.shared.log("Hotkey: starting")
 
+        registerHistorySystemHotkey()
+        hotkeySettingsObserver = NotificationCenter.default.addObserver(
+            forName: .hotkeySettingsDidChange,
+            object: settingsStore,
+            queue: .main,
+        ) { [weak self] _ in
+            self?.registerHistorySystemHotkey()
+        }
         installEventTapIfPossible()
     }
 
@@ -69,7 +207,16 @@ final class EventTapHotkeyService: HotkeyService {
         pendingModifierActivationWorkItem = nil
         accessibilityRetryWorkItem?.cancel()
         accessibilityRetryWorkItem = nil
+        if let hotkeySettingsObserver {
+            NotificationCenter.default.removeObserver(hotkeySettingsObserver)
+        }
+        hotkeySettingsObserver = nil
+        historySystemHotkey.unregister()
         arbiter = HotkeyGestureArbiter()
+    }
+
+    private func registerHistorySystemHotkey() {
+        historySystemHotkey.register(settingsStore.historyHotkey)
     }
 
     private func installEventTapIfPossible() {
@@ -184,6 +331,7 @@ final class EventTapHotkeyService: HotkeyService {
         let activationHotkey = settingsStore.activationHotkey
         let askHotkey = settingsStore.askHotkey
         let personaHotkey = settingsStore.personaHotkey
+        let historyHotkey = settingsStore.historyHotkey
         let shouldConsume = canConsume && arbiter.shouldConsume(
             eventType: eventType,
             keyCode: keyCode,
@@ -191,6 +339,7 @@ final class EventTapHotkeyService: HotkeyService {
             activationHotkey: activationHotkey,
             askHotkey: askHotkey,
             personaHotkey: personaHotkey,
+            historyHotkey: historyHotkey,
         )
 
         switch eventType {
@@ -203,6 +352,7 @@ final class EventTapHotkeyService: HotkeyService {
                     activationHotkey: activationHotkey,
                     askHotkey: askHotkey,
                     personaHotkey: personaHotkey,
+                    historyHotkey: historyHotkey,
                 ),
             )
         case .keyUp:
@@ -221,6 +371,7 @@ final class EventTapHotkeyService: HotkeyService {
                     activationHotkey: activationHotkey,
                     askHotkey: askHotkey,
                     personaHotkey: personaHotkey,
+                    historyHotkey: historyHotkey,
                 ),
             )
         }
@@ -287,7 +438,7 @@ final class EventTapHotkeyService: HotkeyService {
                 DispatchQueue.main.async { [weak self] in
                     self?.onActivationCancelled?()
                 }
-            case .cancel(.ask), .cancel(.personaPicker):
+            case .cancel(.ask), .cancel(.personaPicker), .cancel(.history):
                 break
             case .begin(.ask):
                 ErrorLogStore.shared.log("Hotkey(NSEvent): ask down")
@@ -301,14 +452,31 @@ final class EventTapHotkeyService: HotkeyService {
                 DispatchQueue.main.async { [weak self] in
                     self?.onAskPressEnded?()
                 }
-            case .begin(.personaPicker), .end(.personaPicker):
+            case .begin(.personaPicker), .end(.personaPicker), .begin(.history), .end(.history):
                 break
             case .personaRequested:
                 ErrorLogStore.shared.log("Hotkey(NSEvent): persona picker")
                 DispatchQueue.main.async { [weak self] in
                     self?.onPersonaPickerRequested?()
                 }
+            case .historyRequested:
+                ErrorLogStore.shared.log("Hotkey(NSEvent): history")
+                requestHistoryPicker()
             }
+        }
+    }
+
+    private func requestHistoryPicker() {
+        let now = Date()
+        if let lastHistoryRequestAt,
+           now.timeIntervalSince(lastHistoryRequestAt) < Self.duplicateHistoryRequestSuppression
+        {
+            ErrorLogStore.shared.log("Hotkey: suppressed duplicate History request")
+            return
+        }
+        lastHistoryRequestAt = now
+        DispatchQueue.main.async { [weak self] in
+            self?.onHistoryRequested?()
         }
     }
 

--- a/Sources/Typeflux/Hotkey/HotkeyBinding.swift
+++ b/Sources/Typeflux/Hotkey/HotkeyBinding.swift
@@ -5,6 +5,7 @@ struct HotkeyBinding: Codable, Equatable, Identifiable {
     static let rightCommandKeyCode = 54
     static let rightOptionKeyCode = 61
     static let functionKeyCode = 63
+    static let oKeyCode = 31
 
     var id: UUID
     var keyCode: Int
@@ -72,6 +73,10 @@ struct HotkeyBinding: Codable, Equatable, Identifiable {
         pressCount: 2,
     )
     static let defaultPersona = HotkeyBinding(keyCode: 35, modifierFlags: 1_572_864)
+    static let defaultHistory = HotkeyBinding(
+        keyCode: oKeyCode,
+        modifierFlags: UInt(NSEvent.ModifierFlags.command.union(.option).rawValue),
+    )
 
     static let rightCommandActivation = HotkeyBinding(
         keyCode: rightCommandKeyCode,

--- a/Sources/Typeflux/Hotkey/HotkeyGestureArbiter.swift
+++ b/Sources/Typeflux/Hotkey/HotkeyGestureArbiter.swift
@@ -12,6 +12,7 @@ enum HotkeyGestureEvent: Equatable {
     case end(HotkeyAction)
     case cancel(HotkeyAction)
     case personaRequested
+    case historyRequested
 }
 
 struct HotkeyGestureArbiter {
@@ -43,6 +44,7 @@ struct HotkeyGestureArbiter {
         activationHotkey: HotkeyBinding?,
         askHotkey: HotkeyBinding?,
         personaHotkey: HotkeyBinding?,
+        historyHotkey: HotkeyBinding? = nil,
     ) -> Bool {
         switch eventType {
         case .flagsChanged:
@@ -70,6 +72,12 @@ struct HotkeyGestureArbiter {
             {
                 return true
             }
+            if let historyHotkey,
+               historyHotkey.isModifierOnlyTrigger,
+               keyCode == historyHotkey.keyCode
+            {
+                return true
+            }
             return false
         case .keyDown:
             if let askHotkey, askHotkey.matches(keyCode: keyCode, modifierFlags: modifierFlags) {
@@ -82,6 +90,9 @@ struct HotkeyGestureArbiter {
                 return true
             }
             if let personaHotkey, personaHotkey.matches(keyCode: keyCode, modifierFlags: modifierFlags) {
+                return true
+            }
+            if let historyHotkey, historyHotkey.matches(keyCode: keyCode, modifierFlags: modifierFlags) {
                 return true
             }
             if case .active(.ask) = phase, let askHotkey, askHotkey.keyCode == keyCode {
@@ -117,6 +128,7 @@ struct HotkeyGestureArbiter {
         activationHotkey: HotkeyBinding?,
         askHotkey: HotkeyBinding?,
         personaHotkey: HotkeyBinding?,
+        historyHotkey: HotkeyBinding? = nil,
     ) -> [HotkeyGestureEvent] {
         guard !isRepeat else { return [] }
 
@@ -142,6 +154,15 @@ struct HotkeyGestureArbiter {
             return shouldCancelPendingActivation
                 ? [.cancel(.activation), .personaRequested]
                 : [.personaRequested]
+        }
+
+        if let historyHotkey, historyHotkey.matches(keyCode: keyCode, modifierFlags: modifierFlags) {
+            guard phase == .idle || phase == .pendingModifierActivation else { return [] }
+            let shouldCancelPendingActivation = phase == .pendingModifierActivation
+            phase = .idle
+            return shouldCancelPendingActivation
+                ? [.cancel(.activation), .historyRequested]
+                : [.historyRequested]
         }
 
         return []
@@ -174,6 +195,7 @@ struct HotkeyGestureArbiter {
         activationHotkey: HotkeyBinding?,
         askHotkey: HotkeyBinding?,
         personaHotkey: HotkeyBinding? = nil,
+        historyHotkey: HotkeyBinding? = nil,
         timestamp: TimeInterval = Date().timeIntervalSinceReferenceDate,
     ) -> [HotkeyGestureEvent] {
         if isSecondTapForDoubleTapAsk(
@@ -200,6 +222,7 @@ struct HotkeyGestureArbiter {
                 activationHotkey: activationHotkey,
                 askHotkey: askHotkey,
                 personaHotkey: personaHotkey,
+                historyHotkey: historyHotkey,
             ) {
                 phase = .pendingModifierActivation
                 return [.begin(.activation)]
@@ -231,6 +254,18 @@ struct HotkeyGestureArbiter {
             return shouldCancelPendingActivation
                 ? [.cancel(.activation), .personaRequested]
                 : [.personaRequested]
+        }
+
+        if let historyHotkey,
+           historyHotkey.isModifierOnlyTrigger,
+           historyHotkey.matches(keyCode: keyCode, modifierFlags: modifierFlags)
+        {
+            guard phase == .idle || phase == .pendingModifierActivation else { return [] }
+            let shouldCancelPendingActivation = phase == .pendingModifierActivation
+            phase = .idle
+            return shouldCancelPendingActivation
+                ? [.cancel(.activation), .historyRequested]
+                : [.historyRequested]
         }
 
         if case .active(.ask) = phase,
@@ -292,9 +327,10 @@ struct HotkeyGestureArbiter {
         activationHotkey: HotkeyBinding,
         askHotkey: HotkeyBinding?,
         personaHotkey: HotkeyBinding?,
+        historyHotkey: HotkeyBinding?,
     ) -> Bool {
         guard activationHotkey.isModifierOnlyTrigger else { return false }
-        let competingHotkeys = [askHotkey, personaHotkey].compactMap { $0 }
+        let competingHotkeys = [askHotkey, personaHotkey, historyHotkey].compactMap { $0 }
         return competingHotkeys.contains { hotkey in
             hotkey.modifierFlags == activationHotkey.modifierFlags
                 && (hotkey.keyCode != activationHotkey.keyCode || hotkey.isModifierDoubleTapTrigger)

--- a/Sources/Typeflux/Hotkey/HotkeyService.swift
+++ b/Sources/Typeflux/Hotkey/HotkeyService.swift
@@ -4,6 +4,7 @@ enum HotkeyAction {
     case activation
     case ask
     case personaPicker
+    case history
 }
 
 protocol HotkeyService: AnyObject {
@@ -14,6 +15,7 @@ protocol HotkeyService: AnyObject {
     var onAskPressBegan: (() -> Void)? { get set }
     var onAskPressEnded: (() -> Void)? { get set }
     var onPersonaPickerRequested: (() -> Void)? { get set }
+    var onHistoryRequested: (() -> Void)? { get set }
     var onError: ((String) -> Void)? { get set }
 
     func start()

--- a/Sources/Typeflux/Onboarding/OnboardingView.swift
+++ b/Sources/Typeflux/Onboarding/OnboardingView.swift
@@ -1530,6 +1530,12 @@ struct OnboardingView: View {
                     subtitle: L("onboarding.shortcuts.persona.hint"),
                     binding: HotkeyBinding.defaultPersona,
                 )
+
+                shortcutWideCard(
+                    title: L("settings.shortcuts.history.title"),
+                    subtitle: L("onboarding.shortcuts.history.hint"),
+                    binding: viewModel.historyHotkey,
+                )
             }
 
             if viewModel.externalKeyboardShortcutReplacement == nil {

--- a/Sources/Typeflux/Onboarding/OnboardingViewModel.swift
+++ b/Sources/Typeflux/Onboarding/OnboardingViewModel.swift
@@ -97,6 +97,7 @@ final class OnboardingViewModel: ObservableObject {
     @Published var isGlobeKeyReady: Bool = true
     @Published private(set) var activationHotkey: HotkeyBinding
     @Published private(set) var askHotkey: HotkeyBinding?
+    @Published private(set) var historyHotkey: HotkeyBinding
     @Published private(set) var externalKeyboardShortcutReplacement: ExternalKeyboardShortcutReplacement?
     @Published var showShortcutReplacementAppliedAlert = false
 
@@ -170,8 +171,10 @@ final class OnboardingViewModel: ObservableObject {
         isGlobeKeyReady = globeKeyReader.isReadyForHotkey
         let storedActivationHotkey = settingsStore.activationHotkey ?? .defaultActivation
         let storedAskHotkey = settingsStore.askHotkey
+        let storedHistoryHotkey = settingsStore.historyHotkey ?? .defaultHistory
         activationHotkey = storedActivationHotkey
         askHotkey = storedAskHotkey
+        historyHotkey = storedHistoryHotkey
         externalKeyboardShortcutReplacement = Self.detectExternalKeyboardShortcutReplacement(
             activationHotkey: storedActivationHotkey,
             askHotkey: storedAskHotkey,

--- a/Sources/Typeflux/Overlay/OverlayController.swift
+++ b/Sources/Typeflux/Overlay/OverlayController.swift
@@ -1,4 +1,5 @@
 import AppKit
+import Carbon.HIToolbox
 import QuartzCore
 import SwiftUI
 
@@ -174,6 +175,34 @@ private func overlayEventTapCallback(
     return controller.handleEventTapEvent(type: type, event: event)
 }
 
+private let overlayPickerSystemKeySignature: OSType = 0x5450_4B59 // TPKY
+
+private func overlayPickerSystemKeyCallback(
+    nextHandler _: EventHandlerCallRef?,
+    event: EventRef?,
+    userData: UnsafeMutableRawPointer?,
+) -> OSStatus {
+    guard let event, let userData else { return noErr }
+
+    var hotkeyID = EventHotKeyID()
+    let status = GetEventParameter(
+        event,
+        EventParamName(kEventParamDirectObject),
+        EventParamType(typeEventHotKeyID),
+        nil,
+        MemoryLayout<EventHotKeyID>.size,
+        nil,
+        &hotkeyID,
+    )
+    guard status == noErr, hotkeyID.signature == overlayPickerSystemKeySignature else {
+        return noErr
+    }
+
+    let controller = Unmanaged<OverlayController>.fromOpaque(userData).takeUnretainedValue()
+    controller.handlePickerSystemKey(keyCode: Int(hotkeyID.id))
+    return noErr
+}
+
 struct OverlayFailureAction {
     enum Style {
         case primary
@@ -212,6 +241,11 @@ final class OverlayController {
         let subtitle: String
     }
 
+    enum PickerStyle {
+        case persona
+        case history
+    }
+
     enum PersonaPickerIcon: Equatable {
         case none
         case global
@@ -234,6 +268,8 @@ final class OverlayController {
     private var dismissWorkItem: DispatchWorkItem?
     private var eventTap: CFMachPort?
     private var runLoopSource: CFRunLoopSource?
+    private var pickerSystemKeyHandlerRef: EventHandlerRef?
+    private var pickerSystemKeyRefs: [Int: EventHotKeyRef] = [:]
     private var lastPositionedFrame: NSRect?
     private var lastPositionedPresentation: OverlayViewModel.Presentation?
     private var pendingFrameAnimationWorkItem: DispatchWorkItem?
@@ -248,6 +284,10 @@ final class OverlayController {
 
     deinit {
         removeKeyMonitoring()
+        removePickerSystemKeyCapture()
+        if let pickerSystemKeyHandlerRef {
+            RemoveEventHandler(pickerSystemKeyHandlerRef)
+        }
     }
 
     func setRecordingActionHandlers(onCancel: (() -> Void)?, onConfirm: (() -> Void)?) {
@@ -267,6 +307,16 @@ final class OverlayController {
         model.onPersonaSelectRequested = onSelect
         model.onPersonaConfirmRequested = onConfirm
         model.onPersonaCancelRequested = onCancel
+    }
+
+    func setHistoryPickerActionHandlers(
+        onCopy: ((Int) -> Void)?,
+        onInsert: ((Int) -> Void)?,
+        onRetry: ((Int) -> Void)?,
+    ) {
+        model.onHistoryCopyRequested = onCopy
+        model.onHistoryInsertRequested = onInsert
+        model.onHistoryRetryRequested = onRetry
     }
 
     func setResultDialogHandler(onCopy: (() -> Void)?) {
@@ -614,12 +664,13 @@ final class OverlayController {
         title: String,
         instructions: String,
         icon: PersonaPickerIcon,
+        style: PickerStyle = .persona,
     ) {
         if !Thread.isMainThread {
             DispatchQueue.main.async { [weak self] in
                 self?.showPersonaPicker(
                     items: items, selectedIndex: selectedIndex, title: title,
-                    instructions: instructions, icon: icon,
+                    instructions: instructions, icon: icon, style: style,
                 )
             }
             return
@@ -635,6 +686,7 @@ final class OverlayController {
         model.statusText = title
         model.detailText = instructions
         model.personaPickerIcon = icon
+        model.pickerStyle = style
         refreshWindow()
     }
 
@@ -700,6 +752,7 @@ final class OverlayController {
             model.level = 0
             model.processingProgress = 0
             removeKeyMonitoring()
+            removePickerSystemKeyCapture()
             removeMouseMonitoring()
         }
         if Thread.isMainThread {
@@ -725,6 +778,7 @@ final class OverlayController {
             self?.model.level = 0
             self?.model.processingProgress = 0
             self?.removeKeyMonitoring()
+            self?.removePickerSystemKeyCapture()
             self?.removeMouseMonitoring()
         }
         dismissWorkItem = workItem
@@ -933,14 +987,22 @@ final class OverlayController {
     }
 
     private func updateKeyMonitoring() {
-        if model.presentation == .recordingLocked
+        if model.presentation == .personaPicker {
+            installPickerSystemKeyCaptureIfNeeded()
+            if pickerSystemKeyRefs.isEmpty {
+                installKeyMonitoringIfNeeded()
+            } else {
+                removeKeyMonitoring()
+            }
+        } else if model.presentation == .recordingLocked
             || model.presentation == .recordingLockedPreview
             || model.presentation == .failure
-            || model.presentation == .personaPicker
             || model.presentation == .resultDialog
         {
+            removePickerSystemKeyCapture()
             installKeyMonitoringIfNeeded()
         } else {
+            removePickerSystemKeyCapture()
             removeKeyMonitoring()
         }
 
@@ -949,6 +1011,58 @@ final class OverlayController {
         } else {
             removeMouseMonitoring()
         }
+    }
+
+    private func installPickerSystemKeyCaptureIfNeeded() {
+        guard pickerSystemKeyRefs.isEmpty else { return }
+        installPickerSystemKeyHandlerIfNeeded()
+        guard pickerSystemKeyHandlerRef != nil else { return }
+
+        for keyCode in [53, 125, 126, 36, 76] {
+            let hotkeyID = EventHotKeyID(signature: overlayPickerSystemKeySignature, id: UInt32(keyCode))
+            var hotkeyRef: EventHotKeyRef?
+            let status = RegisterEventHotKey(
+                UInt32(keyCode),
+                0,
+                hotkeyID,
+                GetApplicationEventTarget(),
+                0,
+                &hotkeyRef,
+            )
+            if status == noErr, let hotkeyRef {
+                pickerSystemKeyRefs[keyCode] = hotkeyRef
+            } else {
+                ErrorLogStore.shared.log("Overlay: failed to register picker system key \(keyCode), status \(status)")
+            }
+        }
+    }
+
+    private func installPickerSystemKeyHandlerIfNeeded() {
+        guard pickerSystemKeyHandlerRef == nil else { return }
+
+        var eventType = EventTypeSpec(
+            eventClass: OSType(kEventClassKeyboard),
+            eventKind: UInt32(kEventHotKeyPressed),
+        )
+        let userData = Unmanaged.passUnretained(self).toOpaque()
+        let status = InstallEventHandler(
+            GetApplicationEventTarget(),
+            overlayPickerSystemKeyCallback,
+            1,
+            &eventType,
+            userData,
+            &pickerSystemKeyHandlerRef,
+        )
+        if status != noErr {
+            ErrorLogStore.shared.log("Overlay: failed to install picker system key handler, status \(status)")
+        }
+    }
+
+    private func removePickerSystemKeyCapture() {
+        for ref in pickerSystemKeyRefs.values {
+            UnregisterEventHotKey(ref)
+        }
+        pickerSystemKeyRefs = [:]
     }
 
     private func installKeyMonitoringIfNeeded() {
@@ -1035,6 +1149,12 @@ final class OverlayController {
         if let m = _fallbackLocalMonitor { NSEvent.removeMonitor(m) }
         _fallbackGlobalMonitor = nil
         _fallbackLocalMonitor = nil
+    }
+
+    fileprivate func handlePickerSystemKey(keyCode: Int) {
+        DispatchQueue.main.async { [weak self] in
+            _ = self?.handleKeyCode(keyCode)
+        }
     }
 
     /// Called from the CGEventTap C callback on the main run loop.
@@ -1164,6 +1284,7 @@ final class OverlayViewModel: ObservableObject {
     @Published var personaSelectedIndex: Int = 0
     @Published var personaViewportHeight: CGFloat = 240
     @Published var personaPickerIcon: OverlayController.PersonaPickerIcon = .none
+    @Published var pickerStyle: OverlayController.PickerStyle = .persona
     @Published var failureActions: [OverlayFailureAction] = []
     var onDismissRequested: (() -> Void)?
     var onCancelRequested: (() -> Void)?
@@ -1173,6 +1294,9 @@ final class OverlayViewModel: ObservableObject {
     var onPersonaSelectRequested: ((Int) -> Void)?
     var onPersonaConfirmRequested: (() -> Void)?
     var onPersonaCancelRequested: (() -> Void)?
+    var onHistoryCopyRequested: ((Int) -> Void)?
+    var onHistoryInsertRequested: ((Int) -> Void)?
+    var onHistoryRetryRequested: ((Int) -> Void)?
     var onResultCopyRequested: (() -> Void)?
     var onFailureRetryHandler: (() -> Void)?
 
@@ -1216,6 +1340,18 @@ final class OverlayViewModel: ObservableObject {
 
     func requestPersonaCancel() {
         onPersonaCancelRequested?()
+    }
+
+    func requestHistoryCopy(at index: Int) {
+        onHistoryCopyRequested?(index)
+    }
+
+    func requestHistoryInsert(at index: Int) {
+        onHistoryInsertRequested?(index)
+    }
+
+    func requestHistoryRetry(at index: Int) {
+        onHistoryRetryRequested?(index)
     }
 
     func requestResultCopy() {
@@ -1699,7 +1835,80 @@ private struct OverlayView: View {
     private func personaPickerRow(
         item: OverlayController.PersonaPickerItem, index: Int, isSelected: Bool,
     ) -> some View {
-        HStack(spacing: 12) {
+        OverlayPickerRow(
+            model: model,
+            item: item,
+            index: index,
+            isSelected: isSelected,
+            isHistory: model.pickerStyle == .history,
+        )
+    }
+
+    private func scrollPersonaSelection(with proxy: ScrollViewProxy) {
+        guard model.personaItems.indices.contains(model.personaSelectedIndex) else { return }
+        withAnimation(.easeInOut(duration: 0.12)) {
+            proxy.scrollTo(model.personaSelectedIndex, anchor: .center)
+        }
+    }
+
+    private struct OverlayPickerRow: View {
+        @ObservedObject var model: OverlayViewModel
+        let item: OverlayController.PersonaPickerItem
+        let index: Int
+        let isSelected: Bool
+        let isHistory: Bool
+
+        @State private var isHovered = false
+
+        var body: some View {
+            rowContent
+                .contextMenu {
+                    if isHistory {
+                        historyActions
+                    }
+                }
+        }
+
+        private var rowContent: some View {
+            HStack(spacing: 12) {
+                if !isHistory {
+                    personaAvatar
+                }
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(item.title)
+                        .font(.system(size: 14, weight: .semibold))
+                        .foregroundStyle(Color.white.opacity(isSelected ? 0.98 : 0.94))
+                        .lineLimit(isHistory ? 2 : 1)
+                        .shadow(color: Color.black.opacity(0.34), radius: 2, x: 0, y: 1)
+                    Text(item.subtitle)
+                        .font(.system(size: 11.5, weight: .medium))
+                        .foregroundStyle(Color.white.opacity(isSelected ? 0.76 : 0.58))
+                        .lineLimit(2)
+                        .shadow(color: Color.black.opacity(0.25), radius: 2, x: 0, y: 1)
+                }
+
+                Spacer(minLength: 0)
+
+                if isHistory {
+                    historyCopyButton
+                        .opacity(isHovered ? 1 : 0)
+                        .accessibilityHidden(!isHovered)
+                } else if isSelected {
+                    selectedCheckmark
+                }
+            }
+            .padding(.horizontal, 14)
+            .padding(.vertical, isHistory ? 12 : 10)
+            .background(rowBackground)
+            .contentShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+            .onTapGesture {
+                model.requestPersonaSelection(at: index)
+            }
+            .onHover { isHovered = $0 }
+        }
+
+        private var personaAvatar: some View {
             RoundedRectangle(cornerRadius: 11, style: .continuous)
                 .fill(
                     isSelected
@@ -1716,35 +1925,47 @@ private struct OverlayView: View {
                     RoundedRectangle(cornerRadius: 11, style: .continuous)
                         .stroke(Color.white.opacity(isSelected ? 0.20 : 0.10), lineWidth: 0.8),
                 )
+        }
 
-            VStack(alignment: .leading, spacing: 4) {
-                Text(item.title)
-                    .font(.system(size: 14, weight: .semibold))
-                    .foregroundStyle(Color.white.opacity(isSelected ? 0.98 : 0.94))
-                    .shadow(color: Color.black.opacity(0.34), radius: 2, x: 0, y: 1)
-                Text(item.subtitle)
-                    .font(.system(size: 11.5, weight: .medium))
-                    .foregroundStyle(Color.white.opacity(isSelected ? 0.76 : 0.58))
-                    .lineLimit(2)
-                    .shadow(color: Color.black.opacity(0.25), radius: 2, x: 0, y: 1)
+        private var selectedCheckmark: some View {
+            ZStack {
+                Circle()
+                    .fill(StudioTheme.accent.opacity(0.95))
+                Image(systemName: "checkmark")
+                    .font(.system(size: 9.5, weight: .bold))
+                    .foregroundStyle(Color.white)
             }
+            .frame(width: 21, height: 21)
+        }
 
-            Spacer(minLength: 0)
+        private var historyCopyButton: some View {
+            Button {
+                model.requestHistoryCopy(at: index)
+            } label: {
+                Image(systemName: "doc.on.doc")
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundStyle(Color.white)
+                    .frame(width: 18, height: 18)
+            }
+            .buttonStyle(.plain)
+            .fixedSize()
+            .help(L("common.copy"))
+        }
 
-            if isSelected {
-                ZStack {
-                    Circle()
-                        .fill(StudioTheme.accent.opacity(0.95))
-                    Image(systemName: "checkmark")
-                        .font(.system(size: 9.5, weight: .bold))
-                        .foregroundStyle(Color.white)
-                }
-                .frame(width: 21, height: 21)
+        @ViewBuilder
+        private var historyActions: some View {
+            Button(L("common.copy")) {
+                model.requestHistoryCopy(at: index)
+            }
+            Button(L("overlay.historyPicker.insertAtCursor")) {
+                model.requestHistoryInsert(at: index)
+            }
+            Button(L("overlay.historyPicker.retryTranscription")) {
+                model.requestHistoryRetry(at: index)
             }
         }
-        .padding(.horizontal, 14)
-        .padding(.vertical, 10)
-        .background(
+
+        private var rowBackground: some View {
             RoundedRectangle(cornerRadius: 16, style: .continuous)
                 .fill(
                     isSelected
@@ -1770,18 +1991,7 @@ private struct OverlayView: View {
                                 endPoint: .bottom,
                             ),
                         ),
-                ),
-        )
-        .contentShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
-        .onTapGesture {
-            model.requestPersonaSelection(at: index)
-        }
-    }
-
-    private func scrollPersonaSelection(with proxy: ScrollViewProxy) {
-        guard model.personaItems.indices.contains(model.personaSelectedIndex) else { return }
-        withAnimation(.easeInOut(duration: 0.12)) {
-            proxy.scrollTo(model.personaSelectedIndex, anchor: .center)
+                )
         }
     }
 

--- a/Sources/Typeflux/Resources/en.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/en.lproj/Localizable.strings
@@ -304,6 +304,12 @@
 "overlay.personaPicker.switchApplicationInstructions" = "Choose the persona for the current application. Global persona settings will not change.";
 "overlay.personaPicker.applyTitle" = "Apply Persona";
 "overlay.personaPicker.applyInstructions" = "Choose a persona to rewrite the selected text. Press Return to apply or Esc to cancel.";
+"overlay.historyPicker.title" = "Recent History";
+"overlay.historyPicker.instructions" = "Use Up and Down to choose a record. Press Return to paste it at the cursor.";
+"overlay.historyPicker.empty" = "No reusable history entries yet.";
+"overlay.historyPicker.pasteFallbackTitle" = "History Result";
+"overlay.historyPicker.insertAtCursor" = "Insert at Cursor";
+"overlay.historyPicker.retryTranscription" = "Retry Transcription";
 
 "workflow.apply.inserted" = "Applied to the active app.";
 "workflow.apply.presentedInDialog" = "Direct insertion was unavailable, so the result was shown in a dialog.";
@@ -527,25 +533,32 @@
 "settings.shortcuts.persona.title" = "Persona switcher";
 "settings.shortcuts.persona.subtitle" = "Open a centered picker. With selected text, it can also apply a persona directly to that selection.";
 "settings.shortcuts.persona.footnote" = "";
+"settings.shortcuts.history.title" = "History";
+"settings.shortcuts.history.subtitle" = "Open the History section immediately from anywhere.";
+"settings.shortcuts.history.footnote" = "";
 "settings.advanced.personaHotkeyApply.title" = "Apply persona to selected text";
 "settings.advanced.personaHotkeyApply.subtitle" = "When enabled, the persona shortcut checks for selected text first and uses the picker to rewrite that selection instead of only switching the default persona.";
 "settings.shortcuts.recording" = "Recording a new shortcut";
 "settings.shortcuts.recordingActivation" = "Press the new voice input key or key combination now.";
 "settings.shortcuts.recordingAsk" = "Press the new Ask Anything shortcut now. You can quickly press the same modifier key twice.";
 "settings.shortcuts.recordingPersona" = "Press the shortcut that should open the persona picker.";
+"settings.shortcuts.recordingHistory" = "Press the shortcut that should open history.";
 "settings.shortcuts.recordingGeneric" = "Press the key or key combination you want to use.";
 "settings.shortcuts.record" = "Record";
 "settings.shortcuts.stopRecording" = "Stop Recording";
-"settings.shortcuts.activationConflict" = "Voice input shortcut cannot match the Ask Anything or persona shortcut.";
+"settings.shortcuts.activationConflict" = "Voice input shortcut cannot match the Ask Anything, persona, or history shortcut.";
 "settings.shortcuts.activationUpdated" = "Voice input shortcut updated.";
 "settings.shortcuts.activationUnset" = "Voice input shortcut cleared.";
-"settings.shortcuts.askConflict" = "Ask Anything shortcut cannot match the voice input or persona shortcut.";
+"settings.shortcuts.askConflict" = "Ask Anything shortcut cannot match the voice input, persona, or history shortcut.";
 "settings.shortcuts.askUpdated" = "Ask Anything shortcut updated.";
 "settings.shortcuts.askUnset" = "Ask Anything shortcut cleared.";
 "settings.shortcuts.doubleTapHelp" = "Quickly press this key twice.";
-"settings.shortcuts.personaConflict" = "Persona shortcut cannot match the voice input or Ask Anything shortcut.";
+"settings.shortcuts.personaConflict" = "Persona shortcut cannot match the voice input, Ask Anything, or history shortcut.";
 "settings.shortcuts.personaUpdated" = "Persona shortcut updated.";
 "settings.shortcuts.personaUnset" = "Persona shortcut cleared.";
+"settings.shortcuts.historyConflict" = "History shortcut cannot match the voice input, Ask Anything, or persona shortcut.";
+"settings.shortcuts.historyUpdated" = "History shortcut updated.";
+"settings.shortcuts.historyUnset" = "History shortcut cleared.";
 "settings.shortcuts.unset" = "Unset";
 "settings.shortcuts.none" = "None";
 
@@ -845,6 +858,7 @@
 "onboarding.shortcuts.activation.hint" = "Hold to talk, tap to lock recording";
 "onboarding.shortcuts.ask.hint" = "Double-tap Fn to ask or rewrite selected text";
 "onboarding.shortcuts.persona.hint" = "Switch or apply a writing persona";
+"onboarding.shortcuts.history.hint" = "Open recent history and paste a selected result";
 "onboarding.shortcuts.changeInSettings" = "You can customize shortcuts anytime in Settings → Voice Shortcuts.";
 
 "onboarding.action.back" = "Previous";

--- a/Sources/Typeflux/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/ja.lproj/Localizable.strings
@@ -302,6 +302,12 @@
 "overlay.personaPicker.switchApplicationInstructions" = "現在のアプリのペルソナを選択します。グローバル ペルソナ設定は変更されません。";
 "overlay.personaPicker.applyTitle" = "ペルソナの適用";
 "overlay.personaPicker.applyInstructions" = "選択したテキストを書き換えるペルソナを選択します。 Return を押して適用するか、Esc を押してキャンセルします。";
+"overlay.historyPicker.title" = "最近の履歴";
+"overlay.historyPicker.instructions" = "上下キーで履歴を選び、Return でカーソル位置に貼り付けます。";
+"overlay.historyPicker.empty" = "再利用できる履歴はまだありません。";
+"overlay.historyPicker.pasteFallbackTitle" = "履歴の結果";
+"overlay.historyPicker.insertAtCursor" = "カーソル位置に挿入";
+"overlay.historyPicker.retryTranscription" = "文字起こしを再試行";
 
 "workflow.apply.inserted" = "アクティブなアプリに適用されます。";
 "workflow.apply.presentedInDialog" = "直接挿入は利用できないため、結果はダイアログに表示されました。";
@@ -522,25 +528,32 @@
 "settings.shortcuts.persona.title" = "ペルソナスイッチャー";
 "settings.shortcuts.persona.subtitle" = "中央揃えピッカーを開きます。テキストを選択すると、その選択範囲にペルソナを直接適用することもできます。";
 "settings.shortcuts.persona.footnote" = "";
+"settings.shortcuts.history.title" = "履歴";
+"settings.shortcuts.history.subtitle" = "どこからでもすぐに履歴セクションを開きます。";
+"settings.shortcuts.history.footnote" = "";
 "settings.advanced.personaHotkeyApply.title" = "選択したテキストにペルソナを適用する";
 "settings.advanced.personaHotkeyApply.subtitle" = "有効にすると、ペルソナ ショートカットは最初に選択されたテキストを確認し、デフォルトのペルソナを切り替えるだけでなく、ピッカーを使用してその選択を書き換えます。";
 "settings.shortcuts.recording" = "新しいショートカットを記録する";
 "settings.shortcuts.recordingActivation" = "新しい音声入力キーまたはキーの組み合わせを今すぐ押してください。";
 "settings.shortcuts.recordingAsk" = "新しい「何でも質問」のショートカットを今すぐ押してください。同じ修飾キーを素早く 2 回押すこともできます。";
 "settings.shortcuts.recordingPersona" = "ペルソナピッカーを開くショートカットを押してください。";
+"settings.shortcuts.recordingHistory" = "履歴を開くショートカットを押してください。";
 "settings.shortcuts.recordingGeneric" = "使用するキーまたはキーの組み合わせを押してください。";
 "settings.shortcuts.record" = "記録";
 "settings.shortcuts.stopRecording" = "録音を停止する";
-"settings.shortcuts.activationConflict" = "音声入力ショートカットは、「何でも質問」またはペルソナのショートカットと一致することはできません。";
+"settings.shortcuts.activationConflict" = "音声入力ショートカットは、「何でも質問」、ペルソナ、または履歴のショートカットと一致できません。";
 "settings.shortcuts.activationUpdated" = "音声入力ショートカットが更新されました。";
 "settings.shortcuts.activationUnset" = "音声入力ショートカットを削除しました。";
-"settings.shortcuts.askConflict" = "「何でも聞く」ショートカットは、音声入力またはペルソナのショートカットと一致しません。";
+"settings.shortcuts.askConflict" = "「何でも聞く」ショートカットは、音声入力、ペルソナ、または履歴のショートカットと一致できません。";
 "settings.shortcuts.askUpdated" = "「何でも質問」ショートカットが更新されました。";
 "settings.shortcuts.askUnset" = "「何でも質問」ショートカットを削除しました。";
 "settings.shortcuts.doubleTapHelp" = "このキーを素早く 2 回押します。";
-"settings.shortcuts.personaConflict" = "ペルソナのショートカットは、音声入力または「何でも聞く」ショートカットと一致できません。";
+"settings.shortcuts.personaConflict" = "ペルソナのショートカットは、音声入力、「何でも聞く」、または履歴のショートカットと一致できません。";
 "settings.shortcuts.personaUpdated" = "ペルソナのショートカットが更新されました。";
 "settings.shortcuts.personaUnset" = "ペルソナのショートカットを削除しました。";
+"settings.shortcuts.historyConflict" = "履歴ショートカットは、音声入力、「何でも聞く」、またはペルソナのショートカットと一致できません。";
+"settings.shortcuts.historyUpdated" = "履歴ショートカットが更新されました。";
+"settings.shortcuts.historyUnset" = "履歴ショートカットを削除しました。";
 "settings.shortcuts.unset" = "解除";
 "settings.shortcuts.none" = "未設定";
 
@@ -839,6 +852,7 @@
 "onboarding.shortcuts.ask.hint" = "Fn を 2 回押して質問、または選択したテキストを書き換え";
 "onboarding.shortcuts.persona.hint" = "書き込みペルソナを切り替えるか適用する";
 "onboarding.shortcuts.changeInSettings" = "「設定」→「音声ショートカット」でいつでもショートカットをカスタマイズできます。";
+"onboarding.shortcuts.history.hint" = "最近の履歴を開き、選択した結果を貼り付け";
 
 "onboarding.action.back" = "前へ";
 "onboarding.action.continue" = "次へ";

--- a/Sources/Typeflux/Resources/ko.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/ko.lproj/Localizable.strings
@@ -302,6 +302,12 @@
 "overlay.personaPicker.switchApplicationInstructions" = "현재 애플리케이션의 페르소나를 선택하세요. 전역 페르소나 설정은 변경되지 않습니다.";
 "overlay.personaPicker.applyTitle" = "페르소나 적용";
 "overlay.personaPicker.applyInstructions" = "선택한 텍스트를 다시 쓰려면 페르소나를 선택하세요. 적용하려면 Return을 누르고, 취소하려면 Esc을 누르세요.";
+"overlay.historyPicker.title" = "최근 기록";
+"overlay.historyPicker.instructions" = "위/아래 키로 기록을 선택하고 Return을 눌러 커서 위치에 붙여넣으세요.";
+"overlay.historyPicker.empty" = "아직 재사용할 수 있는 기록이 없습니다.";
+"overlay.historyPicker.pasteFallbackTitle" = "기록 결과";
+"overlay.historyPicker.insertAtCursor" = "현재 위치에 삽입";
+"overlay.historyPicker.retryTranscription" = "전사 다시 시도";
 
 "workflow.apply.inserted" = "활성 앱에 적용됩니다.";
 "workflow.apply.presentedInDialog" = "직접 삽입이 불가능하여 결과가 대화상자에 표시되었습니다.";
@@ -522,25 +528,32 @@
 "settings.shortcuts.persona.title" = "페르소나 스위처";
 "settings.shortcuts.persona.subtitle" = "중앙 선택 도구를 엽니다. 선택한 텍스트를 사용하면 해당 선택 항목에 페르소나를 직접 적용할 수도 있습니다.";
 "settings.shortcuts.persona.footnote" = "";
+"settings.shortcuts.history.title" = "기록";
+"settings.shortcuts.history.subtitle" = "어디서든 기록 섹션을 즉시 엽니다.";
+"settings.shortcuts.history.footnote" = "";
 "settings.advanced.personaHotkeyApply.title" = "선택한 텍스트에 페르소나 적용";
 "settings.advanced.personaHotkeyApply.subtitle" = "활성화되면 페르소나 단축키는 선택한 텍스트를 먼저 확인하고 기본 페르소나만 전환하는 대신 선택기를 사용하여 해당 선택 항목을 다시 작성합니다.";
 "settings.shortcuts.recording" = "새 바로가기 녹음";
 "settings.shortcuts.recordingActivation" = "지금 새로운 음성 입력 키나 키 조합을 누르세요.";
 "settings.shortcuts.recordingAsk" = "지금 새로운 무엇이든 물어보세요 단축키를 누르세요. 같은 보조 키를 빠르게 두 번 누를 수도 있습니다.";
 "settings.shortcuts.recordingPersona" = "페르소나 선택기를 여는 바로가기를 누르세요.";
+"settings.shortcuts.recordingHistory" = "기록을 여는 바로가기를 누르세요.";
 "settings.shortcuts.recordingGeneric" = "사용하려는 키나 키 조합을 누르세요.";
 "settings.shortcuts.record" = "기록";
 "settings.shortcuts.stopRecording" = "녹음 중지";
-"settings.shortcuts.activationConflict" = "음성 입력 바로가기는 무엇이든 물어보세요 또는 페르소나 바로가기와 일치할 수 없습니다.";
+"settings.shortcuts.activationConflict" = "음성 입력 바로가기는 무엇이든 물어보세요, 페르소나 또는 기록 바로가기와 일치할 수 없습니다.";
 "settings.shortcuts.activationUpdated" = "음성 입력 단축키가 업데이트되었습니다.";
 "settings.shortcuts.activationUnset" = "음성 입력 단축키가 삭제되었습니다.";
-"settings.shortcuts.askConflict" = "무엇이든 물어보세요 단축키는 음성 입력 또는 페르소나 단축키와 일치할 수 없습니다.";
+"settings.shortcuts.askConflict" = "무엇이든 물어보세요 단축키는 음성 입력, 페르소나 또는 기록 단축키와 일치할 수 없습니다.";
 "settings.shortcuts.askUpdated" = "무엇이든 물어보세요 바로가기가 업데이트되었습니다.";
 "settings.shortcuts.askUnset" = "무엇이든 물어보세요 단축키가 삭제되었습니다.";
 "settings.shortcuts.doubleTapHelp" = "이 키를 빠르게 두 번 누르세요.";
-"settings.shortcuts.personaConflict" = "페르소나 단축키는 음성 입력 또는 무엇이든 물어보세요 단축키와 일치할 수 없습니다.";
+"settings.shortcuts.personaConflict" = "페르소나 단축키는 음성 입력, 무엇이든 물어보세요 또는 기록 단축키와 일치할 수 없습니다.";
 "settings.shortcuts.personaUpdated" = "페르소나 바로가기가 업데이트되었습니다.";
 "settings.shortcuts.personaUnset" = "페르소나 단축키가 삭제되었습니다.";
+"settings.shortcuts.historyConflict" = "기록 단축키는 음성 입력, 무엇이든 물어보세요 또는 페르소나 단축키와 일치할 수 없습니다.";
+"settings.shortcuts.historyUpdated" = "기록 단축키가 업데이트되었습니다.";
+"settings.shortcuts.historyUnset" = "기록 단축키가 삭제되었습니다.";
 "settings.shortcuts.unset" = "해제";
 "settings.shortcuts.none" = "없음";
 
@@ -839,6 +852,7 @@
 "onboarding.shortcuts.ask.hint" = "Fn을 두 번 눌러 질문하거나 선택한 텍스트 다시 작성";
 "onboarding.shortcuts.persona.hint" = "쓰기 페르소나 전환 또는 적용";
 "onboarding.shortcuts.changeInSettings" = "설정 → 음성 단축키에서 언제든지 단축키를 맞춤 설정할 수 있습니다.";
+"onboarding.shortcuts.history.hint" = "최근 기록을 열고 선택한 결과 붙여넣기";
 
 "onboarding.action.back" = "이전";
 "onboarding.action.continue" = "다음";

--- a/Sources/Typeflux/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/zh-Hans.lproj/Localizable.strings
@@ -304,6 +304,12 @@
 "overlay.personaPicker.switchApplicationInstructions" = "为当前应用选择人设。全局人设设置不会改变。";
 "overlay.personaPicker.applyTitle" = "应用人设";
 "overlay.personaPicker.applyInstructions" = "选择一个人设来改写当前选中文本。按回车应用，按 Esc 取消。";
+"overlay.historyPicker.title" = "最近历史";
+"overlay.historyPicker.instructions" = "使用上下键选择记录，按回车粘贴到当前光标。";
+"overlay.historyPicker.empty" = "还没有可复用的历史记录。";
+"overlay.historyPicker.pasteFallbackTitle" = "历史结果";
+"overlay.historyPicker.insertAtCursor" = "插入当前位置";
+"overlay.historyPicker.retryTranscription" = "重新转写";
 
 "workflow.apply.inserted" = "已应用到当前活动应用。";
 "workflow.apply.presentedInDialog" = "由于无法直接插入，结果已显示在提示框中。";
@@ -527,25 +533,32 @@
 "settings.shortcuts.persona.title" = "人设切换器";
 "settings.shortcuts.persona.subtitle" = "打开居中选择器；如果当前存在选中文本，也可以直接将所选人设应用到这段文本。";
 "settings.shortcuts.persona.footnote" = "";
+"settings.shortcuts.history.title" = "历史记录";
+"settings.shortcuts.history.subtitle" = "在任何地方立即打开历史记录页面。";
+"settings.shortcuts.history.footnote" = "";
 "settings.advanced.personaHotkeyApply.title" = "将人设应用到选中文本";
 "settings.advanced.personaHotkeyApply.subtitle" = "开启后，人设快捷键会先检查是否有选中文本；如果有，就用所选人设直接改写该文本，而不只是切换默认人设。";
 "settings.shortcuts.recording" = "正在录制新的快捷键";
 "settings.shortcuts.recordingActivation" = "现在按下新的语音输入按键或组合键。";
 "settings.shortcuts.recordingAsk" = "现在按下新的“随便问”快捷键。也可以快速连按两次同一个修饰键。";
 "settings.shortcuts.recordingPersona" = "现在按下用于打开人设选择器的快捷键。";
+"settings.shortcuts.recordingHistory" = "现在按下用于打开历史记录的快捷键。";
 "settings.shortcuts.recordingGeneric" = "按下你想使用的按键或组合键。";
 "settings.shortcuts.record" = "录制";
 "settings.shortcuts.stopRecording" = "停止录制";
-"settings.shortcuts.activationConflict" = "语音输入快捷键不能与“随便问”或人设快捷键相同。";
+"settings.shortcuts.activationConflict" = "语音输入快捷键不能与“随便问”、人设或历史记录快捷键相同。";
 "settings.shortcuts.activationUpdated" = "语音输入快捷键已更新。";
 "settings.shortcuts.activationUnset" = "语音输入快捷键已清除。";
-"settings.shortcuts.askConflict" = "“随便问”快捷键不能与语音输入或人设快捷键相同。";
+"settings.shortcuts.askConflict" = "“随便问”快捷键不能与语音输入、人设或历史记录快捷键相同。";
 "settings.shortcuts.askUpdated" = "“随便问”快捷键已更新。";
 "settings.shortcuts.askUnset" = "“随便问”快捷键已清除。";
 "settings.shortcuts.doubleTapHelp" = "快速连按两次这个按键。";
-"settings.shortcuts.personaConflict" = "人设快捷键不能与语音输入或“随便问”快捷键相同。";
+"settings.shortcuts.personaConflict" = "人设快捷键不能与语音输入、“随便问”或历史记录快捷键相同。";
 "settings.shortcuts.personaUpdated" = "人设快捷键已更新。";
 "settings.shortcuts.personaUnset" = "人设快捷键已清除。";
+"settings.shortcuts.historyConflict" = "历史记录快捷键不能与语音输入、“随便问”或人设快捷键相同。";
+"settings.shortcuts.historyUpdated" = "历史记录快捷键已更新。";
+"settings.shortcuts.historyUnset" = "历史记录快捷键已清除。";
 "settings.shortcuts.unset" = "取消设置";
 "settings.shortcuts.none" = "未设置";
 
@@ -845,6 +858,7 @@
 "onboarding.shortcuts.activation.hint" = "按住录音，轻点锁定录制";
 "onboarding.shortcuts.ask.hint" = "连按两次 Fn 提问，可选中文字改写";
 "onboarding.shortcuts.persona.hint" = "切换或应用写作人设";
+"onboarding.shortcuts.history.hint" = "打开最近历史并粘贴选中结果";
 "onboarding.shortcuts.changeInSettings" = "随时可以在 设置 → 语音快捷键 中自定义快捷键。";
 
 "onboarding.action.back" = "上一步";

--- a/Sources/Typeflux/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/zh-Hant.lproj/Localizable.strings
@@ -302,6 +302,12 @@
 "overlay.personaPicker.switchApplicationInstructions" = "為目前應用選擇人設。全域人設設定不會改變。";
 "overlay.personaPicker.applyTitle" = "套用人設";
 "overlay.personaPicker.applyInstructions" = "選擇一個人設來改寫目前選取的文字。按 Enter 套用，按 Esc 取消。";
+"overlay.historyPicker.title" = "最近歷史";
+"overlay.historyPicker.instructions" = "使用上下鍵選擇記錄，按 Enter 貼到目前游標。";
+"overlay.historyPicker.empty" = "還沒有可重用的歷史記錄。";
+"overlay.historyPicker.pasteFallbackTitle" = "歷史結果";
+"overlay.historyPicker.insertAtCursor" = "插入目前位置";
+"overlay.historyPicker.retryTranscription" = "重新轉寫";
 
 "workflow.apply.inserted" = "已套用到目前活動應用。";
 "workflow.apply.presentedInDialog" = "因無法直接插入，結果已顯示在提示框中。";
@@ -525,25 +531,32 @@
 "settings.shortcuts.persona.title" = "人設切換器";
 "settings.shortcuts.persona.subtitle" = "打開置中的選擇器；如果目前有選取文字，也可以直接把所選人設套用到這段文字。";
 "settings.shortcuts.persona.footnote" = "";
+"settings.shortcuts.history.title" = "歷史記錄";
+"settings.shortcuts.history.subtitle" = "在任何地方立即打開歷史記錄頁面。";
+"settings.shortcuts.history.footnote" = "";
 "settings.advanced.personaHotkeyApply.title" = "將人設套用到選取文字";
 "settings.advanced.personaHotkeyApply.subtitle" = "開啟後，人設快捷鍵會先檢查是否有選取文字；如果有，就用所選人設直接改寫該文字，而不只是切換預設人設。";
 "settings.shortcuts.recording" = "正在錄製新的快捷鍵";
 "settings.shortcuts.recordingActivation" = "現在按下新的語音輸入按鍵或組合鍵。";
 "settings.shortcuts.recordingAsk" = "現在按下新的「隨便問」快捷鍵。也可以快速連按兩次同一個修飾鍵。";
 "settings.shortcuts.recordingPersona" = "現在按下用於打開人設選擇器的快捷鍵。";
+"settings.shortcuts.recordingHistory" = "現在按下用於打開歷史記錄的快捷鍵。";
 "settings.shortcuts.recordingGeneric" = "按下你想使用的按鍵或組合鍵。";
 "settings.shortcuts.record" = "錄製";
 "settings.shortcuts.stopRecording" = "停止錄製";
-"settings.shortcuts.activationConflict" = "語音輸入快捷鍵不能與「隨便問」或人設快捷鍵相同。";
+"settings.shortcuts.activationConflict" = "語音輸入快捷鍵不能與「隨便問」、人設或歷史記錄快捷鍵相同。";
 "settings.shortcuts.activationUpdated" = "語音輸入快捷鍵已更新。";
 "settings.shortcuts.activationUnset" = "語音輸入快捷鍵已清除。";
-"settings.shortcuts.askConflict" = "「隨便問」快捷鍵不能與語音輸入或人設快捷鍵相同。";
+"settings.shortcuts.askConflict" = "「隨便問」快捷鍵不能與語音輸入、人設或歷史記錄快捷鍵相同。";
 "settings.shortcuts.askUpdated" = "「隨便問」快捷鍵已更新。";
 "settings.shortcuts.askUnset" = "「隨便問」快捷鍵已清除。";
 "settings.shortcuts.doubleTapHelp" = "快速連按兩次這個按鍵。";
-"settings.shortcuts.personaConflict" = "人設快捷鍵不能與語音輸入或「隨便問」快捷鍵相同。";
+"settings.shortcuts.personaConflict" = "人設快捷鍵不能與語音輸入、「隨便問」或歷史記錄快捷鍵相同。";
 "settings.shortcuts.personaUpdated" = "人設快捷鍵已更新。";
 "settings.shortcuts.personaUnset" = "人設快捷鍵已清除。";
+"settings.shortcuts.historyConflict" = "歷史記錄快捷鍵不能與語音輸入、「隨便問」或人設快捷鍵相同。";
+"settings.shortcuts.historyUpdated" = "歷史記錄快捷鍵已更新。";
+"settings.shortcuts.historyUnset" = "歷史記錄快捷鍵已清除。";
 "settings.shortcuts.unset" = "取消設定";
 "settings.shortcuts.none" = "未設定";
 
@@ -841,6 +854,7 @@
 "onboarding.shortcuts.activation.hint" = "按住錄音，輕點鎖定錄製";
 "onboarding.shortcuts.ask.hint" = "連按兩次 Fn 提問，可選取文字改寫";
 "onboarding.shortcuts.persona.hint" = "切換或套用寫作人設";
+"onboarding.shortcuts.history.hint" = "打開最近歷史並貼上選取結果";
 "onboarding.shortcuts.changeInSettings" = "隨時可在 設定 → 語音快捷鍵 中自訂快捷鍵。";
 
 "onboarding.action.back" = "上一步";

--- a/Sources/Typeflux/Settings/SettingsStore.swift
+++ b/Sources/Typeflux/Settings/SettingsStore.swift
@@ -764,6 +764,31 @@ final class SettingsStore {
         }
     }
 
+    var historyHotkeyJSON: String {
+        get { defaults.string(forKey: "hotkey.history.json") ?? "" }
+        set { defaults.set(newValue, forKey: "hotkey.history.json") }
+    }
+
+    var historyHotkey: HotkeyBinding? {
+        get {
+            if historyHotkeyJSON == "__unset__" { return nil }
+            guard let data = historyHotkeyJSON.data(using: .utf8), !historyHotkeyJSON.isEmpty else {
+                return .defaultHistory
+            }
+
+            return (try? JSONDecoder().decode(HotkeyBinding.self, from: data)) ?? .defaultHistory
+        }
+        set {
+            if let newValue {
+                let data = (try? JSONEncoder().encode(newValue)) ?? Data()
+                historyHotkeyJSON = String(decoding: data, as: UTF8.self)
+            } else {
+                historyHotkeyJSON = "__unset__"
+            }
+            NotificationCenter.default.post(name: .hotkeySettingsDidChange, object: self)
+        }
+    }
+
     private var legacyActivationHotkey: HotkeyBinding? {
         guard activationHotkeyJSON.isEmpty else { return nil }
         let legacyJSON = defaults.string(forKey: "hotkey.custom.json") ?? "[]"

--- a/Sources/Typeflux/Settings/SettingsView.swift
+++ b/Sources/Typeflux/Settings/SettingsView.swift
@@ -165,6 +165,7 @@ struct StudioView: View {
         case activation
         case ask
         case persona
+        case history
     }
 
     private enum PersonaAppPickerScope: String, CaseIterable, Sendable {
@@ -2198,6 +2199,33 @@ struct StudioView: View {
                                 viewModel.unsetPersonaHotkey()
                             },
                         )
+
+                        shortcutConfigurationRow(
+                            configuration: ShortcutConfiguration(
+                                title: L("settings.shortcuts.history.title"),
+                                subtitle: L("settings.shortcuts.history.subtitle"),
+                                footnote: L("settings.shortcuts.history.footnote"),
+                                icon: "clock.arrow.circlepath",
+                                badgeSymbol: "clock",
+                                binding: viewModel.historyHotkey,
+                                isDefault: viewModel.historyHotkey?.signature
+                                    == HotkeyBinding.defaultHistory.signature,
+                                isThisRecording: recordingTarget == .history,
+                            ),
+                            onStartRecording: {
+                                recordingTarget = .history
+                                recorder.start { binding in
+                                    viewModel.setHistoryHotkey(binding)
+                                    recordingTarget = nil
+                                }
+                            },
+                            onReset: {
+                                viewModel.resetHistoryHotkey()
+                            },
+                            onUnset: {
+                                viewModel.unsetHistoryHotkey()
+                            },
+                        )
                     }
 
                     if recorder.isRecording {
@@ -3005,6 +3033,8 @@ struct StudioView: View {
             L("settings.shortcuts.recordingAsk")
         case .persona:
             L("settings.shortcuts.recordingPersona")
+        case .history:
+            L("settings.shortcuts.recordingHistory")
         case nil:
             L("settings.shortcuts.recordingGeneric")
         }

--- a/Sources/Typeflux/Settings/SettingsViewModel.swift
+++ b/Sources/Typeflux/Settings/SettingsViewModel.swift
@@ -203,6 +203,7 @@ final class StudioViewModel: ObservableObject {
     @Published var activationHotkey: HotkeyBinding?
     @Published var askHotkey: HotkeyBinding?
     @Published var personaHotkey: HotkeyBinding?
+    @Published var historyHotkey: HotkeyBinding?
     @Published var historyRetentionPolicy: HistoryRetentionPolicy
     @Published private(set) var historyRecords: [HistoryRecord]
     @Published private(set) var playingAudioRecordID: UUID?
@@ -363,6 +364,7 @@ final class StudioViewModel: ObservableObject {
         activationHotkey = settingsStore.activationHotkey
         askHotkey = settingsStore.askHotkey
         personaHotkey = settingsStore.personaHotkey
+        historyHotkey = settingsStore.historyHotkey
         historyRetentionPolicy = settingsStore.historyRetentionPolicy
         historyRecords = []
         displayedHistory = []
@@ -1558,6 +1560,10 @@ final class StudioViewModel: ObservableObject {
             showToast(L("settings.shortcuts.activationConflict"))
             return
         }
+        if let historyHotkey, binding.signature == historyHotkey.signature {
+            showToast(L("settings.shortcuts.activationConflict"))
+            return
+        }
 
         activationHotkey = binding
         settingsStore.activationHotkey = binding
@@ -1580,6 +1586,10 @@ final class StudioViewModel: ObservableObject {
             return
         }
         if let personaHotkey, binding.signature == personaHotkey.signature {
+            showToast(L("settings.shortcuts.askConflict"))
+            return
+        }
+        if let historyHotkey, binding.signature == historyHotkey.signature {
             showToast(L("settings.shortcuts.askConflict"))
             return
         }
@@ -1608,6 +1618,10 @@ final class StudioViewModel: ObservableObject {
             showToast(L("settings.shortcuts.personaConflict"))
             return
         }
+        if let historyHotkey, binding.signature == historyHotkey.signature {
+            showToast(L("settings.shortcuts.personaConflict"))
+            return
+        }
 
         personaHotkey = binding
         settingsStore.personaHotkey = binding
@@ -1624,10 +1638,40 @@ final class StudioViewModel: ObservableObject {
         showToast(L("settings.shortcuts.personaUnset"))
     }
 
+    func setHistoryHotkey(_ binding: HotkeyBinding) {
+        if let activationHotkey, binding.signature == activationHotkey.signature {
+            showToast(L("settings.shortcuts.historyConflict"))
+            return
+        }
+        if let askHotkey, binding.signature == askHotkey.signature {
+            showToast(L("settings.shortcuts.historyConflict"))
+            return
+        }
+        if let personaHotkey, binding.signature == personaHotkey.signature {
+            showToast(L("settings.shortcuts.historyConflict"))
+            return
+        }
+
+        historyHotkey = binding
+        settingsStore.historyHotkey = binding
+        showToast(L("settings.shortcuts.historyUpdated"))
+    }
+
+    func resetHistoryHotkey() {
+        setHistoryHotkey(.defaultHistory)
+    }
+
+    func unsetHistoryHotkey() {
+        historyHotkey = nil
+        settingsStore.historyHotkey = nil
+        showToast(L("settings.shortcuts.historyUnset"))
+    }
+
     private func syncHotkeysFromStore() {
         activationHotkey = settingsStore.activationHotkey
         askHotkey = settingsStore.askHotkey
         personaHotkey = settingsStore.personaHotkey
+        historyHotkey = settingsStore.historyHotkey
     }
 
     func applyPersonaSelection(_ id: UUID?) {

--- a/Sources/Typeflux/Workflow/WorkflowController+History.swift
+++ b/Sources/Typeflux/Workflow/WorkflowController+History.swift
@@ -1,0 +1,146 @@
+import Foundation
+
+extension WorkflowController {
+    private static let historyPickerLimit = 20
+
+    func handleHistoryPickerRequested() {
+        if isHistoryPickerPresented {
+            dismissHistoryPicker(immediate: true)
+            return
+        }
+
+        if isPersonaPickerPresented {
+            dismissPersonaPicker()
+        }
+
+        guard !isRecording, processingTask == nil else { return }
+
+        let entries = historyPickerEntries()
+        guard !entries.isEmpty else {
+            overlayController.showNotice(message: L("overlay.historyPicker.empty"))
+            overlayController.dismiss(after: 2.0)
+            return
+        }
+
+        historyPickerItems = entries
+        historyPickerSelectedIndex = 0
+        isHistoryPickerPresented = true
+        overlayController.showPersonaPicker(
+            items: entries.map {
+                OverlayController.PersonaPickerItem(
+                    id: $0.id.uuidString,
+                    title: $0.title,
+                    subtitle: $0.subtitle,
+                )
+            },
+            selectedIndex: 0,
+            title: L("overlay.historyPicker.title"),
+            instructions: L("overlay.historyPicker.instructions"),
+            icon: .none,
+            style: .history,
+        )
+    }
+
+    func historyPickerEntries() -> [HistoryPickerEntry] {
+        StatusBarMenuSupport.recentTranscriptionRecords(
+            from: historyStore.list(limit: Self.historyPickerLimit * 3, offset: 0, searchQuery: nil),
+            limit: Self.historyPickerLimit,
+        )
+        .compactMap { record in
+            guard let text = record.finalText?.trimmingCharacters(in: .whitespacesAndNewlines),
+                  !text.isEmpty
+            else { return nil }
+
+            return HistoryPickerEntry(
+                id: record.id,
+                title: StatusBarMenuSupport.recentHistoryTitle(for: record),
+                subtitle: Self.historyPickerSubtitle(for: record.date),
+                text: text,
+                record: record,
+            )
+        }
+    }
+
+    func moveHistorySelection(delta: Int) {
+        guard isHistoryPickerPresented, !historyPickerItems.isEmpty else { return }
+        let maxIndex = historyPickerItems.count - 1
+        historyPickerSelectedIndex = max(0, min(maxIndex, historyPickerSelectedIndex + delta))
+        Task { @MainActor in
+            self.overlayController.updatePersonaPickerSelection(self.historyPickerSelectedIndex)
+        }
+    }
+
+    func confirmHistorySelection() {
+        guard isHistoryPickerPresented,
+              historyPickerItems.indices.contains(historyPickerSelectedIndex)
+        else { return }
+
+        insertHistorySelection(at: historyPickerSelectedIndex)
+    }
+
+    func copyHistorySelection(at index: Int) {
+        guard isHistoryPickerPresented,
+              historyPickerItems.indices.contains(index)
+        else { return }
+
+        let selected = historyPickerItems[index]
+        clipboard.write(text: selected.text)
+        soundEffectPlayer.playAsync(.tip)
+        dismissHistoryPicker(immediate: true)
+    }
+
+    func insertHistorySelection(at index: Int) {
+        guard isHistoryPickerPresented,
+              historyPickerItems.indices.contains(index)
+        else { return }
+
+        let selected = historyPickerItems[index]
+        soundEffectPlayer.playAsync(.tip)
+        dismissHistoryPicker(immediate: true)
+        clipboard.write(text: selected.text)
+        _ = applyText(
+            selected.text,
+            replace: false,
+            fallbackTitle: L("overlay.historyPicker.pasteFallbackTitle"),
+        )
+    }
+
+    func retryHistorySelection(at index: Int) {
+        guard isHistoryPickerPresented,
+              historyPickerItems.indices.contains(index)
+        else { return }
+
+        let selected = historyPickerItems[index]
+        soundEffectPlayer.playAsync(.tip)
+        dismissHistoryPicker(immediate: true)
+        retry(record: selected.record)
+    }
+
+    func selectHistorySelection(at index: Int) {
+        guard isHistoryPickerPresented, historyPickerItems.indices.contains(index) else { return }
+        historyPickerSelectedIndex = index
+        confirmHistorySelection()
+    }
+
+    func dismissHistoryPicker(closeOverlay: Bool = true, immediate: Bool = false) {
+        guard isHistoryPickerPresented else { return }
+        isHistoryPickerPresented = false
+        historyPickerItems = []
+        historyPickerSelectedIndex = 0
+        guard closeOverlay else { return }
+        if immediate {
+            overlayController.dismissImmediately()
+            return
+        }
+        Task { @MainActor in
+            self.overlayController.dismiss(after: 0.05)
+        }
+    }
+
+    private static func historyPickerSubtitle(for date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .short
+        return formatter.string(from: date)
+    }
+}

--- a/Sources/Typeflux/Workflow/WorkflowController+Persona.swift
+++ b/Sources/Typeflux/Workflow/WorkflowController+Persona.swift
@@ -2,6 +2,38 @@ import AppKit
 import Foundation
 
 extension WorkflowController {
+    func moveOverlayPickerSelection(delta: Int) {
+        if isHistoryPickerPresented {
+            moveHistorySelection(delta: delta)
+            return
+        }
+        movePersonaSelection(delta: delta)
+    }
+
+    func selectOverlayPickerSelection(at index: Int) {
+        if isHistoryPickerPresented {
+            selectHistorySelection(at: index)
+            return
+        }
+        selectPersonaSelection(at: index)
+    }
+
+    func confirmOverlayPickerSelection() {
+        if isHistoryPickerPresented {
+            confirmHistorySelection()
+            return
+        }
+        confirmPersonaSelection()
+    }
+
+    func dismissOverlayPicker() {
+        if isHistoryPickerPresented {
+            dismissHistoryPicker()
+            return
+        }
+        dismissPersonaPicker()
+    }
+
     func personaPickerTitle(for mode: PersonaPickerMode) -> String {
         switch mode {
         case .switchDefault:

--- a/Sources/Typeflux/Workflow/WorkflowController.swift
+++ b/Sources/Typeflux/Workflow/WorkflowController.swift
@@ -125,6 +125,9 @@ final class WorkflowController {
     var personaPickerItems: [PersonaPickerEntry] = []
     var personaPickerSelectedIndex = 0
     var personaPickerMode: PersonaPickerMode = .switchDefault
+    var isHistoryPickerPresented = false
+    var historyPickerItems: [HistoryPickerEntry] = []
+    var historyPickerSelectedIndex = 0
 
     // Clarification mode: set when the agent workflow is paused waiting for a user voice reply.
     var pendingClarificationContinuation: CheckedContinuation<String, Error>?
@@ -134,6 +137,14 @@ final class WorkflowController {
         let id: UUID?
         let title: String
         let subtitle: String
+    }
+
+    struct HistoryPickerEntry {
+        let id: UUID
+        let title: String
+        let subtitle: String
+        let text: String
+        let record: HistoryRecord
     }
 
     struct PersonaSelectionContext {
@@ -210,11 +221,16 @@ final class WorkflowController {
             },
         )
         self.overlayController.setPersonaPickerHandlers(
-            onMoveUp: { [weak self] in self?.movePersonaSelection(delta: -1) },
-            onMoveDown: { [weak self] in self?.movePersonaSelection(delta: 1) },
-            onSelect: { [weak self] index in self?.selectPersonaSelection(at: index) },
-            onConfirm: { [weak self] in self?.confirmPersonaSelection() },
-            onCancel: { [weak self] in self?.dismissPersonaPicker() },
+            onMoveUp: { [weak self] in self?.moveOverlayPickerSelection(delta: -1) },
+            onMoveDown: { [weak self] in self?.moveOverlayPickerSelection(delta: 1) },
+            onSelect: { [weak self] index in self?.selectOverlayPickerSelection(at: index) },
+            onConfirm: { [weak self] in self?.confirmOverlayPickerSelection() },
+            onCancel: { [weak self] in self?.dismissOverlayPicker() },
+        )
+        self.overlayController.setHistoryPickerActionHandlers(
+            onCopy: { [weak self] index in self?.copyHistorySelection(at: index) },
+            onInsert: { [weak self] index in self?.insertHistorySelection(at: index) },
+            onRetry: { [weak self] index in self?.retryHistorySelection(at: index) },
         )
         self.agentClarificationWindowController.onDismiss = { [weak self] in
             self?.dismissClarification()
@@ -262,6 +278,9 @@ final class WorkflowController {
         }
         hotkeyService.onPersonaPickerRequested = { [weak self] in
             self?.handlePersonaPickerRequested()
+        }
+        hotkeyService.onHistoryRequested = { [weak self] in
+            self?.handleHistoryPickerRequested()
         }
         hotkeyService.onError = { [weak self] message in
             guard let self else { return }
@@ -319,6 +338,7 @@ final class WorkflowController {
     func stop() {
         hotkeyService.stop()
         dismissPersonaPicker()
+        dismissHistoryPicker()
         askAnswerWindowController.dismiss()
         agentClarificationWindowController.dismiss()
         cancelRecording()
@@ -469,6 +489,9 @@ final class WorkflowController {
         if isPersonaPickerPresented {
             dismissPersonaPicker()
         }
+        if isHistoryPickerPresented {
+            dismissHistoryPicker()
+        }
 
         if !isRecording, isAudioRecorderStarted {
             NSLog("[Workflow] Audio recorder is still stopping, ignoring press")
@@ -599,6 +622,9 @@ final class WorkflowController {
         if isPersonaPickerPresented {
             dismissPersonaPicker()
             return
+        }
+        if isHistoryPickerPresented {
+            dismissHistoryPicker()
         }
 
         let personaHotkeyAppliesToSelection = settingsStore.personaHotkeyAppliesToSelection

--- a/Tests/TypefluxTests/HotkeyGestureArbiterTests.swift
+++ b/Tests/TypefluxTests/HotkeyGestureArbiterTests.swift
@@ -10,6 +10,23 @@ final class HotkeyGestureArbiterTests: XCTestCase {
     )
     private let persona = HotkeyBinding.defaultPersona
 
+    func testHistoryHotkeyRequestsHistory() {
+        var arbiter = HotkeyGestureArbiter()
+
+        let events = arbiter.handleKeyDown(
+            keyCode: HotkeyBinding.defaultHistory.keyCode,
+            modifierFlags: HotkeyBinding.defaultHistory.modifierFlags,
+            isRepeat: false,
+            activationHotkey: activation,
+            askHotkey: ask,
+            personaHotkey: persona,
+            historyHotkey: HotkeyBinding.defaultHistory,
+        )
+
+        XCTAssertEqual(events, [.historyRequested])
+        XCTAssertEqual(arbiter.phase, .idle)
+    }
+
     func testModifierOnlyActivationBeginsImmediatelyWhileArbitrating() {
         var arbiter = HotkeyGestureArbiter()
 

--- a/Tests/TypefluxTests/SettingsStoreTests.swift
+++ b/Tests/TypefluxTests/SettingsStoreTests.swift
@@ -1,4 +1,5 @@
 @testable import Typeflux
+import AppKit
 import XCTest
 
 final class SettingsStoreTests: XCTestCase {
@@ -833,6 +834,20 @@ extension SettingsStoreTests {
         XCTAssertNotNil(store.askHotkey)
         XCTAssertEqual(store.askHotkey?.keyCode, 32)
         XCTAssertEqual(store.askHotkey?.modifierFlags, 256)
+    }
+
+    func testHistoryHotkeyDefaultIsCommandOptionO() {
+        let defaultHotkey = store.historyHotkey
+        XCTAssertNotNil(defaultHotkey)
+        XCTAssertEqual(defaultHotkey?.keyCode, HotkeyBinding.oKeyCode)
+        XCTAssertEqual(defaultHotkey?.modifierFlags, UInt(NSEvent.ModifierFlags.command.union(.option).rawValue))
+    }
+
+    func testHistoryHotkeyRoundTrip() {
+        let testHotkey = HotkeyBinding(keyCode: 45, modifierFlags: 256)
+        store.historyHotkey = testHotkey
+        XCTAssertEqual(store.historyHotkey?.keyCode, 45)
+        XCTAssertEqual(store.historyHotkey?.modifierFlags, 256)
     }
 
     // MARK: - automaticVocabularyCollectionEnabled

--- a/Tests/TypefluxTests/WorkflowControllerAutomaticVocabularyTests.swift
+++ b/Tests/TypefluxTests/WorkflowControllerAutomaticVocabularyTests.swift
@@ -461,6 +461,7 @@ private final class MockWorkflowHotkeyService: HotkeyService {
     var onAskPressBegan: (() -> Void)?
     var onAskPressEnded: (() -> Void)?
     var onPersonaPickerRequested: (() -> Void)?
+    var onHistoryRequested: (() -> Void)?
     var onError: ((String) -> Void)?
 
     func start() {}

--- a/Tests/TypefluxTests/WorkflowControllerProcessingTests.swift
+++ b/Tests/TypefluxTests/WorkflowControllerProcessingTests.swift
@@ -263,6 +263,86 @@ final class WorkflowControllerProcessingTests: XCTestCase {
         XCTAssertFalse(eventRecorder.snapshot().contains("cue-play"))
     }
 
+    func testHistoryPickerConfirmCopiesAndInsertsSelectedHistory() {
+        let textInjector = MockProcessingTextInjector()
+        let clipboard = MockClipboardService()
+        let historyStore = MockProcessingHistoryStore()
+        let baseDate = Date(timeIntervalSince1970: 1_000)
+        historyStore.save(record: HistoryRecord(date: baseDate, transcriptText: "old result"))
+        historyStore.save(record: HistoryRecord(date: baseDate.addingTimeInterval(10), personaResultText: "new result"))
+
+        let controller = makeWorkflowController(
+            textInjector: textInjector,
+            historyStore: historyStore,
+            clipboard: clipboard,
+        )
+
+        controller.handleHistoryPickerRequested()
+        XCTAssertTrue(controller.isHistoryPickerPresented)
+        XCTAssertEqual(controller.historyPickerItems.map(\.text), ["new result", "old result"])
+
+        controller.confirmHistorySelection()
+
+        XCTAssertFalse(controller.isHistoryPickerPresented)
+        XCTAssertEqual(clipboard.storedText, "new result")
+        XCTAssertEqual(textInjector.insertedTexts, ["new result"])
+        XCTAssertTrue(textInjector.replacedTexts.isEmpty)
+    }
+
+    func testHistoryPickerCopyActionDoesNotInsertText() {
+        let textInjector = MockProcessingTextInjector()
+        let clipboard = MockClipboardService()
+        let historyStore = MockProcessingHistoryStore()
+        historyStore.save(record: HistoryRecord(date: Date(timeIntervalSince1970: 1_000), transcriptText: "copy only"))
+        let controller = makeWorkflowController(
+            textInjector: textInjector,
+            historyStore: historyStore,
+            clipboard: clipboard,
+        )
+
+        controller.handleHistoryPickerRequested()
+        controller.copyHistorySelection(at: 0)
+
+        XCTAssertFalse(controller.isHistoryPickerPresented)
+        XCTAssertEqual(clipboard.storedText, "copy only")
+        XCTAssertTrue(textInjector.insertedTexts.isEmpty)
+        XCTAssertTrue(textInjector.replacedTexts.isEmpty)
+    }
+
+    func testHistoryPickerShowsMostRecentTwentyRecords() {
+        let historyStore = MockProcessingHistoryStore()
+        let baseDate = Date(timeIntervalSince1970: 1_000)
+        for index in 0 ..< 25 {
+            historyStore.save(record: HistoryRecord(
+                date: baseDate.addingTimeInterval(TimeInterval(index)),
+                transcriptText: "result \(index)",
+            ))
+        }
+
+        let controller = makeWorkflowController(historyStore: historyStore)
+
+        controller.handleHistoryPickerRequested()
+
+        XCTAssertEqual(controller.historyPickerItems.count, 20)
+        XCTAssertEqual(controller.historyPickerItems.first?.text, "result 24")
+        XCTAssertEqual(controller.historyPickerItems.last?.text, "result 5")
+    }
+
+    func testHistoryPickerRetryActionStartsRetryFlow() {
+        let historyStore = MockProcessingHistoryStore()
+        historyStore.save(record: HistoryRecord(
+            date: Date(timeIntervalSince1970: 1_000),
+            transcriptText: "retry me",
+        ))
+        let controller = makeWorkflowController(historyStore: historyStore)
+
+        controller.handleHistoryPickerRequested()
+        controller.retryHistorySelection(at: 0)
+
+        XCTAssertFalse(controller.isHistoryPickerPresented)
+        XCTAssertNotNil(controller.processingTask)
+    }
+
     func testConfirmingPersonaSelectionPlaysTipCue() async throws {
         let eventRecorder = ThreadSafeEventRecorder()
         let controller = makeWorkflowController(
@@ -692,6 +772,7 @@ final class WorkflowControllerProcessingTests: XCTestCase {
         sttTranscriber: Transcriber = MockProcessingTranscriber(),
         llmService: LLMService = MockProcessingLLMService(),
         historyStore: HistoryStore = MockProcessingHistoryStore(),
+        clipboard: ClipboardService = MockClipboardService(),
         soundEffectPlayer: SoundEffectPlayer? = nil,
         sleep: @escaping @Sendable (Duration) async -> Void = { _ in },
         configureSettings: ((SettingsStore) -> Void)? = nil,
@@ -725,7 +806,7 @@ final class WorkflowControllerProcessingTests: XCTestCase {
             llmService: llmService,
             llmAgentService: MockProcessingLLMAgentService(),
             textInjector: textInjector,
-            clipboard: MockClipboardService(),
+            clipboard: clipboard,
             historyStore: historyStore,
             agentJobStore: MockProcessingAgentJobStore(),
             agentExecutionRegistry: AgentExecutionRegistry(),
@@ -922,6 +1003,7 @@ private final class MockProcessingHotkeyService: HotkeyService {
     var onAskPressBegan: (() -> Void)?
     var onAskPressEnded: (() -> Void)?
     var onPersonaPickerRequested: (() -> Void)?
+    var onHistoryRequested: (() -> Void)?
     var onError: ((String) -> Void)?
 
     func start() {}


### PR DESCRIPTION
## Summary

- References TYP-86.
- Adds a configurable global History shortcut, defaulting to `Option+Command+O`, with system-level registration so recent history can be opened while Typeflux is hidden or another app is focused.
- Adds a floating recent-history picker showing the latest 20 reusable records, keyboard navigation, copy/insert behavior, right-click actions, and retry transcription from a selected history record.
- Surfaces the shortcut in Settings and onboarding, with localized strings across supported languages.

## How to test

- `swift test --filter TypefluxTests.WorkflowControllerProcessingTests/testHistoryPickerRetryActionStartsRetryFlow --filter TypefluxTests.WorkflowControllerProcessingTests/testHistoryPickerConfirmCopiesAndInsertsSelectedHistory --filter TypefluxTests.WorkflowControllerProcessingTests/testHistoryPickerCopyActionDoesNotInsertText --filter TypefluxTests.LocalizationResourceTests`
- `swift test --filter TypefluxTests.HotkeyGestureArbiterTests/testHistoryHotkeyRequestsHistory --filter TypefluxTests.SettingsStoreTests/testHistoryHotkeyDefaultIsCommandOptionO --filter TypefluxTests.SettingsStoreTests/testHistoryHotkeyRoundTrip --filter TypefluxTests.WorkflowControllerProcessingTests/testHistoryPickerShowsMostRecentTwentyRecords`
- `git diff --check`

## Screenshots

- Not captured in this automated heartbeat. UI changes affect the macOS overlay, Settings shortcut row, and onboarding shortcuts page.

## Review

Please request review from the Architect or another SeniorEngineer per the PR policy.
