### PR TITLE
feat: add subscription billing client integration

### DIFF
--- a/Sources/Typeflux/Auth/AccountView.swift
+++ b/Sources/Typeflux/Auth/AccountView.swift
@@ -1,15 +1,19 @@
 import SwiftUI
+import AppKit
 
 struct AccountView: View {
     @ObservedObject var authState: AuthState
     let onLogout: () -> Void
     @ObservedObject private var localization = AppLocalization.shared
     @State private var passwordChangeFlow = PasswordChangeFlow()
+    @State private var isOpeningBilling = false
+    @State private var billingActionError: String?
 
     var body: some View {
         VStack(alignment: .leading, spacing: StudioTheme.Spacing.pageGroup) {
             if let profile = authState.userProfile {
                 profileCard(profile: profile)
+                subscriptionCard
             } else if authState.isLoading {
                 loadingCard
             } else {
@@ -17,7 +21,11 @@ struct AccountView: View {
             }
         }
         .onAppear {
-            Task { await AuthState.shared.refreshTokenIfNeeded() }
+            Task { await authState.refreshTokenIfNeeded() }
+            authState.refreshSubscriptionIfNeeded()
+        }
+        .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
+            authState.refreshSubscriptionIfNeeded()
         }
         .sheet(
             item: Binding(
@@ -39,6 +47,110 @@ struct AccountView: View {
                     handlePasswordChangeRelogin()
                 }
             }
+        }
+    }
+
+    private var subscriptionCard: some View {
+        StudioCard {
+            VStack(alignment: .leading, spacing: StudioTheme.Spacing.large) {
+                HStack(alignment: .top, spacing: StudioTheme.Spacing.medium) {
+                    VStack(alignment: .leading, spacing: StudioTheme.Spacing.xSmall) {
+                        Text(L("auth.account.subscription"))
+                            .font(.studioDisplay(StudioTheme.Typography.sectionTitle, weight: .bold))
+                            .foregroundStyle(StudioTheme.textPrimary)
+
+                        Text(L(subscriptionPresentation.subtitleKey))
+                            .font(.studioBody(StudioTheme.Typography.body))
+                            .foregroundStyle(StudioTheme.textSecondary)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+
+                    Spacer()
+
+                    if authState.isLoadingSubscription {
+                        ProgressView()
+                            .controlSize(.small)
+                    }
+                }
+
+                HStack(alignment: .top, spacing: StudioTheme.Spacing.medium) {
+                    accountSummaryItem(
+                        label: L("auth.account.subscriptionPlan"),
+                        value: localized(subscriptionPresentation.plan),
+                        systemImage: "creditcard"
+                    )
+
+                    accountSummaryItem(
+                        label: L("auth.account.subscriptionStatus"),
+                        value: localized(subscriptionPresentation.status),
+                        systemImage: "checkmark.seal"
+                    )
+
+                    accountSummaryItem(
+                        label: L("auth.account.subscriptionPeriod"),
+                        value: localized(subscriptionPresentation.period),
+                        systemImage: "calendar.badge.clock"
+                    )
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+                if let error = billingActionError ?? authState.subscriptionError {
+                    Text(error)
+                        .font(.studioBody(StudioTheme.Typography.caption))
+                        .foregroundStyle(StudioTheme.danger)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                HStack(spacing: StudioTheme.Spacing.small) {
+                    Spacer()
+
+                    StudioButton(
+                        title: L("auth.account.refreshSubscription"),
+                        systemImage: "arrow.clockwise",
+                        variant: .secondary,
+                        isDisabled: authState.isLoadingSubscription || isOpeningBilling,
+                        isLoading: authState.isLoadingSubscription
+                    ) {
+                        Task { await authState.refreshSubscription() }
+                    }
+
+                    StudioButton(
+                        title: subscriptionPresentation.billingAction == .manageBilling
+                            ? L("auth.account.manageBilling")
+                            : L("auth.account.subscribe"),
+                        systemImage: "arrow.up.forward.app",
+                        variant: .primary,
+                        isDisabled: isOpeningBilling,
+                        isLoading: isOpeningBilling
+                    ) {
+                        openBillingFlow()
+                    }
+                }
+            }
+        }
+    }
+
+    private var subscriptionPresentation: AccountSubscriptionPresentation {
+        AccountSubscriptionPresentation.make(from: authState.subscription)
+    }
+
+    private func localized(_ value: AccountSubscriptionPresentation.TextValue) -> String {
+        switch value {
+        case .localized(let key):
+            L(key)
+        case .literal(let text):
+            text
+        }
+    }
+
+    private func localized(_ period: AccountSubscriptionPresentation.PeriodValue) -> String {
+        switch period {
+        case .unavailable:
+            L("auth.account.subscriptionPeriodUnavailable")
+        case .endsOn(let dateString):
+            String(format: L("auth.account.subscriptionEndsOn"), formattedDate(dateString))
+        case .renewsOn(let dateString):
+            String(format: L("auth.account.subscriptionRenewsOn"), formattedDate(dateString))
         }
     }
 
@@ -251,6 +363,28 @@ struct AccountView: View {
         authState.logout()
         passwordChangeFlow.dismiss()
         LoginWindowController.shared.show()
+    }
+
+    private func openBillingFlow() {
+        billingActionError = nil
+        isOpeningBilling = true
+
+        Task {
+            do {
+                let url = authState.subscription.hasSubscription
+                    ? try await authState.createBillingPortalSession()
+                    : try await authState.startCheckout()
+                await MainActor.run {
+                    NSWorkspace.shared.open(url)
+                    isOpeningBilling = false
+                }
+            } catch {
+                await MainActor.run {
+                    isOpeningBilling = false
+                    billingActionError = error.localizedDescription
+                }
+            }
+        }
     }
 }
 

--- a/Sources/Typeflux/Auth/AuthState.swift
+++ b/Sources/Typeflux/Auth/AuthState.swift
@@ -26,18 +26,27 @@ final class AuthState: ObservableObject {
     private let saveStoredUserProfile: (UserProfile) -> Void
     private let clearStoredSession: () -> Void
     private let fetchProfile: (String) async throws -> UserProfile
+    private let fetchSubscription: (String) async throws -> BillingSubscriptionSnapshot
+    private let createCheckoutSession: (String, String) async throws -> BillingCheckoutSession
+    private let createPortalSession: (String) async throws -> BillingPortalSession
 
     @Published private(set) var isLoggedIn: Bool = false
     @Published private(set) var userProfile: UserProfile?
     @Published private(set) var isLoading: Bool = false
+    @Published private(set) var subscription: BillingSubscriptionSnapshot = .none
+    @Published private(set) var isLoadingSubscription: Bool = false
+    @Published private(set) var subscriptionError: String?
 
     /// Refresh the access token when it expires within this window (7 days).
     private static let refreshEarlyInterval: TimeInterval = 7 * 24 * 3600
 
     /// Background timer interval: check every hour.
     private static let timerInterval: TimeInterval = 3600
+    private static let checkoutPollingAttempts = 6
+    private static let checkoutPollingInterval: Duration = .seconds(3)
 
     private var refreshTimer: Timer?
+    private var checkoutPollingTask: Task<Void, Never>?
 
     var accessToken: String? {
         guard let stored = loadStoredToken(),
@@ -67,6 +76,15 @@ final class AuthState: ObservableObject {
         fetchProfile: @escaping (String) async throws -> UserProfile = { token in
             try await AuthAPIService.fetchProfile(token: token)
         },
+        fetchSubscription: @escaping (String) async throws -> BillingSubscriptionSnapshot = { token in
+            try await BillingAPIService.fetchSubscription(token: token)
+        },
+        createCheckoutSession: @escaping (String, String) async throws -> BillingCheckoutSession = { token, planCode in
+            try await BillingAPIService.createCheckoutSession(token: token, planCode: planCode)
+        },
+        createPortalSession: @escaping (String) async throws -> BillingPortalSession = { token in
+            try await BillingAPIService.createPortalSession(token: token)
+        },
     ) {
         self.loadStoredToken = loadStoredToken
         self.loadStoredUserProfile = loadStoredUserProfile
@@ -74,6 +92,9 @@ final class AuthState: ObservableObject {
         self.saveStoredUserProfile = saveStoredUserProfile
         self.clearStoredSession = clearStoredSession
         self.fetchProfile = fetchProfile
+        self.fetchSubscription = fetchSubscription
+        self.createCheckoutSession = createCheckoutSession
+        self.createPortalSession = createPortalSession
         restoreSession()
     }
 
@@ -92,9 +113,14 @@ final class AuthState: ObservableObject {
     // MARK: - Login
 
     func handleLoginSuccess(token: String, expiresAt: Int, refreshToken: String? = nil) async {
-        KeychainTokenStore.saveToken(token, expiresAt: expiresAt, refreshToken: refreshToken)
+        if let refreshToken {
+            KeychainTokenStore.saveToken(token, expiresAt: expiresAt, refreshToken: refreshToken)
+        } else {
+            saveStoredToken(token, expiresAt)
+        }
         isLoggedIn = true
         await refreshProfile()
+        await refreshSubscription()
         NotificationCenter.default.post(name: .authDidLogin, object: self)
     }
 
@@ -109,6 +135,10 @@ final class AuthState: ObservableObject {
         clearStoredSession()
         isLoggedIn = false
         userProfile = nil
+        subscription = .none
+        subscriptionError = nil
+        checkoutPollingTask?.cancel()
+        checkoutPollingTask = nil
         logger.info("User logged out")
     }
 
@@ -166,6 +196,7 @@ final class AuthState: ObservableObject {
             userProfile = profile
             saveStoredUserProfile(profile)
             logger.info("Profile refreshed for \(profile.email)")
+            await refreshSubscription()
             return .authenticated
         } catch let error as AuthError {
             if shouldInvalidateSession(for: error) {
@@ -178,6 +209,75 @@ final class AuthState: ObservableObject {
         } catch {
             logger.error("Failed to refresh profile: \(error.localizedDescription)")
             return .failed
+        }
+    }
+
+    // MARK: - Subscription
+
+    func refreshSubscriptionIfNeeded() {
+        guard isLoggedIn || accessToken != nil else { return }
+        Task { await refreshSubscription() }
+    }
+
+    @discardableResult
+    func refreshSubscription() async -> BillingSubscriptionSnapshot? {
+        guard let token = accessToken else {
+            subscription = .none
+            return nil
+        }
+
+        isLoadingSubscription = true
+        defer { isLoadingSubscription = false }
+
+        do {
+            let snapshot = try await fetchSubscription(token)
+            subscription = snapshot
+            subscriptionError = nil
+            return snapshot
+        } catch let error as AuthError {
+            if shouldInvalidateSession(for: error) {
+                logout()
+            } else {
+                subscriptionError = error.localizedDescription
+            }
+            return nil
+        } catch {
+            subscriptionError = error.localizedDescription
+            return nil
+        }
+    }
+
+    func startCheckout(planCode: String = BillingPlan.defaultPlanCode) async throws -> URL {
+        guard let token = accessToken else {
+            throw AuthError.unauthorized
+        }
+        let session = try await createCheckoutSession(token, planCode)
+        startCheckoutPolling()
+        return session.url
+    }
+
+    func createBillingPortalSession() async throws -> URL {
+        guard let token = accessToken else {
+            throw AuthError.unauthorized
+        }
+        let session = try await createPortalSession(token)
+        return session.url
+    }
+
+    private func startCheckoutPolling() {
+        checkoutPollingTask?.cancel()
+        checkoutPollingTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            for attempt in 0..<Self.checkoutPollingAttempts {
+                if attempt > 0 {
+                    try? await Task.sleep(for: Self.checkoutPollingInterval)
+                }
+                guard !Task.isCancelled else { return }
+                _ = await self.refreshSubscription()
+                if self.subscription.entitled {
+                    return
+                }
+            }
         }
     }
 

--- a/Sources/Typeflux/Auth/BillingAPIService.swift
+++ b/Sources/Typeflux/Auth/BillingAPIService.swift
@@ -1,0 +1,96 @@
+import Foundation
+import os
+
+struct BillingAPIService: Sendable {
+    private static let logger = Logger(subsystem: "ai.gulu.app.typeflux", category: "BillingAPIService")
+
+    private let executor: CloudRequestExecutor
+
+    init(executor: CloudRequestExecutor = CloudRequestExecutor()) {
+        self.executor = executor
+    }
+
+    func fetchSubscription(token: String) async throws -> BillingSubscriptionSnapshot {
+        try await execute(path: "/api/v1/billing/subscription", method: "GET", token: token, body: nil)
+    }
+
+    func createCheckoutSession(token: String, planCode: String) async throws -> BillingCheckoutSession {
+        let body = try encode(BillingCheckoutSessionRequest(planCode: planCode))
+        return try await execute(path: "/api/v1/billing/checkout-session", method: "POST", token: token, body: body)
+    }
+
+    func createPortalSession(token: String) async throws -> BillingPortalSession {
+        try await execute(path: "/api/v1/billing/portal-session", method: "POST", token: token, body: Data("{}".utf8))
+    }
+
+    static func fetchSubscription(token: String) async throws -> BillingSubscriptionSnapshot {
+        try await BillingAPIService().fetchSubscription(token: token)
+    }
+
+    static func createCheckoutSession(token: String, planCode: String) async throws -> BillingCheckoutSession {
+        try await BillingAPIService().createCheckoutSession(token: token, planCode: planCode)
+    }
+
+    static func createPortalSession(token: String) async throws -> BillingPortalSession {
+        try await BillingAPIService().createPortalSession(token: token)
+    }
+
+    private func encode<Body: Encodable>(_ body: Body) throws -> Data {
+        do {
+            return try JSONEncoder().encode(body)
+        } catch {
+            throw AuthError.networkError(error)
+        }
+    }
+
+    private func execute<Response: Decodable>(
+        path: String,
+        method: String,
+        token: String,
+        body: Data?,
+    ) async throws -> Response {
+        let data: Data
+        let httpResponse: HTTPURLResponse
+        do {
+            (data, httpResponse) = try await executor.execute(apiPath: path) { baseURL in
+                let url = AuthEndpointResolver.resolve(baseURL: baseURL, path: path)
+                var request = URLRequest(url: url)
+                request.httpMethod = method
+                request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+                request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+                request.httpBody = body
+                request.timeoutInterval = 30
+                return request
+            }
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch CloudRequestExecutorError.allEndpointsFailed(let lastError) {
+            Self.logger.error("All billing endpoints failed: \(lastError.localizedDescription)")
+            throw AuthError.networkError(lastError)
+        } catch {
+            Self.logger.error("Billing network error: \(error.localizedDescription)")
+            throw AuthError.networkError(error)
+        }
+
+        let envelope: APIResponse<Response>
+        do {
+            envelope = try JSONDecoder().decode(APIResponse<Response>.self, from: data)
+        } catch {
+            Self.logger.error("Billing decoding error: \(error.localizedDescription)")
+            throw AuthError.invalidResponse
+        }
+
+        if httpResponse.statusCode == 401 {
+            throw AuthError.unauthorized
+        }
+
+        guard httpResponse.statusCode >= 200, httpResponse.statusCode < 300,
+              envelope.code == "OK",
+              let responseData = envelope.data
+        else {
+            throw AuthError.serverError(code: envelope.code, message: envelope.message)
+        }
+
+        return responseData
+    }
+}

--- a/Sources/Typeflux/Auth/BillingModels.swift
+++ b/Sources/Typeflux/Auth/BillingModels.swift
@@ -1,0 +1,218 @@
+import Foundation
+
+struct BillingSubscriptionSnapshot: Decodable, Equatable {
+    let planCode: String?
+    let status: String?
+    let currentPeriodStart: String?
+    let currentPeriodEnd: String?
+    let cancelAtPeriodEnd: Bool
+    let entitled: Bool
+
+    enum CodingKeys: String, CodingKey {
+        case planCode = "plan_code"
+        case status
+        case currentPeriodStart = "current_period_start"
+        case currentPeriodEnd = "current_period_end"
+        case cancelAtPeriodEnd = "cancel_at_period_end"
+        case entitled
+        case subscription
+        case entitlement
+    }
+
+    enum EntitlementCodingKeys: String, CodingKey {
+        case entitled
+    }
+
+    init(
+        planCode: String?,
+        status: String?,
+        currentPeriodStart: String?,
+        currentPeriodEnd: String?,
+        cancelAtPeriodEnd: Bool,
+        entitled: Bool
+    ) {
+        self.planCode = planCode
+        self.status = status
+        self.currentPeriodStart = currentPeriodStart
+        self.currentPeriodEnd = currentPeriodEnd
+        self.cancelAtPeriodEnd = cancelAtPeriodEnd
+        self.entitled = entitled
+    }
+
+    init(from decoder: Decoder) throws {
+        let root = try decoder.container(keyedBy: CodingKeys.self)
+        let source = (try? root.nestedContainer(keyedBy: CodingKeys.self, forKey: .subscription)) ?? root
+        let entitlement = try? root.nestedContainer(keyedBy: EntitlementCodingKeys.self, forKey: .entitlement)
+
+        let status = try source.decodeIfPresent(String.self, forKey: .status)
+        let entitled = try entitlement?.decodeIfPresent(Bool.self, forKey: .entitled)
+            ?? root.decodeIfPresent(Bool.self, forKey: .entitled)
+            ?? Self.defaultEntitlement(for: status, periodEnd: try source.decodeIfPresent(String.self, forKey: .currentPeriodEnd))
+
+        self.init(
+            planCode: try source.decodeIfPresent(String.self, forKey: .planCode),
+            status: status,
+            currentPeriodStart: try source.decodeIfPresent(String.self, forKey: .currentPeriodStart),
+            currentPeriodEnd: try source.decodeIfPresent(String.self, forKey: .currentPeriodEnd),
+            cancelAtPeriodEnd: try source.decodeIfPresent(Bool.self, forKey: .cancelAtPeriodEnd) ?? false,
+            entitled: entitled
+        )
+    }
+
+    var hasSubscription: Bool {
+        guard let status, !status.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return false
+        }
+        return true
+    }
+
+    static var none: BillingSubscriptionSnapshot {
+        BillingSubscriptionSnapshot(
+            planCode: nil,
+            status: nil,
+            currentPeriodStart: nil,
+            currentPeriodEnd: nil,
+            cancelAtPeriodEnd: false,
+            entitled: false
+        )
+    }
+
+    private static func defaultEntitlement(for status: String?, periodEnd: String?) -> Bool {
+        guard let status else { return false }
+        let normalized = status.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard normalized == "active" || normalized == "trialing" else { return false }
+        guard let periodEnd, let endDate = ISO8601DateFormatter.typefluxBillingDate(from: periodEnd) else {
+            return true
+        }
+        return endDate > Date()
+    }
+}
+
+struct BillingCheckoutSession: Decodable, Equatable {
+    let sessionID: String?
+    let url: URL
+
+    enum CodingKeys: String, CodingKey {
+        case sessionID = "session_id"
+        case url
+    }
+}
+
+struct BillingPortalSession: Decodable, Equatable {
+    let url: URL
+}
+
+struct BillingCheckoutSessionRequest: Encodable {
+    let planCode: String
+
+    enum CodingKeys: String, CodingKey {
+        case planCode = "plan_code"
+    }
+}
+
+enum BillingPlan {
+    static let defaultPlanCode = "typeflux_cloud_monthly"
+}
+
+struct AccountSubscriptionPresentation: Equatable {
+    enum BillingAction: Equatable {
+        case subscribe
+        case manageBilling
+    }
+
+    enum TextValue: Equatable {
+        case localized(String)
+        case literal(String)
+    }
+
+    enum PeriodValue: Equatable {
+        case unavailable
+        case renewsOn(String)
+        case endsOn(String)
+    }
+
+    let subtitleKey: String
+    let plan: TextValue
+    let status: TextValue
+    let period: PeriodValue
+    let billingAction: BillingAction
+
+    static func make(from snapshot: BillingSubscriptionSnapshot) -> AccountSubscriptionPresentation {
+        AccountSubscriptionPresentation(
+            subtitleKey: subtitleKey(for: snapshot),
+            plan: planValue(for: snapshot),
+            status: statusValue(for: snapshot),
+            period: periodValue(for: snapshot),
+            billingAction: snapshot.hasSubscription ? .manageBilling : .subscribe
+        )
+    }
+
+    private static func subtitleKey(for snapshot: BillingSubscriptionSnapshot) -> String {
+        if snapshot.entitled {
+            return "auth.account.subscriptionActiveHint"
+        }
+        if snapshot.hasSubscription {
+            return "auth.account.subscriptionInactiveHint"
+        }
+        return "auth.account.subscriptionRequiredHint"
+    }
+
+    private static func planValue(for snapshot: BillingSubscriptionSnapshot) -> TextValue {
+        guard let planCode = snapshot.planCode, !planCode.isEmpty else {
+            return .localized("auth.account.subscriptionNoPlan")
+        }
+        if planCode == BillingPlan.defaultPlanCode {
+            return .localized("auth.account.subscriptionDefaultPlan")
+        }
+        return .literal(planCode.replacingOccurrences(of: "_", with: " ").capitalized)
+    }
+
+    private static func statusValue(for snapshot: BillingSubscriptionSnapshot) -> TextValue {
+        guard let status = snapshot.status, !status.isEmpty else {
+            return .localized("auth.account.subscriptionStatusNone")
+        }
+        let normalized = status.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        switch normalized {
+        case "active":
+            return .localized("auth.account.subscriptionStatusActive")
+        case "trialing":
+            return .localized("auth.account.subscriptionStatusTrialing")
+        case "past_due":
+            return .localized("auth.account.subscriptionStatusPastDue")
+        case "canceled", "cancelled":
+            return .localized("auth.account.subscriptionStatusCanceled")
+        case "unpaid":
+            return .localized("auth.account.subscriptionStatusUnpaid")
+        default:
+            return .literal(status.replacingOccurrences(of: "_", with: " ").capitalized)
+        }
+    }
+
+    private static func periodValue(for snapshot: BillingSubscriptionSnapshot) -> PeriodValue {
+        guard let periodEnd = snapshot.currentPeriodEnd else {
+            return .unavailable
+        }
+        if snapshot.cancelAtPeriodEnd {
+            return .endsOn(periodEnd)
+        }
+        return .renewsOn(periodEnd)
+    }
+}
+
+extension ISO8601DateFormatter {
+    static func typefluxBillingDate(from string: String) -> Date? {
+        typefluxBilling.date(from: string) ?? typefluxBillingFallback.date(from: string)
+    }
+
+    static let typefluxBilling: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter
+    }()
+
+    static let typefluxBillingFallback: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter
+    }()
+}

--- a/Sources/Typeflux/Resources/en.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/en.lproj/Localizable.strings
@@ -1040,7 +1040,7 @@
 "cloud.error.validation" = "The request was invalid. Please check the input and try again.";
 "cloud.error.rateLimited" = "Too many requests. Please wait a moment and try again.";
 "cloud.error.quotaExceeded" = "Your Typeflux Cloud usage quota has been exhausted.";
-"cloud.error.planRequired" = "Your current plan does not include this Typeflux Cloud feature.";
+"cloud.error.planRequired" = "Your current plan does not include this Typeflux Cloud feature. Open Account to subscribe or manage billing.";
 "cloud.error.server" = "Typeflux Cloud is temporarily unavailable. Please try again later.";
 
 "auth.account.provider" = "Login Method";
@@ -1061,6 +1061,27 @@
 "auth.account.relogin" = "Sign In Again";
 "auth.account.signedOutTitle" = "Not Signed In";
 "auth.account.signedOutSubtitle" = "Sign in to sync your account and manage your session.";
+"auth.account.subscription" = "Subscription";
+"auth.account.subscriptionPlan" = "Plan";
+"auth.account.subscriptionStatus" = "Status";
+"auth.account.subscriptionPeriod" = "Billing Period";
+"auth.account.subscriptionActiveHint" = "Your Typeflux Cloud subscription is active.";
+"auth.account.subscriptionInactiveHint" = "Your subscription is not currently entitled to Typeflux Cloud features.";
+"auth.account.subscriptionRequiredHint" = "Subscribe to unlock Typeflux Cloud speech recognition and model inference.";
+"auth.account.subscriptionNoPlan" = "No Plan";
+"auth.account.subscriptionDefaultPlan" = "Typeflux Cloud Monthly";
+"auth.account.subscriptionStatusNone" = "Not Subscribed";
+"auth.account.subscriptionStatusActive" = "Active";
+"auth.account.subscriptionStatusTrialing" = "Trial";
+"auth.account.subscriptionStatusPastDue" = "Past Due";
+"auth.account.subscriptionStatusCanceled" = "Canceled";
+"auth.account.subscriptionStatusUnpaid" = "Unpaid";
+"auth.account.subscriptionPeriodUnavailable" = "Not Available";
+"auth.account.subscriptionEndsOn" = "Ends %@";
+"auth.account.subscriptionRenewsOn" = "Renews %@";
+"auth.account.refreshSubscription" = "Refresh";
+"auth.account.subscribe" = "Subscribe";
+"auth.account.manageBilling" = "Manage Billing";
 
 "agent.clarification.windowTitle" = "Agent Clarification";
 "agent.clarification.assistantSectionTitle" = "Assistant";

--- a/Sources/Typeflux/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/ja.lproj/Localizable.strings
@@ -1029,7 +1029,7 @@
 "cloud.error.validation" = "リクエストが無効です。入力内容を確認してもう一度お試しください。";
 "cloud.error.rateLimited" = "リクエストが多すぎます。しばらく待ってからもう一度お試しください。";
 "cloud.error.quotaExceeded" = "Typeflux Cloud の利用枠を使い切りました。";
-"cloud.error.planRequired" = "現在のプランではこの Typeflux Cloud 機能を利用できません。";
+"cloud.error.planRequired" = "現在のプランではこの Typeflux Cloud 機能を利用できません。アカウント画面で購読または請求管理を行ってください。";
 "cloud.error.server" = "Typeflux Cloud は一時的に利用できません。後でもう一度お試しください。";
 
 "auth.account.provider" = "ログイン方法";
@@ -1050,6 +1050,27 @@
 "auth.account.relogin" = "再度サインイン";
 "auth.account.signedOutTitle" = "未サインイン";
 "auth.account.signedOutSubtitle" = "サインインすると、アカウント情報の確認と現在のセッション管理ができます。";
+"auth.account.subscription" = "サブスクリプション";
+"auth.account.subscriptionPlan" = "プラン";
+"auth.account.subscriptionStatus" = "ステータス";
+"auth.account.subscriptionPeriod" = "請求期間";
+"auth.account.subscriptionActiveHint" = "Typeflux Cloud のサブスクリプションは有効です。";
+"auth.account.subscriptionInactiveHint" = "現在のサブスクリプションでは Typeflux Cloud 機能を利用できません。";
+"auth.account.subscriptionRequiredHint" = "購読すると Typeflux Cloud の音声認識とモデル推論を利用できます。";
+"auth.account.subscriptionNoPlan" = "未購読";
+"auth.account.subscriptionDefaultPlan" = "Typeflux Cloud 月額";
+"auth.account.subscriptionStatusNone" = "未購読";
+"auth.account.subscriptionStatusActive" = "有効";
+"auth.account.subscriptionStatusTrialing" = "トライアル";
+"auth.account.subscriptionStatusPastDue" = "支払い遅延";
+"auth.account.subscriptionStatusCanceled" = "キャンセル済み";
+"auth.account.subscriptionStatusUnpaid" = "未払い";
+"auth.account.subscriptionPeriodUnavailable" = "利用不可";
+"auth.account.subscriptionEndsOn" = "%@ に終了";
+"auth.account.subscriptionRenewsOn" = "%@ に更新";
+"auth.account.refreshSubscription" = "更新";
+"auth.account.subscribe" = "購読";
+"auth.account.manageBilling" = "請求管理";
 
 "agent.clarification.windowTitle" = "アシスタントの確認";
 "agent.clarification.assistantSectionTitle" = "アシスタント";

--- a/Sources/Typeflux/Resources/ko.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/ko.lproj/Localizable.strings
@@ -1029,7 +1029,7 @@
 "cloud.error.validation" = "요청이 올바르지 않습니다. 입력을 확인한 뒤 다시 시도해 주세요.";
 "cloud.error.rateLimited" = "요청이 너무 많습니다. 잠시 후 다시 시도해 주세요.";
 "cloud.error.quotaExceeded" = "Typeflux Cloud 사용 한도를 모두 사용했습니다.";
-"cloud.error.planRequired" = "현재 요금제에는 이 Typeflux Cloud 기능이 포함되어 있지 않습니다.";
+"cloud.error.planRequired" = "현재 요금제에는 이 Typeflux Cloud 기능이 포함되어 있지 않습니다. 계정 화면에서 구독하거나 결제를 관리해 주세요.";
 "cloud.error.server" = "Typeflux Cloud를 일시적으로 사용할 수 없습니다. 나중에 다시 시도해 주세요.";
 
 "auth.account.provider" = "로그인 방법";
@@ -1050,6 +1050,27 @@
 "auth.account.relogin" = "다시 로그인";
 "auth.account.signedOutTitle" = "로그인되지 않음";
 "auth.account.signedOutSubtitle" = "로그인하면 계정 정보를 확인하고 현재 세션을 관리할 수 있습니다.";
+"auth.account.subscription" = "구독";
+"auth.account.subscriptionPlan" = "요금제";
+"auth.account.subscriptionStatus" = "상태";
+"auth.account.subscriptionPeriod" = "결제 기간";
+"auth.account.subscriptionActiveHint" = "Typeflux Cloud 구독이 활성화되어 있습니다.";
+"auth.account.subscriptionInactiveHint" = "현재 구독으로는 Typeflux Cloud 기능을 사용할 수 없습니다.";
+"auth.account.subscriptionRequiredHint" = "구독하면 Typeflux Cloud 음성 인식과 모델 추론을 사용할 수 있습니다.";
+"auth.account.subscriptionNoPlan" = "구독 없음";
+"auth.account.subscriptionDefaultPlan" = "Typeflux Cloud 월간";
+"auth.account.subscriptionStatusNone" = "구독 없음";
+"auth.account.subscriptionStatusActive" = "활성";
+"auth.account.subscriptionStatusTrialing" = "체험";
+"auth.account.subscriptionStatusPastDue" = "연체";
+"auth.account.subscriptionStatusCanceled" = "취소됨";
+"auth.account.subscriptionStatusUnpaid" = "미결제";
+"auth.account.subscriptionPeriodUnavailable" = "사용 불가";
+"auth.account.subscriptionEndsOn" = "%@ 종료";
+"auth.account.subscriptionRenewsOn" = "%@ 갱신";
+"auth.account.refreshSubscription" = "새로고침";
+"auth.account.subscribe" = "구독";
+"auth.account.manageBilling" = "결제 관리";
 
 "agent.clarification.windowTitle" = "어시스턴트 확인 필요";
 "agent.clarification.assistantSectionTitle" = "어시스턴트";

--- a/Sources/Typeflux/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/zh-Hans.lproj/Localizable.strings
@@ -1040,7 +1040,7 @@
 "cloud.error.validation" = "请求无效，请检查输入后重试。";
 "cloud.error.rateLimited" = "请求过于频繁，请稍后再试。";
 "cloud.error.quotaExceeded" = "Typeflux Cloud 使用额度已用完。";
-"cloud.error.planRequired" = "当前套餐不包含此 Typeflux Cloud 功能。";
+"cloud.error.planRequired" = "当前套餐不包含此 Typeflux Cloud 功能。请打开账号页面订阅或管理账单。";
 "cloud.error.server" = "Typeflux Cloud 暂时不可用，请稍后再试。";
 
 "auth.account.provider" = "登录方式";
@@ -1061,6 +1061,27 @@
 "auth.account.relogin" = "重新登录";
 "auth.account.signedOutTitle" = "尚未登录";
 "auth.account.signedOutSubtitle" = "登录后可查看账号信息并管理当前会话。";
+"auth.account.subscription" = "订阅";
+"auth.account.subscriptionPlan" = "套餐";
+"auth.account.subscriptionStatus" = "状态";
+"auth.account.subscriptionPeriod" = "计费周期";
+"auth.account.subscriptionActiveHint" = "您的 Typeflux Cloud 订阅已生效。";
+"auth.account.subscriptionInactiveHint" = "当前订阅暂不能使用 Typeflux Cloud 功能。";
+"auth.account.subscriptionRequiredHint" = "订阅后即可使用 Typeflux Cloud 语音识别和模型推理。";
+"auth.account.subscriptionNoPlan" = "未订阅";
+"auth.account.subscriptionDefaultPlan" = "Typeflux Cloud 月度套餐";
+"auth.account.subscriptionStatusNone" = "未订阅";
+"auth.account.subscriptionStatusActive" = "有效";
+"auth.account.subscriptionStatusTrialing" = "试用中";
+"auth.account.subscriptionStatusPastDue" = "逾期";
+"auth.account.subscriptionStatusCanceled" = "已取消";
+"auth.account.subscriptionStatusUnpaid" = "未付款";
+"auth.account.subscriptionPeriodUnavailable" = "不可用";
+"auth.account.subscriptionEndsOn" = "%@ 到期";
+"auth.account.subscriptionRenewsOn" = "%@ 续费";
+"auth.account.refreshSubscription" = "刷新";
+"auth.account.subscribe" = "订阅";
+"auth.account.manageBilling" = "管理账单";
 
 "agent.clarification.windowTitle" = "助手需要确认";
 "agent.clarification.assistantSectionTitle" = "助手";

--- a/Sources/Typeflux/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/zh-Hant.lproj/Localizable.strings
@@ -1036,7 +1036,7 @@
 "cloud.error.validation" = "請求無效，請檢查輸入後重試。";
 "cloud.error.rateLimited" = "請求過於頻繁，請稍後再試。";
 "cloud.error.quotaExceeded" = "Typeflux Cloud 使用額度已用完。";
-"cloud.error.planRequired" = "目前方案不包含此 Typeflux Cloud 功能。";
+"cloud.error.planRequired" = "目前方案不包含此 Typeflux Cloud 功能。請開啟帳號頁面訂閱或管理帳單。";
 "cloud.error.server" = "Typeflux Cloud 暫時無法使用，請稍後再試。";
 
 "auth.account.provider" = "登入方式";
@@ -1057,6 +1057,27 @@
 "auth.account.relogin" = "重新登入";
 "auth.account.signedOutTitle" = "尚未登入";
 "auth.account.signedOutSubtitle" = "登入後即可查看帳號資訊並管理目前工作階段。";
+"auth.account.subscription" = "訂閱";
+"auth.account.subscriptionPlan" = "方案";
+"auth.account.subscriptionStatus" = "狀態";
+"auth.account.subscriptionPeriod" = "計費週期";
+"auth.account.subscriptionActiveHint" = "您的 Typeflux Cloud 訂閱已啟用。";
+"auth.account.subscriptionInactiveHint" = "目前訂閱暫不能使用 Typeflux Cloud 功能。";
+"auth.account.subscriptionRequiredHint" = "訂閱後即可使用 Typeflux Cloud 語音辨識和模型推理。";
+"auth.account.subscriptionNoPlan" = "未訂閱";
+"auth.account.subscriptionDefaultPlan" = "Typeflux Cloud 月度方案";
+"auth.account.subscriptionStatusNone" = "未訂閱";
+"auth.account.subscriptionStatusActive" = "有效";
+"auth.account.subscriptionStatusTrialing" = "試用中";
+"auth.account.subscriptionStatusPastDue" = "逾期";
+"auth.account.subscriptionStatusCanceled" = "已取消";
+"auth.account.subscriptionStatusUnpaid" = "未付款";
+"auth.account.subscriptionPeriodUnavailable" = "不可用";
+"auth.account.subscriptionEndsOn" = "%@ 到期";
+"auth.account.subscriptionRenewsOn" = "%@ 續費";
+"auth.account.refreshSubscription" = "重新整理";
+"auth.account.subscribe" = "訂閱";
+"auth.account.manageBilling" = "管理帳單";
 
 "agent.clarification.windowTitle" = "助手需要確認";
 "agent.clarification.assistantSectionTitle" = "助手";

--- a/Sources/Typeflux/Settings/SettingsView.swift
+++ b/Sources/Typeflux/Settings/SettingsView.swift
@@ -298,6 +298,7 @@ struct StudioView: View {
             NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification),
         ) { _ in
             viewModel.schedulePermissionRefresh()
+            authState.refreshSubscriptionIfNeeded()
         }
         .overlay(alignment: .bottom) {
             if let toast = viewModel.toastMessage {

--- a/Tests/TypefluxTests/AccountSubscriptionPresentationTests.swift
+++ b/Tests/TypefluxTests/AccountSubscriptionPresentationTests.swift
@@ -1,0 +1,66 @@
+@testable import Typeflux
+import XCTest
+
+final class AccountSubscriptionPresentationTests: XCTestCase {
+    func testNoSubscriptionSelectsSubscribeActionAndRequiredCopy() {
+        let presentation = AccountSubscriptionPresentation.make(from: .none)
+
+        XCTAssertEqual(presentation.billingAction, .subscribe)
+        XCTAssertEqual(presentation.subtitleKey, "auth.account.subscriptionRequiredHint")
+        XCTAssertEqual(presentation.plan, .localized("auth.account.subscriptionNoPlan"))
+        XCTAssertEqual(presentation.status, .localized("auth.account.subscriptionStatusNone"))
+        XCTAssertEqual(presentation.period, .unavailable)
+    }
+
+    func testActiveDefaultPlanSelectsManageBillingAndRenewalPeriod() {
+        let snapshot = BillingSubscriptionSnapshot(
+            planCode: BillingPlan.defaultPlanCode,
+            status: "active",
+            currentPeriodStart: "2026-05-01T00:00:00Z",
+            currentPeriodEnd: "2026-06-01T00:00:00Z",
+            cancelAtPeriodEnd: false,
+            entitled: true
+        )
+
+        let presentation = AccountSubscriptionPresentation.make(from: snapshot)
+
+        XCTAssertEqual(presentation.billingAction, .manageBilling)
+        XCTAssertEqual(presentation.subtitleKey, "auth.account.subscriptionActiveHint")
+        XCTAssertEqual(presentation.plan, .localized("auth.account.subscriptionDefaultPlan"))
+        XCTAssertEqual(presentation.status, .localized("auth.account.subscriptionStatusActive"))
+        XCTAssertEqual(presentation.period, .renewsOn("2026-06-01T00:00:00Z"))
+    }
+
+    func testCancelAtPeriodEndUsesEndsOnPeriodCopy() {
+        let snapshot = BillingSubscriptionSnapshot(
+            planCode: BillingPlan.defaultPlanCode,
+            status: "active",
+            currentPeriodStart: "2026-05-01T00:00:00Z",
+            currentPeriodEnd: "2026-06-01T00:00:00Z",
+            cancelAtPeriodEnd: true,
+            entitled: true
+        )
+
+        let presentation = AccountSubscriptionPresentation.make(from: snapshot)
+
+        XCTAssertEqual(presentation.period, .endsOn("2026-06-01T00:00:00Z"))
+    }
+
+    func testCustomStatusAndPlanUseReadableLiteralFallbacks() {
+        let snapshot = BillingSubscriptionSnapshot(
+            planCode: "team_yearly",
+            status: "requires_action",
+            currentPeriodStart: nil,
+            currentPeriodEnd: nil,
+            cancelAtPeriodEnd: false,
+            entitled: false
+        )
+
+        let presentation = AccountSubscriptionPresentation.make(from: snapshot)
+
+        XCTAssertEqual(presentation.billingAction, .manageBilling)
+        XCTAssertEqual(presentation.subtitleKey, "auth.account.subscriptionInactiveHint")
+        XCTAssertEqual(presentation.plan, .literal("Team Yearly"))
+        XCTAssertEqual(presentation.status, .literal("Requires Action"))
+    }
+}

--- a/Tests/TypefluxTests/AuthStateTests.swift
+++ b/Tests/TypefluxTests/AuthStateTests.swift
@@ -81,6 +81,109 @@ final class AuthStateTests: XCTestCase {
         XCTAssertNil(state.userProfile)
     }
 
+    func testLoginSuccessRefreshesSubscription() async {
+        var storedToken: (token: String, expiresAt: Int)?
+        var savedProfile: UserProfile?
+        var fetchedSubscriptionToken: String?
+        let profile = makeProfile(email: "billing@test.com")
+        let activeSubscription = BillingSubscriptionSnapshot(
+            planCode: BillingPlan.defaultPlanCode,
+            status: "active",
+            currentPeriodStart: nil,
+            currentPeriodEnd: "2026-06-01T00:00:00Z",
+            cancelAtPeriodEnd: false,
+            entitled: true
+        )
+        let state = AuthState(
+            loadStoredToken: { storedToken },
+            loadStoredUserProfile: { nil },
+            saveStoredToken: { token, expiresAt in storedToken = (token, expiresAt) },
+            saveStoredUserProfile: { savedProfile = $0 },
+            clearStoredSession: {},
+            fetchProfile: { _ in profile },
+            fetchSubscription: { token in
+                fetchedSubscriptionToken = token
+                return activeSubscription
+            },
+        )
+
+        await state.handleLoginSuccess(token: "token-1", expiresAt: Int(Date().timeIntervalSince1970) + 3600)
+
+        XCTAssertTrue(state.isLoggedIn)
+        XCTAssertEqual(savedProfile, profile)
+        XCTAssertEqual(fetchedSubscriptionToken, "token-1")
+        XCTAssertEqual(state.subscription, activeSubscription)
+    }
+
+    func testStartCheckoutCreatesSessionAndRefreshesSubscriptionDuringPolling() async throws {
+        var storedToken: (token: String, expiresAt: Int)? = validStoredToken()
+        var requestedPlanCode: String?
+        var refreshCount = 0
+        let activeSubscription = BillingSubscriptionSnapshot(
+            planCode: BillingPlan.defaultPlanCode,
+            status: "active",
+            currentPeriodStart: nil,
+            currentPeriodEnd: "2026-06-01T00:00:00Z",
+            cancelAtPeriodEnd: false,
+            entitled: true
+        )
+        let state = AuthState(
+            loadStoredToken: { storedToken },
+            loadStoredUserProfile: { nil },
+            saveStoredToken: { token, expiresAt in storedToken = (token, expiresAt) },
+            saveStoredUserProfile: { _ in },
+            clearStoredSession: { storedToken = nil },
+            fetchProfile: { _ in self.makeProfile(email: "checkout@test.com") },
+            fetchSubscription: { _ in
+                refreshCount += 1
+                return activeSubscription
+            },
+            createCheckoutSession: { _, planCode in
+                requestedPlanCode = planCode
+                return BillingCheckoutSession(
+                    sessionID: "cs_test_1",
+                    url: URL(string: "https://checkout.stripe.com/cs_test_1")!
+                )
+            },
+        )
+
+        let url = try await state.startCheckout()
+        await waitForSubscriptionRefreshCount { refreshCount }
+
+        XCTAssertEqual(url.absoluteString, "https://checkout.stripe.com/cs_test_1")
+        XCTAssertEqual(requestedPlanCode, BillingPlan.defaultPlanCode)
+        XCTAssertEqual(state.subscription, activeSubscription)
+    }
+
+    func testLogoutClearsSubscription() async {
+        var storedToken: (token: String, expiresAt: Int)? = validStoredToken()
+        let state = AuthState(
+            loadStoredToken: { storedToken },
+            loadStoredUserProfile: { nil },
+            saveStoredToken: { _, _ in },
+            saveStoredUserProfile: { _ in },
+            clearStoredSession: { storedToken = nil },
+            fetchProfile: { _ in self.makeProfile(email: "logout@test.com") },
+            fetchSubscription: { _ in
+                BillingSubscriptionSnapshot(
+                    planCode: BillingPlan.defaultPlanCode,
+                    status: "active",
+                    currentPeriodStart: nil,
+                    currentPeriodEnd: nil,
+                    cancelAtPeriodEnd: false,
+                    entitled: true
+                )
+            },
+        )
+        await waitForRefreshCompletion(state)
+        await state.refreshSubscription()
+
+        state.logout()
+
+        XCTAssertFalse(state.isLoggedIn)
+        XCTAssertEqual(state.subscription, .none)
+    }
+
     private func makeProfile(email: String) -> UserProfile {
         UserProfile(
             id: UUID().uuidString,
@@ -102,5 +205,11 @@ final class AuthStateTests: XCTestCase {
             await Task.yield()
         }
         await Task.yield()
+    }
+
+    private func waitForSubscriptionRefreshCount(_ count: @escaping () -> Int) async {
+        for _ in 0..<100 where count() == 0 {
+            await Task.yield()
+        }
     }
 }

--- a/Tests/TypefluxTests/BillingAPIServiceTests.swift
+++ b/Tests/TypefluxTests/BillingAPIServiceTests.swift
@@ -1,0 +1,150 @@
+@testable import Typeflux
+import XCTest
+
+final class BillingAPIServiceTests: XCTestCase {
+    private let baseURL = URL(string: "https://api.example")!
+
+    func testFetchSubscriptionBuildsAuthenticatedRequestAndDecodesFlatResponse() async throws {
+        let session = BillingStubSession()
+        await session.setHandler { request in
+            XCTAssertEqual(request.url?.absoluteString, "https://api.example/api/v1/billing/subscription")
+            XCTAssertEqual(request.httpMethod, "GET")
+            XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer token-1")
+            let body = """
+            {
+              "code": "OK",
+              "data": {
+                "plan_code": "typeflux_cloud_monthly",
+                "status": "active",
+                "current_period_end": "2026-06-01T00:00:00Z",
+                "cancel_at_period_end": false,
+                "entitled": true
+              }
+            }
+            """
+            return (Data(body.utf8), Self.httpResponse(url: request.url!, status: 200))
+        }
+        let service = makeService(session: session)
+
+        let snapshot = try await service.fetchSubscription(token: "token-1")
+
+        XCTAssertEqual(snapshot.planCode, "typeflux_cloud_monthly")
+        XCTAssertEqual(snapshot.status, "active")
+        XCTAssertTrue(snapshot.entitled)
+        XCTAssertTrue(snapshot.hasSubscription)
+    }
+
+    func testFetchSubscriptionDecodesNestedPlanResponse() async throws {
+        let session = BillingStubSession()
+        await session.setHandler { request in
+            let body = """
+            {
+              "code": "OK",
+              "data": {
+                "subscription": {
+                  "plan_code": "typeflux_cloud_monthly",
+                  "status": "canceled",
+                  "cancel_at_period_end": true
+                },
+                "entitlement": { "entitled": false }
+              }
+            }
+            """
+            return (Data(body.utf8), Self.httpResponse(url: request.url!, status: 200))
+        }
+        let service = makeService(session: session)
+
+        let snapshot = try await service.fetchSubscription(token: "token-1")
+
+        XCTAssertEqual(snapshot.planCode, "typeflux_cloud_monthly")
+        XCTAssertEqual(snapshot.status, "canceled")
+        XCTAssertTrue(snapshot.cancelAtPeriodEnd)
+        XCTAssertFalse(snapshot.entitled)
+    }
+
+    func testSubscriptionDecodingInfersEntitlementFromActiveNonFractionalPeriodEnd() throws {
+        let json = """
+        {
+          "plan_code": "typeflux_cloud_monthly",
+          "status": "active",
+          "current_period_end": "2999-06-01T00:00:00Z"
+        }
+        """
+
+        let snapshot = try JSONDecoder().decode(BillingSubscriptionSnapshot.self, from: Data(json.utf8))
+
+        XCTAssertTrue(snapshot.entitled)
+    }
+
+    func testCreateCheckoutSessionPostsPlanCodeAndDecodesURL() async throws {
+        let session = BillingStubSession()
+        await session.setHandler { request in
+            XCTAssertEqual(request.url?.absoluteString, "https://api.example/api/v1/billing/checkout-session")
+            XCTAssertEqual(request.httpMethod, "POST")
+            let json = try XCTUnwrap(JSONSerialization.jsonObject(with: request.httpBody ?? Data()) as? [String: Any])
+            XCTAssertEqual(json["plan_code"] as? String, "typeflux_cloud_monthly")
+            let body = """
+            {"code": "OK", "data": {"session_id": "cs_test_1", "url": "https://checkout.stripe.com/cs_test_1"}}
+            """
+            return (Data(body.utf8), Self.httpResponse(url: request.url!, status: 200))
+        }
+        let service = makeService(session: session)
+
+        let sessionResponse = try await service.createCheckoutSession(
+            token: "token-1",
+            planCode: BillingPlan.defaultPlanCode
+        )
+
+        XCTAssertEqual(sessionResponse.sessionID, "cs_test_1")
+        XCTAssertEqual(sessionResponse.url.absoluteString, "https://checkout.stripe.com/cs_test_1")
+    }
+
+    func testCreatePortalSessionPostsToPortalEndpoint() async throws {
+        let session = BillingStubSession()
+        await session.setHandler { request in
+            XCTAssertEqual(request.url?.absoluteString, "https://api.example/api/v1/billing/portal-session")
+            XCTAssertEqual(request.httpMethod, "POST")
+            let body = """
+            {"code": "OK", "data": {"url": "https://billing.stripe.com/session/test"}}
+            """
+            return (Data(body.utf8), Self.httpResponse(url: request.url!, status: 200))
+        }
+        let service = makeService(session: session)
+
+        let portal = try await service.createPortalSession(token: "token-1")
+
+        XCTAssertEqual(portal.url.absoluteString, "https://billing.stripe.com/session/test")
+    }
+
+    private func makeService(session: BillingStubSession) -> BillingAPIService {
+        let selector = CloudEndpointSelector(baseURLs: [baseURL], prober: BillingNoOpProber())
+        return BillingAPIService(executor: CloudRequestExecutor(selector: selector, session: session))
+    }
+
+    private static func httpResponse(url: URL, status: Int) -> HTTPURLResponse {
+        HTTPURLResponse(url: url, statusCode: status, httpVersion: nil, headerFields: nil)!
+    }
+}
+
+private actor BillingStubSession: CloudHTTPSession {
+    typealias Handler = @Sendable (URLRequest) async throws -> (Data, URLResponse)
+
+    private var handler: Handler?
+
+    func setHandler(_ handler: @escaping Handler) {
+        self.handler = handler
+    }
+
+    func data(for request: URLRequest) async throws -> (Data, URLResponse) {
+        guard let handler else {
+            throw URLError(.badServerResponse)
+        }
+        return try await handler(request)
+    }
+}
+
+private struct BillingNoOpProber: CloudEndpointProbing {
+    func probe(baseURL: URL, nonce: String, timeout: TimeInterval) async throws -> CloudEndpointProbeResult {
+        CloudEndpointProbeResult(latencyMs: 1, serverID: nil, serverVersion: nil, nonceMatches: true)
+    }
+}


### PR DESCRIPTION
## Summary

- Adds Typeflux Cloud billing DTOs and `BillingAPIService` methods for subscription, checkout session, and portal session endpoints.
- Extends account/auth state with subscription refresh, login/app-activation refresh hooks, checkout start, bounded checkout polling, and logout cleanup.
- Adds an Account subscription section with plan/status/period display and Stripe-hosted Checkout/Portal browser actions.
- Updates localized `SUBSCRIPTION_REQUIRED`/billing copy across supported locales.
- Adds focused tests for billing endpoint construction/decoding, subscription state transitions, and Account subscription presentation selection.

References TYP-98 and TYP-100.

## How to Test

- `swift test --skip-update --filter TypefluxTests.BillingAPIServiceTests`
- `swift test --skip-update --filter TypefluxTests.AccountSubscriptionPresentationTests`
- `swift test --skip-update --filter TypefluxTests.AuthStateTests`
- `swift test --skip-update --filter TypefluxTests.LocalizationResourceTests --filter TypefluxTests.TypefluxCloudServerErrorMessageTests`
- `git diff --check`

Note: SwiftPM initially had a partial `swift-protobuf` submodule checkout; initializing the two nested submodules with shallow fetch resolved dependency materialization.

## Screenshots

Not captured in this heartbeat. UI changes are limited to the Account page subscription section and still need screenshot capture during review/manual QA.
