### PR TITLE
fix: TYP-94 onboarding model setup flow

### DIFF
--- a/Sources/Typeflux/App/AppCoordinator.swift
+++ b/Sources/Typeflux/App/AppCoordinator.swift
@@ -49,6 +49,8 @@ final class AppCoordinator {
                 openAIBackendFactory: { OpenAIRealtimePreviewBackend(settingsStore: settingsStore) },
                 appleBackendFactory: { AppleSpeechPreviewBackend() },
             ),
+            localModelManager: localModelManager,
+            notificationService: di.notificationService,
         )
         self.workflowController = workflowController
 
@@ -100,7 +102,11 @@ final class AppCoordinator {
     private func presentOnboarding() {
         let controller = OnboardingWindowController()
         onboardingWindowController = controller
-        controller.show(settingsStore: di.settingsStore) { [weak self] in
+        controller.show(
+            settingsStore: di.settingsStore,
+            localModelManager: di.localModelManager,
+            notificationService: di.notificationService,
+        ) { [weak self] in
             self?.onboardingWindowController = nil
             self?.presentPermissionGuidanceIfNeeded()
         }

--- a/Sources/Typeflux/App/StatusBarController.swift
+++ b/Sources/Typeflux/App/StatusBarController.swift
@@ -628,9 +628,15 @@ enum StatusBarMenuSupport {
     private static let titleTextLimit = 42
 
     static func localModelDownloadTitle(for status: LocalModelDownloadProgressStatus) -> String? {
-        guard case .downloading(let model, let progress) = status else { return nil }
-        let percent = Int((progress * 100).rounded())
-        return L("menu.downloadingLocalModelNamed", model.displayName, percent)
+        switch status {
+        case .idle:
+            return nil
+        case .downloading(let model, let progress):
+            let percent = Int((progress * 100).rounded())
+            return L("menu.downloadingLocalModelNamed", model.displayName, percent)
+        case .failed(let model, _):
+            return L("menu.localModelDownloadFailedNamed", model.displayName)
+        }
     }
 
     static func recentTranscriptionRecords(from records: [HistoryRecord], limit: Int = 10) -> [HistoryRecord] {

--- a/Sources/Typeflux/Onboarding/OnboardingView.swift
+++ b/Sources/Typeflux/Onboarding/OnboardingView.swift
@@ -66,6 +66,25 @@ struct OnboardingView: View {
         } message: {
             Text(shortcutReplacementAppliedAlertMessage)
         }
+        .alert(
+            L("onboarding.sttConfig.incompleteAlert.title"),
+            isPresented: $viewModel.showIncompleteSTTConfigurationAlert,
+        ) {
+            Button(L("common.ok"), role: .cancel) {}
+        } message: {
+            Text(L("onboarding.sttConfig.incompleteAlert.message"))
+        }
+        .alert(
+            L("onboarding.llmConfig.incompleteAlert.title"),
+            isPresented: $viewModel.showIncompleteLLMConfigurationAlert,
+        ) {
+            Button(L("onboarding.llmConfig.incompleteAlert.skip"), role: .cancel) {
+                viewModel.skipIncompleteLLMConfiguration()
+            }
+            Button(L("onboarding.llmConfig.incompleteAlert.continueConfig")) {}
+        } message: {
+            Text(L("onboarding.llmConfig.incompleteAlert.message"))
+        }
         .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
             if viewModel.currentStep == .permissions {
                 viewModel.refreshPermissions()
@@ -587,7 +606,7 @@ struct OnboardingView: View {
                 let isSelected = viewModel.localSTTModel == model
 
                 Button {
-                    viewModel.localSTTModel = model
+                    viewModel.selectLocalSTTModel(model)
                 } label: {
                     HStack(spacing: 14) {
                         languageSelectionIndicator(isSelected: isSelected)
@@ -1920,7 +1939,10 @@ struct OnboardingView: View {
             Spacer()
 
             if viewModel.currentStep == .account {
-                footerTertiaryButton(title: L("onboarding.account.skip")) {
+                footerTertiaryButton(
+                    title: L("onboarding.account.skip"),
+                    foregroundColor: onboardingAccountSkipText,
+                ) {
                     viewModel.continueWithoutCloudAccount()
                 }
             } else if viewModel.isSkippable {
@@ -2002,12 +2024,16 @@ struct OnboardingView: View {
         .buttonStyle(StudioInteractiveButtonStyle())
     }
 
-    private func footerTertiaryButton(title: String, action: @escaping () -> Void) -> some View {
+    private func footerTertiaryButton(
+        title: String,
+        foregroundColor: Color? = nil,
+        action: @escaping () -> Void,
+    ) -> some View {
         Button(action: action) {
             Text(title.uppercased())
                 .font(.studioBody(11, weight: .bold))
                 .tracking(1.0)
-                .foregroundStyle(onboardingSecondaryText)
+                .foregroundStyle(foregroundColor ?? onboardingSecondaryText)
                 .frame(height: 38)
                 .padding(.horizontal, 10)
         }
@@ -2160,6 +2186,10 @@ struct OnboardingView: View {
 
     private var onboardingTertiaryText: Color {
         StudioTheme.textTertiary.opacity(isDarkMode ? 0.94 : 0.98)
+    }
+
+    private var onboardingAccountSkipText: Color {
+        StudioTheme.textTertiary.opacity(isDarkMode ? 0.56 : 0.62)
     }
 
     private var onboardingCardSurface: Color {

--- a/Sources/Typeflux/Onboarding/OnboardingViewModel.swift
+++ b/Sources/Typeflux/Onboarding/OnboardingViewModel.swift
@@ -92,6 +92,8 @@ final class OnboardingViewModel: ObservableObject {
     @Published var permissions: [PrivacyGuard.PermissionSnapshot] = []
     @Published var requestingPermissions: Set<PrivacyGuard.PermissionID> = []
     @Published var showIncompletePermissionsAlert = false
+    @Published var showIncompleteSTTConfigurationAlert = false
+    @Published var showIncompleteLLMConfigurationAlert = false
 
     // Globe key (🌐) macOS keyboard setting
     @Published var isGlobeKeyReady: Bool = true
@@ -103,19 +105,27 @@ final class OnboardingViewModel: ObservableObject {
     private let settingsStore: SettingsStore
     private let authState: AuthState
     private let globeKeyReader: GlobeKeyPreferenceReading
+    private let localModelManager: (any LocalSTTModelManaging)?
+    private let notificationService: LocalNotificationSending
     let onComplete: () -> Void
     private var cloudAccountModelDefaultsObserver: NSObjectProtocol?
+    private var localSTTPreparationTask: Task<Void, Never>?
+    private var localSTTPreparationModel: LocalSTTModel?
 
     init(
         settingsStore: SettingsStore,
         authState: AuthState? = nil,
         globeKeyReader: GlobeKeyPreferenceReading = SystemGlobeKeyPreferenceReader(),
+        localModelManager: (any LocalSTTModelManaging)? = nil,
+        notificationService: LocalNotificationSending = NoopLocalNotificationService(),
         onComplete: @escaping () -> Void
     ) {
         self.settingsStore = settingsStore
         let resolvedAuthState = authState ?? .shared
         self.authState = resolvedAuthState
         self.globeKeyReader = globeKeyReader
+        self.localModelManager = localModelManager
+        self.notificationService = notificationService
         self.onComplete = onComplete
         let initialUseCloudAccountModels = resolvedAuthState.isLoggedIn
             && settingsStore.sttProvider == .typefluxOfficial
@@ -192,6 +202,7 @@ final class OnboardingViewModel: ObservableObject {
         if let cloudAccountModelDefaultsObserver {
             NotificationCenter.default.removeObserver(cloudAccountModelDefaultsObserver)
         }
+        localSTTPreparationTask?.cancel()
     }
 
     var canGoBack: Bool {
@@ -214,10 +225,49 @@ final class OnboardingViewModel: ObservableObject {
 
     var isSkippable: Bool {
         switch currentStep {
-        case .language, .stt, .llm, .permissions:
+        case .language, .permissions:
             true
-        case .account, .shortcuts:
+        case .account, .stt, .llm, .shortcuts:
             false
+        }
+    }
+
+    var isSTTConfigurationComplete: Bool {
+        switch sttProvider {
+        case .localModel, .appleSpeech, .typefluxOfficial:
+            true
+        case .freeModel:
+            hasText(freeSTTModel)
+        case .whisperAPI:
+            hasText(whisperBaseURL) && hasText(whisperAPIKey) && hasText(whisperModel)
+        case .multimodalLLM:
+            hasText(multimodalLLMBaseURL) && hasText(multimodalLLMAPIKey) && hasText(multimodalLLMModel)
+        case .aliCloud:
+            hasText(aliCloudAPIKey)
+        case .doubaoRealtime:
+            hasText(doubaoAppID) && hasText(doubaoAccessToken) && hasText(doubaoResourceID)
+        case .googleCloud:
+            hasText(googleCloudProjectID) && hasText(googleCloudModel)
+        case .groq:
+            hasText(groqSTTAPIKey) && hasText(groqSTTModel)
+        }
+    }
+
+    var isLLMConfigurationComplete: Bool {
+        switch llmProvider {
+        case .ollama:
+            hasText(ollamaBaseURL) && hasText(ollamaModel)
+        case .openAICompatible:
+            switch llmRemoteProvider {
+            case .typefluxCloud:
+                authState.isLoggedIn
+            case .freeModel:
+                hasText(llmModel)
+            case .custom:
+                hasText(llmBaseURL) && hasText(llmModel)
+            default:
+                hasText(llmBaseURL) && hasText(llmModel) && hasText(llmAPIKey)
+            }
         }
     }
 
@@ -238,21 +288,29 @@ final class OnboardingViewModel: ObservableObject {
     }
 
     func advance() {
+        if currentStep == .stt && !isSTTConfigurationComplete {
+            showIncompleteSTTConfigurationAlert = true
+            return
+        }
+        if currentStep == .stt {
+            showIncompleteSTTConfigurationAlert = false
+        }
+
+        if currentStep == .llm && !isLLMConfigurationComplete {
+            showIncompleteLLMConfigurationAlert = true
+            return
+        }
+        if currentStep == .llm {
+            showIncompleteLLMConfigurationAlert = false
+        }
+
         if currentStep == .permissions && !allRequiredPermissionsGranted {
             showIncompletePermissionsAlert = true
             return
         }
 
         saveCurrentStepSettings()
-        if isLastStep {
-            complete()
-        } else {
-            let nextStep = adjacentStep(offset: 1) ?? (visibleSteps.last ?? .shortcuts)
-            stepDirection = 1
-            withAnimation(.easeInOut(duration: 0.22)) {
-                currentStep = nextStep
-            }
-        }
+        advanceToNextStepOrComplete()
     }
 
     func skip() {
@@ -285,6 +343,13 @@ final class OnboardingViewModel: ObservableObject {
         advance()
     }
 
+    func skipIncompleteLLMConfiguration() {
+        guard currentStep == .llm else { return }
+        showIncompleteLLMConfigurationAlert = false
+        saveCurrentStepSettings()
+        advanceToNextStepOrComplete()
+    }
+
     func selectOllama() {
         llmProvider = .ollama
         llmConnectionTestState = .idle
@@ -293,6 +358,15 @@ final class OnboardingViewModel: ObservableObject {
     func selectSTTProvider(_ provider: STTProvider) {
         sttProvider = provider
         sttConnectionTestState = .idle
+        if provider == .localModel {
+            prepareSelectedLocalSTTModelInBackground()
+        }
+    }
+
+    func selectLocalSTTModel(_ model: LocalSTTModel) {
+        localSTTModel = model
+        guard sttProvider == .localModel else { return }
+        prepareSelectedLocalSTTModelInBackground()
     }
 
     func selectLLMRemoteProvider(_ provider: LLMRemoteProvider) {
@@ -543,6 +617,7 @@ final class OnboardingViewModel: ObservableObject {
                 settingsStore.whisperModel = whisperModel
             case .localModel:
                 settingsStore.localSTTModel = localSTTModel
+                applySelectedLocalSTTDefaults()
             case .multimodalLLM:
                 settingsStore.multimodalLLMBaseURL = multimodalLLMBaseURL
                 settingsStore.multimodalLLMAPIKey = multimodalLLMAPIKey
@@ -598,6 +673,91 @@ final class OnboardingViewModel: ObservableObject {
         settingsStore.applyDefaultPersonaIfLLMConfigured()
         settingsStore.isOnboardingCompleted = true
         onComplete()
+    }
+
+    private func advanceToNextStepOrComplete() {
+        if isLastStep {
+            complete()
+        } else {
+            let nextStep = adjacentStep(offset: 1) ?? (visibleSteps.last ?? .shortcuts)
+            stepDirection = 1
+            withAnimation(.easeInOut(duration: 0.22)) {
+                currentStep = nextStep
+            }
+        }
+    }
+
+    private func prepareSelectedLocalSTTModelInBackground() {
+        guard let localModelManager else { return }
+
+        applySelectedLocalSTTDefaults()
+        let targetModel = localSTTModel
+        let configuration = localSTTConfiguration(for: targetModel)
+
+        if localModelManager.isModelAvailable(targetModel) {
+            LocalModelDownloadProgressCenter.shared.clear()
+            return
+        }
+
+        if localSTTPreparationModel == targetModel, localSTTPreparationTask != nil {
+            return
+        }
+
+        localSTTPreparationTask?.cancel()
+        localSTTPreparationModel = targetModel
+        LocalModelDownloadProgressCenter.shared.reportDownloading(model: targetModel, progress: 0.02)
+        localSTTPreparationTask = Task { [weak self, localModelManager, notificationService] in
+            do {
+                try await localModelManager.prepareModel(configuration: configuration) { update in
+                    LocalModelDownloadProgressCenter.shared.reportDownloading(
+                        model: targetModel,
+                        progress: update.progress,
+                    )
+                }
+                guard !Task.isCancelled else { return }
+                LocalModelDownloadProgressCenter.shared.clear()
+                await notificationService.sendLocalNotification(
+                    title: L("notification.localModelReady.title"),
+                    body: L("notification.localModelReady.body"),
+                    identifier: "ai.gulu.app.typeflux.local-model-ready",
+                )
+            } catch {
+                guard !Task.isCancelled else {
+                    LocalModelDownloadProgressCenter.shared.clear()
+                    return
+                }
+                NetworkDebugLogger.logError(context: "Onboarding local STT model download failed", error: error)
+                LocalModelDownloadProgressCenter.shared.reportFailed(
+                    model: targetModel,
+                    message: error.localizedDescription,
+                )
+            }
+            await MainActor.run {
+                guard self?.localSTTPreparationModel == targetModel else { return }
+                self?.localSTTPreparationModel = nil
+                self?.localSTTPreparationTask = nil
+            }
+        }
+    }
+
+    private func applySelectedLocalSTTDefaults() {
+        settingsStore.localSTTModel = localSTTModel
+        settingsStore.localSTTModelIdentifier = localSTTModel.defaultModelIdentifier
+        settingsStore.localSTTDownloadSource = localSTTModel.recommendedDownloadSource
+        settingsStore.localSTTAutoSetup = true
+    }
+
+    private func localSTTConfiguration(for model: LocalSTTModel) -> LocalSTTConfiguration {
+        LocalSTTConfiguration(
+            model: model,
+            modelIdentifier: model.defaultModelIdentifier,
+            downloadSource: model.recommendedDownloadSource,
+            autoSetup: true,
+        )
+    }
+
+    private func hasText(_ value: String) -> Bool {
+        !value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
 
     private func adjacentStep(offset: Int) -> Step? {

--- a/Sources/Typeflux/Onboarding/OnboardingWindowController.swift
+++ b/Sources/Typeflux/Onboarding/OnboardingWindowController.swift
@@ -18,7 +18,12 @@ final class OnboardingWindowController: NSObject {
         NSApp.activate(ignoringOtherApps: true)
     }
 
-    func show(settingsStore: SettingsStore, onComplete: @escaping () -> Void) {
+    func show(
+        settingsStore: SettingsStore,
+        localModelManager: LocalModelManager? = nil,
+        notificationService: LocalNotificationSending = NoopLocalNotificationService(),
+        onComplete: @escaping () -> Void,
+    ) {
         if let window {
             DockVisibilityController.shared.windowDidShow(window)
             window.makeKeyAndOrderFront(nil)
@@ -28,7 +33,11 @@ final class OnboardingWindowController: NSObject {
 
         onCompleteHandler = onComplete
 
-        let viewModel = OnboardingViewModel(settingsStore: settingsStore) { [weak self] in
+        let viewModel = OnboardingViewModel(
+            settingsStore: settingsStore,
+            localModelManager: localModelManager,
+            notificationService: notificationService,
+        ) { [weak self] in
             self?.handleComplete()
         }
 

--- a/Sources/Typeflux/Resources/en.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/en.lproj/Localizable.strings
@@ -125,6 +125,7 @@
 "menu.downloadingUpdate" = "Downloading Update…";
 "menu.installingUpdate" = "Installing Update…";
 "menu.downloadingLocalModelNamed" = "Downloading %@… %d%%";
+"menu.localModelDownloadFailedNamed" = "%@ download failed";
 "menu.quit" = "Quit";
 "menu.status.ready" = "Ready";
 "menu.status.recording" = "Recording in progress…";
@@ -757,6 +758,12 @@
 "settings.models.localSTT.transferProgress" = "%@ downloaded (%@ of %@)";
 "notification.localModelReady.title" = "Typeflux";
 "notification.localModelReady.body" = "Local model is ready.";
+"workflow.localModelDownloadingAlert.title" = "Local speech model is downloading";
+"workflow.localModelDownloadingAlert.message" = "%@ is still downloading and cannot be used yet. Typeflux will send a system notification when it is ready.";
+"workflow.localModelDownloadingAlert.progress" = "Current progress: %d%%";
+"workflow.localModelDownloadingAlert.failedTitle" = "Local speech model download failed";
+"workflow.localModelDownloadingAlert.failedMessage" = "The download failed: %@. You can try again by pressing the shortcut when your network is available.";
+"workflow.localModelDownloadingAlert.failedProgress" = "Download failed";
 "cloud.autoSwitch.title" = "Typeflux Cloud is ready";
 "cloud.autoSwitch.body" = "Voice recognition and AI models are now powered by Typeflux Cloud. You can switch back to your own providers anytime in Settings.";
 "settings.models.redownload" = "Re-download";
@@ -814,8 +821,15 @@
 
 "onboarding.sttProvider.subtitle" = "Choose the engine that converts your voice to text";
 "onboarding.sttConfig.subtitle" = "Configure credentials and preferences";
+"onboarding.sttConfig.incomplete.message" = "Complete the selected speech model configuration before continuing.";
+"onboarding.sttConfig.incompleteAlert.title" = "Speech model not configured";
+"onboarding.sttConfig.incompleteAlert.message" = "Complete the selected speech model configuration before continuing to the next step.";
 "onboarding.llmProvider.subtitle" = "Choose the model that rewrites and refines your dictation";
 "onboarding.llmConfig.subtitle" = "Configure credentials and preferences";
+"onboarding.llmConfig.incompleteAlert.title" = "Language model not configured";
+"onboarding.llmConfig.incompleteAlert.message" = "Voice transcription can still work, but rewriting and polishing features that need a language model will be limited for now.";
+"onboarding.llmConfig.incompleteAlert.continueConfig" = "Continue Setup";
+"onboarding.llmConfig.incompleteAlert.skip" = "Skip";
 
 "onboarding.permissions.title" = "Grant permissions";
 "onboarding.permissions.subtitle" = "Typeflux needs a few system permissions to capture your voice and insert text into other apps.";
@@ -854,7 +868,7 @@
 "onboarding.action.back" = "Previous";
 "onboarding.action.continue" = "Next";
 "onboarding.action.skip" = "Skip";
-"onboarding.account.skip" = "Skip";
+"onboarding.account.skip" = "Skip, I'll configure my own models";
 "onboarding.action.getStarted" = "Get Started";
 
 // MARK: - Agent Framework

--- a/Sources/Typeflux/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/ja.lproj/Localizable.strings
@@ -125,6 +125,7 @@
 "menu.downloadingUpdate" = "アップデートをダウンロード中…";
 "menu.installingUpdate" = "アップデートをインストール中…";
 "menu.downloadingLocalModelNamed" = "%@をダウンロード中… %d%%";
+"menu.localModelDownloadFailedNamed" = "%@のダウンロードに失敗しました";
 "menu.quit" = "やめる";
 "menu.status.ready" = "準備完了";
 "menu.status.recording" = "録音中です…";
@@ -750,6 +751,12 @@
 "settings.models.localSTT.transferProgress" = "%@ ダウンロード済み（%@ / %@）";
 "notification.localModelReady.title" = "Typeflux";
 "notification.localModelReady.body" = "ローカルモデルの準備ができました。";
+"workflow.localModelDownloadingAlert.title" = "ローカル音声モデルをダウンロード中です";
+"workflow.localModelDownloadingAlert.message" = "%@ はまだダウンロード中のため、今は使用できません。準備が完了すると Typeflux がシステム通知でお知らせします。";
+"workflow.localModelDownloadingAlert.progress" = "現在の進捗：%d%%";
+"workflow.localModelDownloadingAlert.failedTitle" = "ローカル音声モデルのダウンロードに失敗しました";
+"workflow.localModelDownloadingAlert.failedMessage" = "ダウンロードに失敗しました：%@。ネットワークが利用できる状態で、もう一度ショートカットを押すと再試行できます。";
+"workflow.localModelDownloadingAlert.failedProgress" = "ダウンロードに失敗しました";
 "cloud.autoSwitch.title" = "Typeflux Cloud が有効になりました";
 "cloud.autoSwitch.body" = "音声認識と AI モデルが Typeflux Cloud に切り替わりました。「設定」からいつでも自分のモデルに戻せます。";
 "settings.models.redownload" = "再ダウンロード";
@@ -807,8 +814,15 @@
 
 "onboarding.sttProvider.subtitle" = "音声をテキストに変換するエンジンを選択してください";
 "onboarding.sttConfig.subtitle" = "資格情報と設定を構成する";
+"onboarding.sttConfig.incomplete.message" = "続行する前に、選択した音声モデルの設定を完了してください。";
+"onboarding.sttConfig.incompleteAlert.title" = "音声モデルの設定が未完了です";
+"onboarding.sttConfig.incompleteAlert.message" = "次のステップに進む前に、選択した音声モデルの設定を完了してください。";
 "onboarding.llmProvider.subtitle" = "ディクテーションを書き直して改良するモデルを選択してください";
 "onboarding.llmConfig.subtitle" = "資格情報と設定を構成する";
+"onboarding.llmConfig.incompleteAlert.title" = "言語モデルの設定が未完了です";
+"onboarding.llmConfig.incompleteAlert.message" = "音声文字起こしは引き続き利用できますが、言語モデルが必要な書き換えや推敲機能は一時的に制限されます。";
+"onboarding.llmConfig.incompleteAlert.continueConfig" = "設定を続ける";
+"onboarding.llmConfig.incompleteAlert.skip" = "スキップ";
 
 "onboarding.permissions.title" = "権限を付与する";
 "onboarding.permissions.subtitle" = "Typeflux では、音声をキャプチャして他のアプリにテキストを挿入するには、いくつかのシステム権限が必要です。";
@@ -847,7 +861,7 @@
 "onboarding.action.back" = "前へ";
 "onboarding.action.continue" = "次へ";
 "onboarding.action.skip" = "スキップ";
-"onboarding.account.skip" = "スキップ";
+"onboarding.account.skip" = "スキップして自分のモデルを設定";
 "onboarding.action.getStarted" = "始めましょう";
 
 // MARK: - Agent Framework

--- a/Sources/Typeflux/Resources/ko.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/ko.lproj/Localizable.strings
@@ -125,6 +125,7 @@
 "menu.downloadingUpdate" = "업데이트 다운로드 중…";
 "menu.installingUpdate" = "업데이트 설치 중…";
 "menu.downloadingLocalModelNamed" = "%@ 다운로드 중… %d%%";
+"menu.localModelDownloadFailedNamed" = "%@ 다운로드 실패";
 "menu.quit" = "종료";
 "menu.status.ready" = "준비";
 "menu.status.recording" = "녹음 진행 중…";
@@ -750,6 +751,12 @@
 "settings.models.localSTT.transferProgress" = "%@ 다운로드됨(%@ / %@)";
 "notification.localModelReady.title" = "Typeflux";
 "notification.localModelReady.body" = "로컬 모델이 준비되었습니다.";
+"workflow.localModelDownloadingAlert.title" = "로컬 음성 모델 다운로드 중";
+"workflow.localModelDownloadingAlert.message" = "%@ 모델은 아직 다운로드 중이어서 사용할 수 없습니다. 준비가 완료되면 Typeflux가 시스템 알림으로 알려드립니다.";
+"workflow.localModelDownloadingAlert.progress" = "현재 진행률: %d%%";
+"workflow.localModelDownloadingAlert.failedTitle" = "로컬 음성 모델 다운로드 실패";
+"workflow.localModelDownloadingAlert.failedMessage" = "다운로드에 실패했습니다: %@. 네트워크가 사용 가능할 때 단축키를 다시 누르면 재시도할 수 있습니다.";
+"workflow.localModelDownloadingAlert.failedProgress" = "다운로드 실패";
 "cloud.autoSwitch.title" = "Typeflux Cloud이(가) 활성화되었습니다";
 "cloud.autoSwitch.body" = "음성 인식과 AI 모델이 Typeflux Cloud로 전환되었습니다. 「설정」에서 언제든지 본인의 모델로 되돌릴 수 있습니다.";
 "settings.models.redownload" = "다시 다운로드";
@@ -807,8 +814,15 @@
 
 "onboarding.sttProvider.subtitle" = "음성을 텍스트로 변환하는 엔진을 선택하세요";
 "onboarding.sttConfig.subtitle" = "자격 증명 및 기본 설정 구성";
+"onboarding.sttConfig.incomplete.message" = "계속하기 전에 선택한 음성 모델 설정을 완료하세요.";
+"onboarding.sttConfig.incompleteAlert.title" = "음성 모델 설정이 완료되지 않았습니다";
+"onboarding.sttConfig.incompleteAlert.message" = "다음 단계로 진행하기 전에 선택한 음성 모델 설정을 완료하세요.";
 "onboarding.llmProvider.subtitle" = "받아쓰기를 다시 작성하고 다듬는 모델을 선택하세요";
 "onboarding.llmConfig.subtitle" = "자격 증명 및 기본 설정 구성";
+"onboarding.llmConfig.incompleteAlert.title" = "언어 모델 설정이 완료되지 않았습니다";
+"onboarding.llmConfig.incompleteAlert.message" = "음성 전사는 계속 사용할 수 있지만, 언어 모델이 필요한 다시 쓰기와 다듬기 기능은 당분간 제한됩니다.";
+"onboarding.llmConfig.incompleteAlert.continueConfig" = "계속 설정";
+"onboarding.llmConfig.incompleteAlert.skip" = "건너뛰기";
 
 "onboarding.permissions.title" = "권한 부여";
 "onboarding.permissions.subtitle" = "Typeflux에 음성을 캡처하고 다른 앱에 텍스트를 삽입하려면 몇 가지 시스템 권한이 필요합니다.";
@@ -847,7 +861,7 @@
 "onboarding.action.back" = "이전";
 "onboarding.action.continue" = "다음";
 "onboarding.action.skip" = "건너뛰기";
-"onboarding.account.skip" = "건너뛰기";
+"onboarding.account.skip" = "건너뛰고 내 모델 설정";
 "onboarding.action.getStarted" = "시작하기";
 
 // MARK: - Agent Framework

--- a/Sources/Typeflux/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/zh-Hans.lproj/Localizable.strings
@@ -125,6 +125,7 @@
 "menu.downloadingUpdate" = "正在下载更新…";
 "menu.installingUpdate" = "正在安装更新…";
 "menu.downloadingLocalModelNamed" = "正在下载 %@… %d%%";
+"menu.localModelDownloadFailedNamed" = "%@ 下载失败";
 "menu.quit" = "退出";
 "menu.status.ready" = "已就绪";
 "menu.status.recording" = "录音中…";
@@ -757,6 +758,12 @@
 "settings.models.localSTT.transferProgress" = "已下载 %@（%@ / %@）";
 "notification.localModelReady.title" = "Typeflux";
 "notification.localModelReady.body" = "本地模型已就绪。";
+"workflow.localModelDownloadingAlert.title" = "本地语音模型正在下载";
+"workflow.localModelDownloadingAlert.message" = "%@ 还在下载中，暂时无法使用。下载完成后，Typeflux 会通过系统通知提醒你。";
+"workflow.localModelDownloadingAlert.progress" = "当前进度：%d%%";
+"workflow.localModelDownloadingAlert.failedTitle" = "本地语音模型下载失败";
+"workflow.localModelDownloadingAlert.failedMessage" = "下载失败：%@。网络恢复后，再次按快捷键即可重新尝试。";
+"workflow.localModelDownloadingAlert.failedProgress" = "下载失败";
 "cloud.autoSwitch.title" = "已启用 Typeflux Cloud";
 "cloud.autoSwitch.body" = "语音识别与 AI 模型已自动切换为 Typeflux Cloud 云端服务，可随时在「设置」中切换回您自己的模型。";
 "settings.models.redownload" = "重新下载";
@@ -814,8 +821,15 @@
 
 "onboarding.sttProvider.subtitle" = "选择将语音转换为文字的引擎";
 "onboarding.sttConfig.subtitle" = "配置凭据与偏好设置";
+"onboarding.sttConfig.incomplete.message" = "请先完成当前语音模型配置，再继续。";
+"onboarding.sttConfig.incompleteAlert.title" = "语音模型尚未配置完成";
+"onboarding.sttConfig.incompleteAlert.message" = "请先完成当前选择的语音模型配置，然后再继续下一步。";
 "onboarding.llmProvider.subtitle" = "选择用于润色和优化你语音内容的模型";
 "onboarding.llmConfig.subtitle" = "配置凭据与偏好设置";
+"onboarding.llmConfig.incompleteAlert.title" = "语言模型还未配置完成";
+"onboarding.llmConfig.incompleteAlert.message" = "语音转写可以继续使用，但润色、改写等需要语言模型的功能会暂时受限。";
+"onboarding.llmConfig.incompleteAlert.continueConfig" = "继续配置";
+"onboarding.llmConfig.incompleteAlert.skip" = "跳过";
 
 "onboarding.permissions.title" = "授予权限";
 "onboarding.permissions.subtitle" = "Typeflux 需要少量系统权限，用于录制语音并将文字输入到其他应用。";
@@ -854,7 +868,7 @@
 "onboarding.action.back" = "上一步";
 "onboarding.action.continue" = "下一步";
 "onboarding.action.skip" = "跳过";
-"onboarding.account.skip" = "跳过";
+"onboarding.account.skip" = "跳过，我要自己配置模型";
 "onboarding.action.getStarted" = "开始使用";
 
 // MARK: - Agent 框架

--- a/Sources/Typeflux/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/zh-Hant.lproj/Localizable.strings
@@ -125,6 +125,7 @@
 "menu.downloadingUpdate" = "正在下載更新…";
 "menu.installingUpdate" = "正在安裝更新…";
 "menu.downloadingLocalModelNamed" = "正在下載 %@… %d%%";
+"menu.localModelDownloadFailedNamed" = "%@ 下載失敗";
 "menu.quit" = "結束";
 "menu.status.ready" = "已就緒";
 "menu.status.recording" = "錄音中…";
@@ -753,6 +754,12 @@
 "settings.models.localSTT.transferProgress" = "已下載 %@（%@ / %@）";
 "notification.localModelReady.title" = "Typeflux";
 "notification.localModelReady.body" = "本地模型已就緒。";
+"workflow.localModelDownloadingAlert.title" = "本地語音模型正在下載";
+"workflow.localModelDownloadingAlert.message" = "%@ 仍在下載中，暫時無法使用。下載完成後，Typeflux 會透過系統通知提醒你。";
+"workflow.localModelDownloadingAlert.progress" = "目前進度：%d%%";
+"workflow.localModelDownloadingAlert.failedTitle" = "本地語音模型下載失敗";
+"workflow.localModelDownloadingAlert.failedMessage" = "下載失敗：%@。網路恢復後，再次按快捷鍵即可重新嘗試。";
+"workflow.localModelDownloadingAlert.failedProgress" = "下載失敗";
 "cloud.autoSwitch.title" = "已啟用 Typeflux Cloud";
 "cloud.autoSwitch.body" = "語音辨識與 AI 模型已自動切換為 Typeflux Cloud 雲端服務，可隨時在「設定」中切換回您自己的模型。";
 "settings.models.redownload" = "重新下載";
@@ -810,8 +817,15 @@
 
 "onboarding.sttProvider.subtitle" = "選擇將語音轉換為文字的引擎";
 "onboarding.sttConfig.subtitle" = "設定憑據與偏好設定";
+"onboarding.sttConfig.incomplete.message" = "請先完成目前語音模型設定，再繼續。";
+"onboarding.sttConfig.incompleteAlert.title" = "語音模型尚未設定完成";
+"onboarding.sttConfig.incompleteAlert.message" = "請先完成目前選擇的語音模型設定，然後再繼續下一步。";
 "onboarding.llmProvider.subtitle" = "選擇用於潤色和優化語音內容的模型";
 "onboarding.llmConfig.subtitle" = "設定憑據與偏好設定";
+"onboarding.llmConfig.incompleteAlert.title" = "語言模型尚未設定完成";
+"onboarding.llmConfig.incompleteAlert.message" = "語音轉寫仍可繼續使用，但潤色、改寫等需要語言模型的功能會暫時受限。";
+"onboarding.llmConfig.incompleteAlert.continueConfig" = "繼續設定";
+"onboarding.llmConfig.incompleteAlert.skip" = "略過";
 
 "onboarding.permissions.title" = "授予權限";
 "onboarding.permissions.subtitle" = "Typeflux 需要少量系統權限，用於錄製語音並將文字輸入其他應用程式。";
@@ -850,7 +864,7 @@
 "onboarding.action.back" = "上一步";
 "onboarding.action.continue" = "下一步";
 "onboarding.action.skip" = "略過";
-"onboarding.account.skip" = "略過";
+"onboarding.account.skip" = "略過，我要自行設定模型";
 "onboarding.action.getStarted" = "開始使用";
 
 // MARK: - Agent 框架

--- a/Sources/Typeflux/STT/AutoModelDownloadService.swift
+++ b/Sources/Typeflux/STT/AutoModelDownloadService.swift
@@ -212,10 +212,16 @@ final class AutoModelDownloadService {
             await notifyLocalModelReady()
 
         } catch {
-            LocalModelDownloadProgressCenter.shared.clear()
-            guard !Task.isCancelled else { return }
+            guard !Task.isCancelled else {
+                LocalModelDownloadProgressCenter.shared.clear()
+                return
+            }
             NetworkDebugLogger.logError(context: "Auto model download failed", error: error)
             setStatus(.failed)
+            LocalModelDownloadProgressCenter.shared.reportFailed(
+                model: config.model,
+                message: error.localizedDescription,
+            )
 
             var failedState = loadState()
             failedState.nextRetryDate = Date().addingTimeInterval(

--- a/Sources/Typeflux/STT/LocalModelDownloadProgressCenter.swift
+++ b/Sources/Typeflux/STT/LocalModelDownloadProgressCenter.swift
@@ -9,6 +9,7 @@ extension Notification.Name {
 enum LocalModelDownloadProgressStatus: Equatable {
     case idle
     case downloading(model: LocalSTTModel, progress: Double)
+    case failed(model: LocalSTTModel, message: String)
 }
 
 final class LocalModelDownloadProgressCenter {
@@ -24,6 +25,10 @@ final class LocalModelDownloadProgressCenter {
     func reportDownloading(model: LocalSTTModel, progress: Double) {
         let clampedProgress = min(max(progress, 0), 1)
         updateStatus(.downloading(model: model, progress: clampedProgress))
+    }
+
+    func reportFailed(model: LocalSTTModel, message: String) {
+        updateStatus(.failed(model: model, message: message))
     }
 
     func clear() {

--- a/Sources/Typeflux/Settings/SettingsViewModel.swift
+++ b/Sources/Typeflux/Settings/SettingsViewModel.swift
@@ -2024,6 +2024,7 @@ final class StudioViewModel: ObservableObject {
                       localSTTPreparationID == preparationID,
                       localSTTFocusedModel == targetModel
                 else {
+                    LocalModelDownloadProgressCenter.shared.clear()
                     return
                 }
 
@@ -2031,7 +2032,10 @@ final class StudioViewModel: ObservableObject {
                 localSTTPreparationDetail = L("settings.models.localSTT.prepareFailed")
                 localSTTTransferDetail = ""
                 isLocalSTTPrepared = false
-                LocalModelDownloadProgressCenter.shared.clear()
+                LocalModelDownloadProgressCenter.shared.reportFailed(
+                    model: targetModel,
+                    message: error.localizedDescription,
+                )
                 showToast(L("settings.models.localSTT.prepareFailed"))
             }
             if localSTTPreparationID == preparationID {

--- a/Sources/Typeflux/Workflow/LocalModelDownloadAlertPresenter.swift
+++ b/Sources/Typeflux/Workflow/LocalModelDownloadAlertPresenter.swift
@@ -1,0 +1,234 @@
+import AppKit
+import SwiftUI
+
+protocol LocalModelDownloadAlertPresenting {
+    @MainActor
+    func showDownloadingAlert(model: LocalSTTModel, progress: Double)
+}
+
+final class SystemLocalModelDownloadAlertPresenter: NSObject, LocalModelDownloadAlertPresenting, NSWindowDelegate, @unchecked Sendable {
+    private var alertWindow: NSPanel?
+    private var alertViewModel: LocalModelDownloadAlertViewModel?
+    private var progressObserver: NSObjectProtocol?
+    private var progressTimer: Timer?
+
+    @MainActor
+    func showDownloadingAlert(model: LocalSTTModel, progress: Double) {
+        if let alertWindow, let alertViewModel {
+            alertViewModel.progress = progress
+            alertWindow.orderFront(nil)
+            return
+        }
+
+        let window = NSPanel(
+            contentRect: NSRect(x: 0, y: 0, width: 440, height: 190),
+            styleMask: [.nonactivatingPanel, .titled, .closable, .fullSizeContentView],
+            backing: .buffered,
+            defer: false,
+        )
+        window.isFloatingPanel = true
+        window.isReleasedWhenClosed = false
+        window.titleVisibility = .hidden
+        window.titlebarAppearsTransparent = true
+        window.isMovableByWindowBackground = true
+        window.hidesOnDeactivate = false
+        window.level = .floating
+        window.standardWindowButton(.closeButton)?.isHidden = true
+        window.standardWindowButton(.miniaturizeButton)?.isHidden = true
+        window.standardWindowButton(.zoomButton)?.isHidden = true
+        window.delegate = self
+
+        let viewModel = LocalModelDownloadAlertViewModel(progress: progress)
+        let contentView = LocalModelDownloadAlertContentView(
+            viewModel: viewModel,
+            title: L("workflow.localModelDownloadingAlert.title"),
+            message: L("workflow.localModelDownloadingAlert.message", model.displayName),
+        ) { [weak self] in
+            self?.closeAlert()
+        }
+        window.contentViewController = NSHostingController(rootView: contentView)
+
+        progressObserver = NotificationCenter.default.addObserver(
+            forName: .localModelDownloadProgressDidChange,
+            object: nil,
+            queue: .main,
+        ) { [weak self, weak viewModel] _ in
+            self?.applyProgressStatus(
+                LocalModelDownloadProgressCenter.shared.status,
+                model: model,
+                viewModel: viewModel,
+            )
+        }
+
+        alertWindow = window
+        alertViewModel = viewModel
+        startProgressTimer(model: model, viewModel: viewModel)
+        centerAlertWindow(window)
+        window.orderFront(nil)
+    }
+
+    @MainActor
+    private func closeAlert() {
+        alertWindow?.close()
+        cleanupAlert()
+    }
+
+    @MainActor
+    func windowWillClose(_ notification: Notification) {
+        cleanupAlert()
+    }
+
+    @MainActor
+    private func cleanupAlert() {
+        if let progressObserver {
+            NotificationCenter.default.removeObserver(progressObserver)
+            self.progressObserver = nil
+        }
+        progressTimer?.invalidate()
+        progressTimer = nil
+        alertWindow?.delegate = nil
+        alertWindow = nil
+        alertViewModel = nil
+    }
+
+    @MainActor
+    private func startProgressTimer(model: LocalSTTModel, viewModel: LocalModelDownloadAlertViewModel) {
+        progressTimer?.invalidate()
+        progressTimer = Timer.scheduledTimer(withTimeInterval: 0.5, repeats: true) { [weak self, weak viewModel] _ in
+            self?.applyProgressStatus(
+                LocalModelDownloadProgressCenter.shared.status,
+                model: model,
+                viewModel: viewModel,
+            )
+        }
+    }
+
+    private func applyProgressStatus(
+        _ status: LocalModelDownloadProgressStatus,
+        model: LocalSTTModel,
+        viewModel: LocalModelDownloadAlertViewModel?,
+    ) {
+        switch status {
+        case .downloading(let currentModel, let currentProgress) where currentModel == model:
+            Task { @MainActor in
+                viewModel?.failureMessage = nil
+                viewModel?.progress = currentProgress
+            }
+        case .failed(let currentModel, let message) where currentModel == model:
+            Task { @MainActor in
+                viewModel?.failureMessage = message
+            }
+        case .idle:
+            Task { @MainActor [weak self] in
+                self?.closeAlert()
+            }
+        default:
+            break
+        }
+    }
+
+    @MainActor
+    private func centerAlertWindow(_ window: NSWindow) {
+        let targetScreen = NSScreen.screens.first { NSMouseInRect(NSEvent.mouseLocation, $0.frame, false) }
+            ?? NSScreen.main
+        guard let visibleFrame = targetScreen?.visibleFrame else {
+            window.center()
+            return
+        }
+
+        let frame = window.frame
+        let origin = NSPoint(
+            x: visibleFrame.midX - frame.width / 2,
+            y: visibleFrame.midY - frame.height / 2,
+        )
+        window.setFrameOrigin(origin)
+    }
+
+}
+
+@MainActor
+private final class LocalModelDownloadAlertViewModel: ObservableObject {
+    @Published var progress: Double
+    @Published var failureMessage: String?
+
+    init(progress: Double) {
+        self.progress = progress
+    }
+}
+
+private struct LocalModelDownloadAlertContentView: View {
+    @ObservedObject var viewModel: LocalModelDownloadAlertViewModel
+    let title: String
+    let message: String
+    let onClose: () -> Void
+
+    var body: some View {
+        VStack(spacing: 0) {
+            VStack(alignment: .leading, spacing: 16) {
+                header
+                progressSection
+            }
+            .padding(.horizontal, 20)
+            .padding(.top, 18)
+            .padding(.bottom, 16)
+
+            Divider()
+
+            HStack {
+                Spacer()
+                Button(L("common.ok"), action: onClose)
+                    .keyboardShortcut(.defaultAction)
+            }
+            .padding(16)
+        }
+        .frame(width: 440)
+    }
+
+    private var header: some View {
+        HStack(alignment: .top, spacing: 16) {
+            Image(systemName: "arrow.down.circle.fill")
+                .font(.system(size: 42, weight: .regular))
+                .foregroundStyle(StudioTheme.accent)
+                .frame(width: 48, height: 48)
+                .accessibilityHidden(true)
+
+            VStack(alignment: .leading, spacing: 6) {
+                Text(viewModel.failureMessage == nil ? title : L("workflow.localModelDownloadingAlert.failedTitle"))
+                    .font(.headline)
+                    .fontWeight(.semibold)
+                    .foregroundStyle(.primary)
+                Text(viewModel.failureMessage == nil ? message : L(
+                    "workflow.localModelDownloadingAlert.failedMessage",
+                    viewModel.failureMessage ?? "",
+                ))
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
+    private var progressSection: some View {
+        VStack(alignment: .trailing, spacing: 6) {
+            ProgressView(value: normalizedProgress)
+                .progressViewStyle(.linear)
+                .frame(maxWidth: .infinity)
+            Text(progressText)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private var normalizedProgress: Double {
+        min(max(viewModel.progress, 0), 1)
+    }
+
+    private var progressText: String {
+        if viewModel.failureMessage != nil {
+            return L("workflow.localModelDownloadingAlert.failedProgress")
+        }
+        let percent = Int((normalizedProgress * 100).rounded())
+        return L("workflow.localModelDownloadingAlert.progress", percent)
+    }
+}

--- a/Sources/Typeflux/Workflow/WorkflowController.swift
+++ b/Sources/Typeflux/Workflow/WorkflowController.swift
@@ -89,6 +89,9 @@ final class WorkflowController {
     let agentClarificationWindowController: AgentClarificationWindowController
     let soundEffectPlayer: SoundEffectPlayer
     let liveTranscriptionPreviewer: (any LiveTranscriptionPreviewing)?
+    let localModelManager: (any LocalSTTModelManaging)?
+    let notificationService: LocalNotificationSending
+    let localModelDownloadAlertPresenter: any LocalModelDownloadAlertPresenting
     let sleep: @Sendable (Duration) async -> Void
 
     var currentSelectedText: String?
@@ -121,6 +124,10 @@ final class WorkflowController {
     var localModelPreheatTask: Task<Void, Never>?
     var lastLocalModelPreheatConfiguration: LocalSTTConfiguration?
     var localModelPreheatObserver: NSObjectProtocol?
+    var localModelPreparationTask: Task<Void, Never>?
+    var localModelPreparationConfiguration: LocalSTTConfiguration?
+    var localModelDownloadAlertTask: Task<Void, Never>?
+    var suppressNextActivationTapAfterLocalModelDownloadAlert = false
     var isPersonaPickerPresented = false
     var personaPickerItems: [PersonaPickerEntry] = []
     var personaPickerSelectedIndex = 0
@@ -166,6 +173,10 @@ final class WorkflowController {
         agentClarificationWindowController: AgentClarificationWindowController,
         soundEffectPlayer: SoundEffectPlayer,
         liveTranscriptionPreviewer: (any LiveTranscriptionPreviewing)? = nil,
+        localModelManager: (any LocalSTTModelManaging)? = nil,
+        notificationService: LocalNotificationSending = NoopLocalNotificationService(),
+        localModelDownloadAlertPresenter: any LocalModelDownloadAlertPresenting =
+            SystemLocalModelDownloadAlertPresenter(),
         sleep: @escaping @Sendable (Duration) async -> Void = { duration in
             try? await Task.sleep(for: duration)
         },
@@ -188,6 +199,9 @@ final class WorkflowController {
         self.agentClarificationWindowController = agentClarificationWindowController
         self.soundEffectPlayer = soundEffectPlayer
         self.liveTranscriptionPreviewer = liveTranscriptionPreviewer
+        self.localModelManager = localModelManager
+        self.notificationService = notificationService
+        self.localModelDownloadAlertPresenter = localModelDownloadAlertPresenter
         self.sleep = sleep
         self.overlayController.setRecordingActionHandlers(
             onCancel: { [weak self] in
@@ -328,6 +342,12 @@ final class WorkflowController {
         localModelPreheatTask?.cancel()
         localModelPreheatTask = nil
         lastLocalModelPreheatConfiguration = nil
+        localModelPreparationTask?.cancel()
+        localModelPreparationTask = nil
+        localModelPreparationConfiguration = nil
+        localModelDownloadAlertTask?.cancel()
+        localModelDownloadAlertTask = nil
+        suppressNextActivationTapAfterLocalModelDownloadAlert = false
         if let obs = localModelPreheatObserver {
             NotificationCenter.default.removeObserver(obs)
             localModelPreheatObserver = nil
@@ -455,6 +475,11 @@ final class WorkflowController {
     }
 
     func handleActivationTap() {
+        if suppressNextActivationTapAfterLocalModelDownloadAlert {
+            suppressNextActivationTapAfterLocalModelDownloadAlert = false
+            RecordingStartupLatencyTrace.shared.mark("workflow.activation_tap_suppressed.local_model_download")
+            return
+        }
         if let suppressActivationTapUntil, Date() < suppressActivationTapUntil {
             self.suppressActivationTapUntil = nil
             RecordingStartupLatencyTrace.shared.mark("workflow.activation_tap_suppressed")
@@ -498,6 +523,13 @@ final class WorkflowController {
             return
         }
 
+        if showSelectedLocalModelDownloadAlertIfNeeded() {
+            if !startLocked {
+                suppressNextActivationTapAfterLocalModelDownloadAlert = true
+            }
+            return
+        }
+
         if !PrivacyGuard.isRunningInAppBundle {
             Task { @MainActor in
                 let msg = L("workflow.devApp.requiredMessage")
@@ -530,6 +562,84 @@ final class WorkflowController {
         pendingRecordingStartID = startID
         Task { [weak self] in
             await self?.beginRecording(intent: intent, startLocked: startLocked, startID: startID)
+        }
+    }
+
+    func showSelectedLocalModelDownloadAlertIfNeeded() -> Bool {
+        guard settingsStore.sttProvider == .localModel else { return false }
+
+        let selectedModel = settingsStore.localSTTModel
+        if case let .downloading(model, progress) = LocalModelDownloadProgressCenter.shared.status,
+           model == selectedModel
+        {
+            showLocalModelDownloadAlert(model: model, progress: progress)
+            return true
+        }
+
+        guard let localModelManager, !localModelManager.isModelAvailable(selectedModel) else {
+            return false
+        }
+
+        let configuration = LocalSTTConfiguration(settingsStore: settingsStore)
+        startSelectedLocalModelDownloadIfNeeded(configuration: configuration)
+        showLocalModelDownloadAlert(model: selectedModel, progress: 0.02)
+        return true
+    }
+
+    private func showLocalModelDownloadAlert(model: LocalSTTModel, progress: Double) {
+        guard localModelDownloadAlertTask == nil else { return }
+        localModelDownloadAlertTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            defer {
+                self.localModelDownloadAlertTask = nil
+            }
+            self.localModelDownloadAlertPresenter.showDownloadingAlert(
+                model: model,
+                progress: progress,
+            )
+        }
+    }
+
+    private func startSelectedLocalModelDownloadIfNeeded(configuration: LocalSTTConfiguration) {
+        guard let localModelManager else { return }
+        if localModelPreparationConfiguration == configuration, localModelPreparationTask != nil {
+            return
+        }
+
+        localModelPreparationTask?.cancel()
+        localModelPreparationConfiguration = configuration
+        LocalModelDownloadProgressCenter.shared.reportDownloading(model: configuration.model, progress: 0.02)
+        localModelPreparationTask = Task { [weak self, localModelManager, notificationService, configuration] in
+            do {
+                try await localModelManager.prepareModel(configuration: configuration) { update in
+                    LocalModelDownloadProgressCenter.shared.reportDownloading(
+                        model: configuration.model,
+                        progress: update.progress,
+                    )
+                }
+                guard !Task.isCancelled else { return }
+                LocalModelDownloadProgressCenter.shared.clear()
+                await notificationService.sendLocalNotification(
+                    title: L("notification.localModelReady.title"),
+                    body: L("notification.localModelReady.body"),
+                    identifier: "ai.gulu.app.typeflux.local-model-ready",
+                )
+            } catch {
+                guard !Task.isCancelled else {
+                    LocalModelDownloadProgressCenter.shared.clear()
+                    return
+                }
+                NetworkDebugLogger.logError(context: "Workflow local STT model download failed", error: error)
+                LocalModelDownloadProgressCenter.shared.reportFailed(
+                    model: configuration.model,
+                    message: error.localizedDescription,
+                )
+            }
+            await MainActor.run { [weak self, configuration] in
+                guard let self, self.localModelPreparationConfiguration == configuration else { return }
+                self.localModelPreparationTask = nil
+                self.localModelPreparationConfiguration = nil
+            }
         }
     }
 

--- a/Tests/TypefluxTests/OnboardingViewModelTests.swift
+++ b/Tests/TypefluxTests/OnboardingViewModelTests.swift
@@ -49,6 +49,17 @@ final class OnboardingViewModelTests: XCTestCase {
     }
 
     @MainActor
+    func testContinueWithoutCloudAccountMovesToManualSetup() {
+        let viewModel = OnboardingViewModel(settingsStore: store, onComplete: {})
+        viewModel.currentStep = .account
+
+        viewModel.continueWithoutCloudAccount()
+
+        XCTAssertFalse(viewModel.useCloudAccountModels)
+        XCTAssertEqual(viewModel.currentStep, .stt)
+    }
+
+    @MainActor
     func testUsingCloudAccountSkipsModelConfigurationSteps() {
         let authState = makeLoggedInAuthState()
         let viewModel = OnboardingViewModel(settingsStore: store, authState: authState, onComplete: {})
@@ -86,6 +97,9 @@ final class OnboardingViewModelTests: XCTestCase {
 
         viewModel.currentStep = .stt
         viewModel.sttProvider = .multimodalLLM
+        viewModel.multimodalLLMBaseURL = "https://api.openai.com/v1"
+        viewModel.multimodalLLMAPIKey = "sk-test"
+        viewModel.multimodalLLMModel = "gpt-4o-mini-transcribe"
 
         viewModel.advance()
         XCTAssertEqual(viewModel.currentStep, .permissions)
@@ -93,6 +107,98 @@ final class OnboardingViewModelTests: XCTestCase {
 
         viewModel.goBack()
         XCTAssertEqual(viewModel.currentStep, .stt)
+    }
+
+    @MainActor
+    func testRemoteSTTConfigurationBlocksAdvanceUntilComplete() {
+        let viewModel = OnboardingViewModel(settingsStore: store, onComplete: {})
+        viewModel.currentStep = .stt
+        viewModel.selectSTTProvider(.whisperAPI)
+        viewModel.whisperBaseURL = "https://api.openai.com/v1"
+        viewModel.whisperModel = "whisper-1"
+        viewModel.whisperAPIKey = ""
+
+        XCTAssertFalse(viewModel.isSTTConfigurationComplete)
+
+        viewModel.advance()
+
+        XCTAssertEqual(viewModel.currentStep, .stt)
+        XCTAssertTrue(viewModel.showIncompleteSTTConfigurationAlert)
+
+        viewModel.whisperAPIKey = "sk-test"
+        viewModel.advance()
+
+        XCTAssertEqual(viewModel.currentStep, .llm)
+        XCTAssertFalse(viewModel.showIncompleteSTTConfigurationAlert)
+    }
+
+    @MainActor
+    func testLocalSTTCanAdvanceWithoutManualCredentialConfiguration() {
+        let viewModel = OnboardingViewModel(settingsStore: store, onComplete: {})
+        viewModel.currentStep = .stt
+        viewModel.selectSTTProvider(.localModel)
+
+        XCTAssertTrue(viewModel.isSTTConfigurationComplete)
+
+        viewModel.advance()
+
+        XCTAssertEqual(viewModel.currentStep, .llm)
+        XCTAssertEqual(store.sttProvider, .localModel)
+    }
+
+    @MainActor
+    func testSelectingLocalSTTStartsBackgroundModelPreparation() async {
+        let modelManager = StubLocalModelManager()
+        let prepared = expectation(description: "local STT model preparation started")
+        modelManager.onPrepare = {
+            prepared.fulfill()
+        }
+        let viewModel = OnboardingViewModel(
+            settingsStore: store,
+            localModelManager: modelManager,
+            onComplete: {},
+        )
+        viewModel.currentStep = .stt
+
+        viewModel.selectSTTProvider(.localModel)
+
+        await fulfillment(of: [prepared], timeout: 1)
+        XCTAssertEqual(modelManager.preparedConfigurations.first?.model, .senseVoiceSmall)
+        XCTAssertEqual(store.localSTTModel, .senseVoiceSmall)
+        XCTAssertTrue(store.localSTTAutoSetup)
+    }
+
+    @MainActor
+    func testIncompleteLLMConfigurationShowsAlertAndStaysOnStep() {
+        let viewModel = OnboardingViewModel(settingsStore: store, onComplete: {})
+        viewModel.currentStep = .llm
+        viewModel.llmProvider = .openAICompatible
+        viewModel.llmRemoteProvider = .openAI
+        viewModel.llmBaseURL = "https://api.openai.com/v1"
+        viewModel.llmModel = "gpt-4o-mini"
+        viewModel.llmAPIKey = ""
+
+        viewModel.advance()
+
+        XCTAssertEqual(viewModel.currentStep, .llm)
+        XCTAssertTrue(viewModel.showIncompleteLLMConfigurationAlert)
+    }
+
+    @MainActor
+    func testSkippingIncompleteLLMConfigurationContinuesToPermissions() {
+        let viewModel = OnboardingViewModel(settingsStore: store, onComplete: {})
+        viewModel.currentStep = .llm
+        viewModel.llmProvider = .openAICompatible
+        viewModel.llmRemoteProvider = .openAI
+        viewModel.llmBaseURL = "https://api.openai.com/v1"
+        viewModel.llmModel = "gpt-4o-mini"
+        viewModel.llmAPIKey = ""
+
+        viewModel.advance()
+        viewModel.skipIncompleteLLMConfiguration()
+
+        XCTAssertEqual(viewModel.currentStep, .permissions)
+        XCTAssertFalse(viewModel.showIncompleteLLMConfigurationAlert)
     }
 
     @MainActor
@@ -272,6 +378,9 @@ final class OnboardingViewModelTests: XCTestCase {
                 }
             }
             viewModel.advance()
+            if viewModel.showIncompleteLLMConfigurationAlert {
+                viewModel.skipIncompleteLLMConfiguration()
+            }
             guardCounter += 1
         }
         XCTAssertTrue(store.isOnboardingCompleted, "Onboarding failed to complete within bounded iterations")
@@ -429,5 +538,53 @@ private final class StubGlobeKeyPreferenceReader: GlobeKeyPreferenceReading {
 
     func currentUsage() -> GlobeKeyUsage? {
         usage
+    }
+}
+
+private final class StubLocalModelManager: LocalSTTModelManaging {
+    var onPrepare: (() -> Void)?
+
+    private let lock = NSLock()
+    private var _preparedConfigurations: [LocalSTTConfiguration] = []
+
+    var preparedConfigurations: [LocalSTTConfiguration] {
+        lock.withLock { _preparedConfigurations }
+    }
+
+    func prepareModel(
+        settingsStore: SettingsStore,
+        onUpdate: (@Sendable (LocalSTTPreparationUpdate) -> Void)?,
+    ) async throws {
+        try await prepareModel(configuration: LocalSTTConfiguration(settingsStore: settingsStore), onUpdate: onUpdate)
+    }
+
+    func prepareModel(
+        configuration: LocalSTTConfiguration,
+        onUpdate: (@Sendable (LocalSTTPreparationUpdate) -> Void)?,
+    ) async throws {
+        lock.withLock {
+            _preparedConfigurations.append(configuration)
+        }
+        onUpdate?(LocalSTTPreparationUpdate(
+            message: "Preparing",
+            progress: 0.5,
+            storagePath: storagePath(for: configuration),
+            source: "Test",
+        ))
+        onPrepare?()
+    }
+
+    func preparedModelInfo(settingsStore _: SettingsStore) -> LocalSTTPreparedModelInfo? {
+        nil
+    }
+
+    func isModelAvailable(_: LocalSTTModel) -> Bool {
+        false
+    }
+
+    func deleteModelFiles(_: LocalSTTModel) throws {}
+
+    func storagePath(for configuration: LocalSTTConfiguration) -> String {
+        "/tmp/\(configuration.model.rawValue)"
     }
 }

--- a/Tests/TypefluxTests/StatusBarMenuSupportTests.swift
+++ b/Tests/TypefluxTests/StatusBarMenuSupportTests.swift
@@ -18,6 +18,14 @@ final class StatusBarMenuSupportTests: XCTestCase {
         XCTAssertNil(StatusBarMenuSupport.localModelDownloadTitle(for: .idle))
     }
 
+    func testLocalModelDownloadTitleIncludesFailureState() {
+        let title = StatusBarMenuSupport.localModelDownloadTitle(
+            for: .failed(model: .senseVoiceSmall, message: "Network unavailable"),
+        )
+
+        XCTAssertEqual(title, L("menu.localModelDownloadFailedNamed", LocalSTTModel.senseVoiceSmall.displayName))
+    }
+
     @MainActor
     func testStatusBarMenuIncludesSettingsItemNearAppearanceControls() throws {
         if ProcessInfo.processInfo.environment["CI"] == "true" {

--- a/Tests/TypefluxTests/WorkflowControllerProcessingTests.swift
+++ b/Tests/TypefluxTests/WorkflowControllerProcessingTests.swift
@@ -686,6 +686,113 @@ final class WorkflowControllerProcessingTests: XCTestCase {
         audioRecorder.releasePendingStop()
     }
 
+    func testPressShowsLocalModelDownloadAlertAndDoesNotRecord() async {
+        LocalModelDownloadProgressCenter.shared.clear()
+        defer { LocalModelDownloadProgressCenter.shared.clear() }
+
+        let audioRecorder = MockProcessingAudioRecorder()
+        let alertPresenter = MockLocalModelDownloadAlertPresenter()
+        let localModelManager = MockWorkflowLocalModelManager()
+        let controller = makeWorkflowController(
+            audioRecorder: audioRecorder,
+            localModelManager: localModelManager,
+            localModelDownloadAlertPresenter: alertPresenter,
+            configureSettings: { settingsStore in
+                settingsStore.sttProvider = .localModel
+                settingsStore.localSTTModel = .senseVoiceSmall
+            },
+        )
+        LocalModelDownloadProgressCenter.shared.reportDownloading(model: .senseVoiceSmall, progress: 0.42)
+
+        controller.handlePressBegan(intent: .dictation, startLocked: false)
+        controller.handlePressBegan(intent: .dictation, startLocked: false)
+        await waitForMainActorWork()
+        controller.handleActivationTap()
+        await waitForMainActorWork()
+
+        XCTAssertEqual(audioRecorder.startCallCount, 0)
+        XCTAssertFalse(controller.isRecording)
+        XCTAssertEqual(alertPresenter.presentedModels, [.senseVoiceSmall])
+        XCTAssertEqual(alertPresenter.presentedProgresses, [0.42])
+
+        controller.handlePressBegan(intent: .dictation, startLocked: false)
+        await waitForMainActorWork()
+
+        XCTAssertEqual(audioRecorder.startCallCount, 0)
+        XCTAssertFalse(controller.isRecording)
+        XCTAssertEqual(alertPresenter.presentedModels, [.senseVoiceSmall, .senseVoiceSmall])
+        XCTAssertEqual(alertPresenter.presentedProgresses, [0.42, 0.42])
+    }
+
+    func testPressStartsLocalModelDownloadWhenSelectedModelIsMissing() async {
+        LocalModelDownloadProgressCenter.shared.clear()
+        defer { LocalModelDownloadProgressCenter.shared.clear() }
+
+        let audioRecorder = MockProcessingAudioRecorder()
+        let alertPresenter = MockLocalModelDownloadAlertPresenter()
+        let localModelManager = MockWorkflowLocalModelManager()
+        let prepared = expectation(description: "selected local model preparation started")
+        localModelManager.onPrepare = {
+            prepared.fulfill()
+        }
+        let controller = makeWorkflowController(
+            audioRecorder: audioRecorder,
+            localModelManager: localModelManager,
+            localModelDownloadAlertPresenter: alertPresenter,
+            configureSettings: { settingsStore in
+                settingsStore.sttProvider = .localModel
+                settingsStore.localSTTModel = .senseVoiceSmall
+            },
+        )
+
+        controller.handlePressBegan(intent: .dictation, startLocked: false)
+        await fulfillment(of: [prepared], timeout: 1)
+        await waitForMainActorWork()
+
+        XCTAssertEqual(audioRecorder.startCallCount, 0)
+        XCTAssertFalse(controller.isRecording)
+        XCTAssertEqual(localModelManager.preparedConfigurations.first?.model, .senseVoiceSmall)
+        XCTAssertEqual(alertPresenter.presentedModels, [.senseVoiceSmall])
+        XCTAssertEqual(alertPresenter.presentedProgresses, [0.02])
+    }
+
+    func testLocalModelDownloadFailureUpdatesProgressCenter() async {
+        LocalModelDownloadProgressCenter.shared.clear()
+        defer { LocalModelDownloadProgressCenter.shared.clear() }
+
+        let localModelManager = MockWorkflowLocalModelManager()
+        localModelManager.prepareError = NSError(
+            domain: "WorkflowControllerProcessingTests",
+            code: 1,
+            userInfo: [NSLocalizedDescriptionKey: "Network unavailable"],
+        )
+        let prepared = expectation(description: "selected local model preparation attempted")
+        localModelManager.onPrepare = {
+            prepared.fulfill()
+        }
+        let controller = makeWorkflowController(
+            localModelManager: localModelManager,
+            configureSettings: { settingsStore in
+                settingsStore.sttProvider = .localModel
+                settingsStore.localSTTModel = .senseVoiceSmall
+            },
+        )
+
+        controller.handlePressBegan(intent: .dictation, startLocked: false)
+        await fulfillment(of: [prepared], timeout: 1)
+
+        for _ in 0..<100 {
+            if case let .failed(model, message) = LocalModelDownloadProgressCenter.shared.status {
+                XCTAssertEqual(model, .senseVoiceSmall)
+                XCTAssertEqual(message, "Network unavailable")
+                return
+            }
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+
+        XCTFail("Expected local model download failure status")
+    }
+
     private func makeWorkflowController(
         textInjector: TextInjector = MockProcessingTextInjector(),
         audioRecorder: AudioRecorder = MockProcessingAudioRecorder(),
@@ -693,6 +800,9 @@ final class WorkflowControllerProcessingTests: XCTestCase {
         llmService: LLMService = MockProcessingLLMService(),
         historyStore: HistoryStore = MockProcessingHistoryStore(),
         soundEffectPlayer: SoundEffectPlayer? = nil,
+        localModelManager: (any LocalSTTModelManaging)? = nil,
+        localModelDownloadAlertPresenter: any LocalModelDownloadAlertPresenting =
+            MockLocalModelDownloadAlertPresenter(),
         sleep: @escaping @Sendable (Duration) async -> Void = { _ in },
         configureSettings: ((SettingsStore) -> Void)? = nil,
     ) -> WorkflowController {
@@ -739,6 +849,8 @@ final class WorkflowControllerProcessingTests: XCTestCase {
                 settingsStore: settingsStore,
             ),
             soundEffectPlayer: soundEffectPlayer ?? SoundEffectPlayer(settingsStore: settingsStore),
+            localModelManager: localModelManager,
+            localModelDownloadAlertPresenter: localModelDownloadAlertPresenter,
             sleep: sleep,
         )
     }
@@ -1227,6 +1339,79 @@ private final class ThreadSafeEventRecorder: @unchecked Sendable {
             }
             try? await Task.sleep(for: .milliseconds(10))
         }
+    }
+}
+
+private final class MockLocalModelDownloadAlertPresenter: LocalModelDownloadAlertPresenting {
+    private(set) var presentedModels: [LocalSTTModel] = []
+    private(set) var presentedProgresses: [Double] = []
+
+    @MainActor
+    func showDownloadingAlert(model: LocalSTTModel, progress: Double) {
+        presentedModels.append(model)
+        presentedProgresses.append(progress)
+    }
+}
+
+private final class MockWorkflowLocalModelManager: LocalSTTModelManaging {
+    var onPrepare: (() -> Void)?
+    var prepareError: Error?
+
+    private let lock = NSLock()
+    private var _availableModels: Set<LocalSTTModel> = []
+    private var _preparedConfigurations: [LocalSTTConfiguration] = []
+
+    var preparedConfigurations: [LocalSTTConfiguration] {
+        lock.withLock { _preparedConfigurations }
+    }
+
+    func prepareModel(
+        settingsStore: SettingsStore,
+        onUpdate: (@Sendable (LocalSTTPreparationUpdate) -> Void)?,
+    ) async throws {
+        try await prepareModel(configuration: LocalSTTConfiguration(settingsStore: settingsStore), onUpdate: onUpdate)
+    }
+
+    func prepareModel(
+        configuration: LocalSTTConfiguration,
+        onUpdate: (@Sendable (LocalSTTPreparationUpdate) -> Void)?,
+    ) async throws {
+        lock.withLock {
+            _preparedConfigurations.append(configuration)
+        }
+        onUpdate?(LocalSTTPreparationUpdate(
+            message: "Preparing",
+            progress: 0.5,
+            storagePath: storagePath(for: configuration),
+            source: "Test",
+        ))
+        onPrepare?()
+        if let prepareError {
+            throw prepareError
+        }
+        let _: Void = lock.withLock {
+            _availableModels.insert(configuration.model)
+        }
+    }
+
+    func preparedModelInfo(settingsStore: SettingsStore) -> LocalSTTPreparedModelInfo? {
+        let configuration = LocalSTTConfiguration(settingsStore: settingsStore)
+        guard isModelAvailable(configuration.model) else { return nil }
+        return LocalSTTPreparedModelInfo(storagePath: storagePath(for: configuration), sourceDisplayName: "Test")
+    }
+
+    func isModelAvailable(_ model: LocalSTTModel) -> Bool {
+        lock.withLock { _availableModels.contains(model) }
+    }
+
+    func deleteModelFiles(_ model: LocalSTTModel) throws {
+        _ = lock.withLock {
+            _availableModels.remove(model)
+        }
+    }
+
+    func storagePath(for configuration: LocalSTTConfiguration) -> String {
+        "/tmp/\(configuration.model.rawValue)"
     }
 }
 


### PR DESCRIPTION
## Summary

References Paperclip issue TYP-94.

- Updates onboarding manual setup flow copy and validation for account, STT, and LLM configuration steps.
- Starts and tracks local speech model downloads from onboarding/settings/runtime paths, including menu bar progress, ready notification, and failure state handling.
- Adds a non-blocking local model download reminder window with app-consistent layout, live progress updates, centered placement, auto-close on completion, and retry behavior after failure.
- Fixes local model preparation cleanup to avoid cross-actor state writes.

## How to test

- `swift test --filter TypefluxTests.OnboardingViewModelTests`
- `swift test --filter TypefluxTests.WorkflowControllerProcessingTests`
- `swift test --filter TypefluxTests.LocalizationResourceTests`
- `swift test --filter TypefluxTests.StatusBarMenuSupportTests`

## Screenshots

Not captured from this CLI session; reviewer should verify the macOS dialog behavior interactively because it depends on app window/menu focus and local model download state.

## Review

Please request review from Architect or another SeniorEngineer before merge.
