### PR TITLE
fix: use recording preview as fallback when saved audio is silent

### DIFF
--- a/Sources/Typeflux/Workflow/WorkflowController+Processing.swift
+++ b/Sources/Typeflux/Workflow/WorkflowController+Processing.swift
@@ -364,8 +364,10 @@ extension WorkflowController {
             _ = await liveTranscriptionPreviewer?.finish()
             let realtimeTranscriptionSession = activeRealtimeTranscriptionSession
             let realtimeAudioBufferPump = activeRealtimeAudioBufferPump
+            let recordingPreviewText = latestRecordingPreviewText.trimmingCharacters(in: .whitespacesAndNewlines)
             activeRealtimeTranscriptionSession = nil
             activeRealtimeAudioBufferPump = nil
+            latestRecordingPreviewText = ""
             isAudioRecorderStarted = false
             let audioFileReadyAt = Date()
             let recordingIntent = recordingIntent
@@ -404,7 +406,7 @@ extension WorkflowController {
                 return
             }
 
-            if !audioAnalysis.containsAudibleSignal {
+            if !audioAnalysis.containsAudibleSignal, recordingPreviewText.isEmpty {
                 try? FileManager.default.removeItem(at: validatedAudioFile.fileURL)
                 realtimeAudioBufferPump?.cancel()
                 await realtimeTranscriptionSession?.cancel()
@@ -414,6 +416,20 @@ extension WorkflowController {
                     self.overlayController.showNotice(message: L("workflow.transcription.noSpeech"))
                 }
                 return
+            }
+
+            if !audioAnalysis.containsAudibleSignal {
+                NetworkDebugLogger.logMessage(
+                    """
+                    [Audio Analysis] continuing despite low saved-audio signal because recording preview produced text
+                    duration: \(String(format: "%.3f", audioAnalysis.duration))
+                    rmsPowerDB: \(audioAnalysis.rmsPowerDB)
+                    peakPowerDB: \(audioAnalysis.peakPowerDB)
+                    audibleDuration: \(String(format: "%.3f", audioAnalysis.audibleDuration))
+                    audibleFrameRatio: \(audioAnalysis.audibleFrameRatio)
+                    previewLength: \(recordingPreviewText.count)
+                    """,
+                )
             }
 
             await MainActor.run { () -> Void in
@@ -484,6 +500,7 @@ extension WorkflowController {
                     personaPrompt: personaPrompt,
                     recordingIntent: recordingIntent,
                     sessionID: sessionID,
+                    recordingPreviewText: recordingPreviewText,
                 )
                 NetworkDebugLogger.logMessage(
                     "[Ask Timing] process completed in \(Self.formatDurationSince(processingStartedAt))",
@@ -502,6 +519,7 @@ extension WorkflowController {
             await activeRealtimeTranscriptionSession?.cancel()
             activeRealtimeTranscriptionSession = nil
             activeRealtimeAudioBufferPump = nil
+            latestRecordingPreviewText = ""
             isAudioRecorderStarted = false
             let msg = "Processing failed: \(error.localizedDescription)"
             ErrorLogStore.shared.log(msg)
@@ -600,6 +618,7 @@ extension WorkflowController {
         recordingIntent: RecordingIntent,
         sessionID: UUID,
         forceResultDialogOnSuccess: Bool = false,
+        recordingPreviewText: String = "",
     ) async {
         var record = record
         do {
@@ -638,20 +657,21 @@ extension WorkflowController {
                 && inputContext == nil
                 && hasRewritePersona
 
-            let transcribedText: String
+            let rawTranscribedText: String
             var mergedLLMResult: String?
+            let fallbackPreviewText = recordingPreviewText.trimmingCharacters(in: .whitespacesAndNewlines)
 
             let transcriptionStartedAt = Date()
             NetworkDebugLogger.logMessage("[Ask Timing] transcription entered intent=\(recordingIntent.traceName)")
             if let realtimeTranscriptionSession {
                 do {
-                    transcribedText = try await realtimeTranscriptionSession.finish()
+                    rawTranscribedText = try await realtimeTranscriptionSession.finish()
                 } catch {
                     NetworkDebugLogger.logError(
                         context: "Realtime STT session failed; falling back to recorded audio",
                         error: error,
                     )
-                    transcribedText = try await sttRouter.transcribeStream(
+                    rawTranscribedText = try await sttRouter.transcribeStream(
                         audioFile: audioFile,
                         scenario: cloudScenario,
                     ) { _ in }
@@ -664,10 +684,10 @@ extension WorkflowController {
                     cloudScenario: cloudScenario,
                     sessionID: sessionID,
                 )
-                transcribedText = mergedResult.transcript
+                rawTranscribedText = mergedResult.transcript
                 mergedLLMResult = mergedResult.rewritten
             } else {
-                transcribedText = try await sttRouter.transcribeStream(
+                rawTranscribedText = try await sttRouter.transcribeStream(
                     audioFile: audioFile,
                     scenario: cloudScenario,
                 ) { _ in }
@@ -677,6 +697,16 @@ extension WorkflowController {
             )
 
             try ensureProcessingIsActive(sessionID)
+            let normalizedRawTranscript = rawTranscribedText.trimmingCharacters(in: .whitespacesAndNewlines)
+            let transcribedText: String
+            if normalizedRawTranscript.isEmpty, !fallbackPreviewText.isEmpty {
+                transcribedText = fallbackPreviewText
+                NetworkDebugLogger.logMessage(
+                    "[Transcription] using recording preview text because final transcription was empty",
+                )
+            } else {
+                transcribedText = rawTranscribedText
+            }
             pipelineTiming.transcriptionCompletedAt = Date()
             record.pipelineTiming = pipelineTiming
             record.transcriptText = transcribedText

--- a/Sources/Typeflux/Workflow/WorkflowController.swift
+++ b/Sources/Typeflux/Workflow/WorkflowController.swift
@@ -117,6 +117,7 @@ final class WorkflowController {
     var activeProcessingRecordID: UUID?
     var lastRetryableFailureRecord: HistoryRecord?
     var lastDialogResultText: String?
+    var latestRecordingPreviewText = ""
     var shouldPreserveLLMConfigurationNotice = false
     var localModelPreheatTask: Task<Void, Never>?
     var lastLocalModelPreheatConfiguration: LocalSTTConfiguration?
@@ -375,6 +376,7 @@ final class WorkflowController {
         if shouldStopAudioRecorder {
             _ = try? audioRecorder.stop()
         }
+        latestRecordingPreviewText = ""
         activeRealtimeAudioBufferPump?.cancel()
         activeRealtimeAudioBufferPump = nil
         Task {
@@ -413,6 +415,7 @@ final class WorkflowController {
                     guard !trimmed.isEmpty else { return }
                     Task { @MainActor [weak self] in
                         guard let self, self.isRecording else { return }
+                        self.latestRecordingPreviewText = trimmed
                         self.overlayController.updateRecordingPreviewText(trimmed)
                     }
                 }
@@ -740,6 +743,7 @@ final class WorkflowController {
         recordingMode = effectiveStartLocked ? .locked : .holdToTalk
         recordingIntent = effectiveIntent
         lastRetryableFailureRecord = nil
+        latestRecordingPreviewText = ""
         NSLog("[Workflow] Recording started")
 
         Task { @MainActor in
@@ -772,6 +776,7 @@ final class WorkflowController {
                         guard !trimmed.isEmpty else { return }
                         Task { @MainActor [weak self] in
                             guard let self, self.isRecording else { return }
+                            self.latestRecordingPreviewText = trimmed
                             self.overlayController.updateRecordingPreviewText(trimmed)
                         }
                     },

--- a/Tests/TypefluxTests/WorkflowControllerProcessingTests.swift
+++ b/Tests/TypefluxTests/WorkflowControllerProcessingTests.swift
@@ -686,6 +686,80 @@ final class WorkflowControllerProcessingTests: XCTestCase {
         audioRecorder.releasePendingStop()
     }
 
+    func testFinishRecordingContinuesWhenPreviewTextExistsDespiteSilentAudioGate() async throws {
+        let audioURL = try writeSilentTestAudio(duration: 1.0)
+        defer { try? FileManager.default.removeItem(at: audioURL) }
+
+        let textInjector = MockProcessingTextInjector()
+        let audioRecorder = FileReturningAudioRecorder(fileURL: audioURL)
+        let controller = makeWorkflowController(
+            textInjector: textInjector,
+            audioRecorder: audioRecorder,
+            sttTranscriber: MockProcessingTranscriber(transcript: "final transcript"),
+            sleep: { _ in },
+        )
+        controller.latestRecordingPreviewText = "preview transcript"
+        controller.isAudioRecorderStarted = true
+
+        await controller.finishRecordingAndProcess(recordingStoppedAt: Date())
+        await waitUntil {
+            textInjector.insertedTexts == ["final transcript"]
+        }
+
+        XCTAssertEqual(audioRecorder.stopCallCount, 1)
+        XCTAssertEqual(textInjector.insertedTexts, ["final transcript"])
+        XCTAssertTrue(controller.latestRecordingPreviewText.isEmpty)
+    }
+
+    func testFinishRecordingUsesPreviewTextWhenFinalTranscriptionIsEmpty() async throws {
+        let audioURL = try writeSilentTestAudio(duration: 1.0)
+        defer { try? FileManager.default.removeItem(at: audioURL) }
+
+        let textInjector = MockProcessingTextInjector()
+        let historyStore = MockProcessingHistoryStore()
+        let audioRecorder = FileReturningAudioRecorder(fileURL: audioURL)
+        let controller = makeWorkflowController(
+            textInjector: textInjector,
+            audioRecorder: audioRecorder,
+            sttTranscriber: MockProcessingTranscriber(transcript: ""),
+            historyStore: historyStore,
+            sleep: { _ in },
+        )
+        controller.latestRecordingPreviewText = "preview transcript"
+        controller.isAudioRecorderStarted = true
+
+        await controller.finishRecordingAndProcess(recordingStoppedAt: Date())
+        await waitUntil {
+            textInjector.insertedTexts == ["preview transcript"]
+        }
+
+        XCTAssertEqual(audioRecorder.stopCallCount, 1)
+        XCTAssertEqual(textInjector.insertedTexts, ["preview transcript"])
+        XCTAssertEqual(historyStore.list().last?.transcriptText, "preview transcript")
+        XCTAssertTrue(controller.latestRecordingPreviewText.isEmpty)
+    }
+
+    func testFinishRecordingCancelsSilentAudioWhenPreviewTextIsEmpty() async throws {
+        let audioURL = try writeSilentTestAudio(duration: 1.0)
+
+        let textInjector = MockProcessingTextInjector()
+        let audioRecorder = FileReturningAudioRecorder(fileURL: audioURL)
+        let controller = makeWorkflowController(
+            textInjector: textInjector,
+            audioRecorder: audioRecorder,
+            sttTranscriber: MockProcessingTranscriber(transcript: "should not transcribe"),
+            sleep: { _ in },
+        )
+        controller.isAudioRecorderStarted = true
+
+        await controller.finishRecordingAndProcess(recordingStoppedAt: Date())
+        await waitForMainActorWork()
+
+        XCTAssertEqual(audioRecorder.stopCallCount, 1)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: audioURL.path))
+        XCTAssertTrue(textInjector.insertedTexts.isEmpty)
+    }
+
     private func makeWorkflowController(
         textInjector: TextInjector = MockProcessingTextInjector(),
         audioRecorder: AudioRecorder = MockProcessingAudioRecorder(),
@@ -782,6 +856,42 @@ final class WorkflowControllerProcessingTests: XCTestCase {
     private func waitForMainActorWork() async {
         await MainActor.run {}
         try? await Task.sleep(for: .milliseconds(20))
+    }
+
+    private func waitUntil(
+        timeout: TimeInterval = 1,
+        condition: @escaping () -> Bool,
+    ) async {
+        let deadline = Date().addingTimeInterval(timeout)
+        while !condition(), Date() < deadline {
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+    }
+
+    private func writeSilentTestAudio(duration: TimeInterval, sampleRate: Double = 16_000) throws -> URL {
+        guard let format = AVAudioFormat(
+            commonFormat: .pcmFormatFloat32,
+            sampleRate: sampleRate,
+            channels: 1,
+            interleaved: false,
+        ) else {
+            throw NSError(domain: "WorkflowControllerProcessingTests", code: 1)
+        }
+
+        let frameCount = Int(duration * sampleRate)
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+            .appendingPathExtension("wav")
+        let audioFile = try AVAudioFile(forWriting: url, settings: format.settings)
+        guard let buffer = AVAudioPCMBuffer(
+            pcmFormat: format,
+            frameCapacity: AVAudioFrameCount(frameCount),
+        ) else {
+            throw NSError(domain: "WorkflowControllerProcessingTests", code: 2)
+        }
+        buffer.frameLength = AVAudioFrameCount(frameCount)
+        try audioFile.write(from: buffer)
+        return url
     }
 }
 
@@ -974,6 +1084,34 @@ private final class MockProcessingAudioRecorder: AudioRecorder {
         stops += 1
         lock.unlock()
         return AudioFile(fileURL: URL(fileURLWithPath: "/tmp/mock.wav"), duration: 1)
+    }
+}
+
+private final class FileReturningAudioRecorder: AudioRecorder {
+    private let fileURL: URL
+    private let lock = NSLock()
+    private var stops = 0
+
+    init(fileURL: URL) {
+        self.fileURL = fileURL
+    }
+
+    var stopCallCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return stops
+    }
+
+    func start(
+        levelHandler _: @escaping (Float) -> Void,
+        audioBufferHandler _: ((AVAudioPCMBuffer) -> Void)?,
+    ) throws {}
+
+    func stop() throws -> AudioFile {
+        lock.lock()
+        stops += 1
+        lock.unlock()
+        return AudioFile(fileURL: fileURL, duration: 1)
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes an issue where transcription was auto-cancelled when the saved audio file was detected as silent, even though the live transcription preview had already produced text.

## Problem

- During recording, live transcription preview successfully recognized speech and displayed text
- After recording stopped, `AudioContentAnalyzer` analyzed the saved audio file
- In some cases (mic gain differences, encoding issues), the saved audio signal fell below the audible threshold (RMS < -42dB or peak < -35dB)
- The workflow was cancelled with a "no speech detected" notice, and the preview text was lost

## Fix

- Track `latestRecordingPreviewText` during recording
- When audio analysis returns `containsAudibleSignal == false`, check if preview text exists:
  - If preview text is non-empty, continue processing instead of cancelling
  - If final STT returns empty, use the preview text as fallback
- Clear preview text state at all exit points (start, cancel, finish, error)
- Add detailed debug logging for the fallback path

## Tests

3 new regression tests added to `WorkflowControllerProcessingTests`:
- `testFinishRecordingContinuesWhenPreviewTextExistsDespiteSilentAudioGate`
- `testFinishRecordingUsesPreviewTextWhenFinalTranscriptionIsEmpty`
- `testFinishRecordingCancelsSilentAudioWhenPreviewTextIsEmpty`

All 39 tests pass.