### PR TITLE
fix: disable local LLM thinking output

### DIFF
--- a/Sources/Typeflux/LLM/OllamaLLMService.swift
+++ b/Sources/Typeflux/LLM/OllamaLLMService.swift
@@ -214,6 +214,7 @@ final class OllamaLLMService: LLMService {
             "model": model,
             "stream": stream,
             "keep_alive": localModelKeepAlive,
+            "think": thinkingControl(for: model),
             "messages": [
                 ["role": "system", "content": systemPrompt],
                 ["role": "user", "content": userPrompt],
@@ -222,6 +223,15 @@ final class OllamaLLMService: LLMService {
                 "temperature": temperature,
             ],
         ]
+    }
+
+    private static func thinkingControl(for model: String) -> Any {
+        let normalizedModel = model.lowercased()
+        if normalizedModel.contains("gpt-oss") {
+            return "low"
+        }
+
+        return false
     }
 }
 

--- a/Sources/Typeflux/LLM/OpenAICompatibleResponseSupport.swift
+++ b/Sources/Typeflux/LLM/OpenAICompatibleResponseSupport.swift
@@ -104,6 +104,9 @@ enum OpenAICompatibleResponseSupport {
             body["include_reasoning"] = false
         } else if let effort = reasoningEffort(baseURL: baseURL, model: model) {
             body["reasoning"] = ["effort": effort]
+            if isLocalEndpoint(baseURL) {
+                body["reasoning_effort"] = effort
+            }
         }
     }
 
@@ -204,6 +207,7 @@ enum OpenAICompatibleResponseSupport {
             "mimo",
         ]
         return disabledHosts.contains(where: { host.contains($0) })
+            || isLocalEndpoint(baseURL)
             || disabledModelKeywords.contains(where: { normalizedModel.contains($0) })
     }
 
@@ -245,6 +249,10 @@ enum OpenAICompatibleResponseSupport {
             return "none"
         }
 
+        if isLocalEndpoint(baseURL) {
+            return "none"
+        }
+
         if host == "api.openai.com" || host.hasSuffix(".openai.com"),
            normalizedModel.hasPrefix("gpt-5"),
            !normalizedModel.contains("pro")
@@ -261,6 +269,29 @@ enum OpenAICompatibleResponseSupport {
         }
 
         return nil
+    }
+
+    private static func isLocalEndpoint(_ baseURL: URL) -> Bool {
+        guard let host = baseURL.host?.lowercased() else { return false }
+
+        if host == "localhost" || host == "127.0.0.1" || host == "::1" {
+            return true
+        }
+
+        if host.hasPrefix("10.") || host.hasPrefix("192.168.") {
+            return true
+        }
+
+        let parts = host.split(separator: ".")
+        if parts.count == 4,
+           parts[0] == "172",
+           let second = Int(parts[1]),
+           (16 ... 31).contains(second)
+        {
+            return true
+        }
+
+        return false
     }
 
     private static func extractText(from value: Any?) -> String? {

--- a/Tests/TypefluxTests/LLMServiceTests.swift
+++ b/Tests/TypefluxTests/LLMServiceTests.swift
@@ -126,9 +126,22 @@ final class LLMServiceTests: XCTestCase {
         )
 
         XCTAssertEqual(body["keep_alive"] as? String, "30m")
+        XCTAssertEqual(body["think"] as? Bool, false)
         XCTAssertEqual(body["model"] as? String, "llama3")
         XCTAssertEqual(body["stream"] as? Bool, true)
         let options = try XCTUnwrap(body["options"] as? [String: Any])
         XCTAssertEqual(options["temperature"] as? Double, 0.4)
+    }
+
+    func testOllamaChatRequestUsesLowThinkingForGPTOSSModels() {
+        let body = OllamaLLMService.makeChatRequestBody(
+            model: "gpt-oss:20b",
+            systemPrompt: "system",
+            userPrompt: "user",
+            stream: true,
+            temperature: 0.4,
+        )
+
+        XCTAssertEqual(body["think"] as? String, "low")
     }
 }

--- a/Tests/TypefluxTests/OpenAICompatibleResponseSupportTests.swift
+++ b/Tests/TypefluxTests/OpenAICompatibleResponseSupportTests.swift
@@ -87,6 +87,37 @@ final class OpenAICompatibleResponseSupportTests: XCTestCase {
         XCTAssertEqual(body["include_reasoning"] as? Bool, false)
     }
 
+    func testProviderTuningDisablesReasoningForLocalOpenAICompatibleEndpoint() throws {
+        var body: [String: Any] = ["model": "qwen3:8b"]
+        try OpenAICompatibleResponseSupport.applyProviderTuning(
+            body: &body,
+            baseURL: XCTUnwrap(URL(string: "http://127.0.0.1:11434/v1")),
+            model: "qwen3:8b",
+        )
+
+        XCTAssertEqual(body["enable_thinking"] as? Bool, false)
+        XCTAssertEqual(body["reasoning_effort"] as? String, "none")
+        XCTAssertEqual(
+            (body["reasoning"] as? [String: String])?["effort"],
+            "none",
+        )
+    }
+
+    func testProviderTuningDisablesReasoningForPrivateNetworkOpenAICompatibleEndpoint() throws {
+        var body: [String: Any] = ["model": "local-reasoning-model"]
+        try OpenAICompatibleResponseSupport.applyProviderTuning(
+            body: &body,
+            baseURL: XCTUnwrap(URL(string: "http://192.168.1.10:8000/v1")),
+            model: "local-reasoning-model",
+        )
+
+        XCTAssertEqual(body["reasoning_effort"] as? String, "none")
+        XCTAssertEqual(
+            (body["reasoning"] as? [String: String])?["effort"],
+            "none",
+        )
+    }
+
     func testProviderTuningUsesLowestOpenAIReasoningEffort() throws {
         var modernBody: [String: Any] = ["model": "gpt-5.4"]
         try OpenAICompatibleResponseSupport.applyProviderTuning(


### PR DESCRIPTION
## Summary
- References TYP-88.
- Sends native Ollama `think` controls so thinking-capable local models avoid verbose reasoning output; GPT-OSS uses the lowest supported setting.
- Treats localhost/private-network OpenAI-compatible endpoints as local LLMs and sends reasoning disable controls (`reasoning`, `reasoning_effort`, and existing Qwen toggle where applicable).
- Adds focused tests for Ollama request bodies and local OpenAI-compatible provider tuning.

## How to test
- `swift test --filter TypefluxTests.OpenAICompatibleResponseSupportTests --filter TypefluxTests.LLMServiceTests`

## Screenshots
- Not applicable; no UI changes.

## Review
- Please request Code Review from Architect or another SeniorEngineer.