### PR TITLE
feat(ax): show copy dialog when plain text insertion fails

### DIFF
--- a/Sources/Typeflux/TextInjection/AXTextInjector+Paste.swift
+++ b/Sources/Typeflux/TextInjection/AXTextInjector+Paste.swift
@@ -308,7 +308,7 @@ extension AXTextInjector {
             return
         }
 
-        guard Self.shouldPerformStrictPasteVerification(
+        guard Self.shouldAttemptPasteVerification(
             replaceSelection: replaceSelection,
             strictFallbackEnabled: strictFallbackEnabled,
         ) else {
@@ -440,9 +440,11 @@ extension AXTextInjector {
             }
         }
 
-        if let reason = after.failureReason,
-           reason == "focused-element-not-editable" || reason == "accessibility-not-trusted"
-        {
+        if let reason = after.failureReason, reason == "accessibility-not-trusted" {
+            return .failure(reason)
+        }
+
+        if let reason = after.failureReason, reason == "focused-element-not-editable" {
             if !replaceSelection, before == nil {
                 return .indeterminate
             }

--- a/Sources/Typeflux/TextInjection/AXTextInjector.swift
+++ b/Sources/Typeflux/TextInjection/AXTextInjector.swift
@@ -326,16 +326,27 @@ final class AXTextInjector: TextInjector {
 
     /// Strict paste verification is scoped to edit-apply (replace selection)
     /// flows, where a silently failed replacement must be surfaced so the user
-    /// can copy the result manually. Plain insertions (voice dictation) cannot
-    /// be reliably verified through AX on apps like WeChat, Warp, Codex,
-    /// terminals, and the Safari address bar — their AXValue does not reflect
-    /// the paste in time, which would produce a false-positive "copy result"
-    /// dialog even when the paste visibly succeeded.
+    /// can copy the result manually.
     static func shouldPerformStrictPasteVerification(
         replaceSelection: Bool,
         strictFallbackEnabled: Bool,
     ) -> Bool {
         strictFallbackEnabled && replaceSelection
+    }
+
+    /// Plain insertions (voice dictation) cannot be reliably verified through
+    /// AX on apps like WeChat, Warp, Codex, terminals, and the Safari address
+    /// bar. We still run fail-open verification so deterministic failures can
+    /// surface the copy dialog, while indeterminate targets keep best-effort
+    /// paste behavior.
+    static func shouldAttemptPasteVerification(
+        replaceSelection: Bool,
+        strictFallbackEnabled: Bool,
+    ) -> Bool {
+        !replaceSelection || shouldPerformStrictPasteVerification(
+            replaceSelection: replaceSelection,
+            strictFallbackEnabled: strictFallbackEnabled,
+        )
     }
 
     static func shouldAllowClipboardSelectionReplacementWithoutAXBaseline(

--- a/Tests/TypefluxTests/AXTextInjectorTests.swift
+++ b/Tests/TypefluxTests/AXTextInjectorTests.swift
@@ -650,6 +650,28 @@ final class AXTextInjectorTests: XCTestCase {
         XCTAssertEqual(result, .failure("focused-element-not-editable"))
     }
 
+    func testEvaluatePasteVerificationFailsForInsertWhenAccessibilityIsNotTrusted() {
+        let after = CurrentInputTextSnapshot(
+            processID: 42,
+            processName: "Notes",
+            role: "AXTextArea",
+            text: nil,
+            isEditable: false,
+            isFocusedTarget: false,
+            failureReason: "accessibility-not-trusted",
+        )
+
+        let result = AXTextInjector.evaluatePasteVerification(
+            insertedText: "hello",
+            replaceSelection: false,
+            targetProcessID: 42,
+            before: nil,
+            after: after,
+        )
+
+        XCTAssertEqual(result, .failure("accessibility-not-trusted"))
+    }
+
     func testShouldActivateTargetBeforePasteReturnsFalseWhenFlagDisabled() {
         let result = AXTextInjector.shouldActivateTargetBeforePaste(
             flagEnabled: false,
@@ -808,6 +830,42 @@ final class AXTextInjectorTests: XCTestCase {
         )
 
         XCTAssertFalse(result)
+    }
+
+    func testShouldAttemptPasteVerificationReturnsTrueForInsertWhenFlagDisabled() {
+        let result = AXTextInjector.shouldAttemptPasteVerification(
+            replaceSelection: false,
+            strictFallbackEnabled: false,
+        )
+
+        XCTAssertTrue(result)
+    }
+
+    func testShouldAttemptPasteVerificationReturnsTrueForInsertWhenFlagEnabled() {
+        let result = AXTextInjector.shouldAttemptPasteVerification(
+            replaceSelection: false,
+            strictFallbackEnabled: true,
+        )
+
+        XCTAssertTrue(result)
+    }
+
+    func testShouldAttemptPasteVerificationReturnsFalseForReplaceWhenFlagDisabled() {
+        let result = AXTextInjector.shouldAttemptPasteVerification(
+            replaceSelection: true,
+            strictFallbackEnabled: false,
+        )
+
+        XCTAssertFalse(result)
+    }
+
+    func testShouldAttemptPasteVerificationReturnsTrueForReplaceWhenFlagEnabled() {
+        let result = AXTextInjector.shouldAttemptPasteVerification(
+            replaceSelection: true,
+            strictFallbackEnabled: true,
+        )
+
+        XCTAssertTrue(result)
     }
 
     func testShouldRestoreCapturedPasteboardReturnsTrueWhenChangeCountMatches() {

--- a/Tests/TypefluxTests/WorkflowControllerProcessingTests.swift
+++ b/Tests/TypefluxTests/WorkflowControllerProcessingTests.swift
@@ -47,6 +47,23 @@ final class WorkflowControllerProcessingTests: XCTestCase {
         XCTAssertTrue(textInjector.insertedTexts.isEmpty)
     }
 
+    func testApplyTextPresentsCopyDialogWhenInsertThrows() {
+        let textInjector = MockProcessingTextInjector(
+            insertError: NSError(
+                domain: "AXTextInjector",
+                code: 2,
+                userInfo: [NSLocalizedDescriptionKey: "Paste insertion could not be verified"],
+            ),
+        )
+        let controller = makeWorkflowController(textInjector: textInjector)
+
+        let outcome = controller.applyText("Manual copy fallback", replace: false)
+
+        XCTAssertEqual(outcome, .presentedInDialog)
+        XCTAssertEqual(controller.lastDialogResultText, "Manual copy fallback")
+        XCTAssertTrue(textInjector.insertedTexts.isEmpty)
+    }
+
     func testHandleDetachedAgentLaunchKeepsProcessingStatusVisible() {
         let controller = makeWorkflowController()
         controller.activeProcessingRecordID = UUID()
@@ -997,13 +1014,19 @@ private final class MockProcessingTextInjector: TextInjector {
     private(set) var replacedTexts: [String] = []
     private let selectionSnapshot: TextSelectionSnapshot
     private let inputSnapshot: CurrentInputTextSnapshot
+    private let insertError: Error?
+    private let replaceError: Error?
 
     init(
         selectionSnapshot: TextSelectionSnapshot = TextSelectionSnapshot(),
         inputSnapshot: CurrentInputTextSnapshot = CurrentInputTextSnapshot(),
+        insertError: Error? = nil,
+        replaceError: Error? = nil,
     ) {
         self.selectionSnapshot = selectionSnapshot
         self.inputSnapshot = inputSnapshot
+        self.insertError = insertError
+        self.replaceError = replaceError
     }
 
     func getSelectionSnapshot() async -> TextSelectionSnapshot {
@@ -1019,10 +1042,16 @@ private final class MockProcessingTextInjector: TextInjector {
     }
 
     func insert(text: String) throws {
+        if let insertError {
+            throw insertError
+        }
         insertedTexts.append(text)
     }
 
     func replaceSelection(text: String) throws {
+        if let replaceError {
+            throw replaceError
+        }
         replacedTexts.append(text)
     }
 }


### PR DESCRIPTION
## Summary

- References TYP-96.
- Plain insertions (voice dictation) now run fail-open paste verification so deterministic failures surface the copy/result dialog instead of silently dropping the text.
- Adds `shouldAttemptPasteVerification` so insert operations are verified while indeterminate targets (WeChat, Warp, terminals, Safari address bar) keep best-effort paste behavior without false-positive dialogs.
- Splits `accessibility-not-trusted` from `focused-element-not-editable` handling so the former always returns a hard failure.
- Adds unit tests for `AXTextInjector` paste verification and `WorkflowController` dialog fallback on insert throws.

## How to test

- `swift test --filter TypefluxTests.AXTextInjectorTests`
- `swift test --filter TypefluxTests.WorkflowControllerProcessingTests`
- `git diff --check`

## Screenshots

- No UI changes; behavior change affects the copy/result dialog shown after a failed text insertion.

## Review

Please request review from the Architect or another SeniorEngineer per the PR policy.