### PR TITLE
fix: disable thinking for custom LLM provider

### DIFF
--- a/Sources/Typeflux/LLM/Agent/LLMMultiTurnService+OpenAI.swift
+++ b/Sources/Typeflux/LLM/Agent/LLMMultiTurnService+OpenAI.swift
@@ -93,7 +93,7 @@ extension OpenAICompatibleAgentService: LLMMultiTurnService {
             baseURL: baseURL,
             candidate: tuningCandidate,
         )
-        let rawText = Self.rawOpenAIText(from: result.data)
+        let rawText = LLMAgentResponseSupport.extractOpenAICompatibleText(from: result.data) ?? ""
         let containsThinking = OpenAICompatibleResponseSupport.containsLeadingThinkingTags(rawText)
         let turnResult = parseOpenAITurnResult(from: result.data)
         if !rawText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
@@ -105,17 +105,6 @@ extension OpenAICompatibleAgentService: LLMMultiTurnService {
             )
         }
         return turnResult
-    }
-
-    private static func rawOpenAIText(from data: Data) -> String {
-        guard let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-              let choice = (object["choices"] as? [[String: Any]])?.first,
-              let message = choice["message"] as? [String: Any],
-              let text = message["content"] as? String
-        else {
-            return ""
-        }
-        return text
     }
 
     func buildOpenAIBody(
@@ -163,7 +152,7 @@ extension OpenAICompatibleAgentService: LLMMultiTurnService {
             return AgentTurnResult(turn: .text(""), tokenUsage: nil)
         }
 
-        let rawText = message["content"] as? String ?? ""
+        let rawText = OpenAICompatibleResponseSupport.extractTextDelta(from: data) ?? ""
         let text = OpenAICompatibleResponseSupport.stripLeadingThinkingTags(rawText)
         let toolCallsRaw = message["tool_calls"] as? [[String: Any]] ?? []
 

--- a/Sources/Typeflux/LLM/Agent/LLMMultiTurnService+OpenAI.swift
+++ b/Sources/Typeflux/LLM/Agent/LLMMultiTurnService+OpenAI.swift
@@ -14,6 +14,7 @@ extension OpenAICompatibleAgentService: LLMMultiTurnService {
             switch connection.provider.apiStyle {
             case .openAICompatible:
                 try await self.multiTurnOpenAI(
+                    provider: connection.provider,
                     baseURL: connection.baseURL,
                     model: connection.model,
                     apiKey: connection.apiKey,
@@ -49,6 +50,7 @@ extension OpenAICompatibleAgentService: LLMMultiTurnService {
     // MARK: - OpenAI Compatible
 
     private func multiTurnOpenAI(
+        provider: LLMRemoteProvider,
         baseURL: URL,
         model: String,
         apiKey: String,
@@ -70,11 +72,50 @@ extension OpenAICompatibleAgentService: LLMMultiTurnService {
         }
 
         var body = buildOpenAIBody(model: model, messages: messages, tools: tools, config: config)
-        OpenAICompatibleResponseSupport.applyProviderTuning(body: &body, baseURL: baseURL, model: model)
+        OpenAICompatibleResponseSupport.applyProviderTuning(
+            body: &body,
+            baseURL: baseURL,
+            model: model,
+            provider: provider,
+        )
+        let baseBody = body
+        let tuningCandidate = RemoteLLMClient.applyCustomThinkingTuning(
+            body: &body,
+            provider: provider,
+            baseURL: baseURL,
+        )
         request.httpBody = try JSONSerialization.data(withJSONObject: body)
 
-        let data = try await RemoteLLMClient.performJSONRequest(request)
-        return parseOpenAITurnResult(from: data)
+        let result = try await RemoteLLMClient.performJSONRequestWithCustomThinkingAdaptation(
+            request,
+            baseBody: baseBody,
+            provider: provider,
+            baseURL: baseURL,
+            candidate: tuningCandidate,
+        )
+        let rawText = Self.rawOpenAIText(from: result.data)
+        let containsThinking = OpenAICompatibleResponseSupport.containsLeadingThinkingTags(rawText)
+        let turnResult = parseOpenAITurnResult(from: result.data)
+        if !rawText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            RemoteLLMClient.recordCustomThinkingTuningSuccess(
+                provider: provider,
+                baseURL: baseURL,
+                candidate: result.candidate,
+                containsThinking: containsThinking,
+            )
+        }
+        return turnResult
+    }
+
+    private static func rawOpenAIText(from data: Data) -> String {
+        guard let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let choice = (object["choices"] as? [[String: Any]])?.first,
+              let message = choice["message"] as? [String: Any],
+              let text = message["content"] as? String
+        else {
+            return ""
+        }
+        return text
     }
 
     func buildOpenAIBody(

--- a/Sources/Typeflux/LLM/LLMAgentResponseSupport.swift
+++ b/Sources/Typeflux/LLM/LLMAgentResponseSupport.swift
@@ -197,14 +197,8 @@ enum LLMAgentResponseSupport {
     // MARK: - Text content extraction (for when model responds with text instead of a tool call)
 
     static func extractOpenAICompatibleText(from data: Data) -> String? {
-        guard let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-              let choice = (object["choices"] as? [[String: Any]])?.first,
-              let message = choice["message"] as? [String: Any],
-              let content = message["content"] as? String
-        else {
-            return nil
-        }
-        let trimmed = content.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let text = OpenAICompatibleResponseSupport.extractTextDelta(from: data) else { return nil }
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
         return trimmed.isEmpty ? nil : trimmed
     }
 

--- a/Sources/Typeflux/LLM/LLMThinkingTuningAdaptation.swift
+++ b/Sources/Typeflux/LLM/LLMThinkingTuningAdaptation.swift
@@ -138,12 +138,13 @@ struct LLMThinkingTuningAdaptationState: Codable, Equatable {
     }
 }
 
-final class LLMThinkingTuningAdaptationStore {
+final class LLMThinkingTuningAdaptationStore: @unchecked Sendable {
     static let cooldownInterval: TimeInterval = 24 * 60 * 60
 
     private let defaults: UserDefaults
     private let now: () -> Date
     private let defaultsKey = "llm.custom.thinkingTuning.adaptationStates"
+    private let lock = NSLock()
 
     init(defaults: UserDefaults = .standard, now: @escaping () -> Date = Date.init) {
         self.defaults = defaults
@@ -151,6 +152,95 @@ final class LLMThinkingTuningAdaptationStore {
     }
 
     func candidate(for baseURL: URL) -> LLMThinkingTuningCandidate? {
+        locked {
+            candidateLocked(for: baseURL)
+        }
+    }
+
+    func applyCandidate(
+        to body: inout [String: Any],
+        for baseURL: URL,
+    ) -> LLMThinkingTuningCandidate? {
+        guard let candidate = candidate(for: baseURL) else { return nil }
+        for (key, value) in candidate.parameters {
+            body[key] = value
+        }
+        return candidate
+    }
+
+    func recordUnsupportedParameter(baseURL: URL, candidate: LLMThinkingTuningCandidate?) {
+        guard let candidate else { return }
+        locked {
+            recordFailureLocked(baseURL: baseURL, candidate: candidate, reason: .unsupportedParameter)
+        }
+    }
+
+    func recordSuccess(
+        baseURL: URL,
+        candidate: LLMThinkingTuningCandidate?,
+        containsThinking: Bool,
+    ) {
+        guard let candidate else { return }
+        locked {
+            if containsThinking {
+                let state = stateLocked(for: baseURL)
+                let reason: LLMThinkingTuningFailureReason = if state.mode == .locked,
+                                                                state.lockedCandidateID == candidate.id
+                {
+                    .regressed
+                } else {
+                    .ineffective
+                }
+                recordFailureLocked(baseURL: baseURL, candidate: candidate, reason: reason)
+                return
+            }
+
+            let key = Self.normalizedBaseURLKey(baseURL)
+            var states = loadStates()
+            let failures = states[key]?.failures ?? []
+            states[key] = .locked(candidateID: candidate.id, lockedAt: now(), failures: failures)
+            saveStates(states)
+        }
+    }
+
+    func state(for baseURL: URL) -> LLMThinkingTuningAdaptationState {
+        locked {
+            stateLocked(for: baseURL)
+        }
+    }
+
+    func reset(baseURL: URL) {
+        let key = Self.normalizedBaseURLKey(baseURL)
+        locked {
+            var states = loadStates()
+            states.removeValue(forKey: key)
+            saveStates(states)
+        }
+    }
+
+    func resetAll() {
+        locked {
+            defaults.removeObject(forKey: defaultsKey)
+        }
+    }
+
+    static func normalizedBaseURLKey(_ url: URL) -> String {
+        guard var components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
+            return url.absoluteString.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        }
+        components.scheme = components.scheme?.lowercased()
+        components.host = components.host?.lowercased()
+        components.query = nil
+        components.fragment = nil
+
+        var value = components.string ?? url.absoluteString
+        while value.hasSuffix("/") {
+            value.removeLast()
+        }
+        return value
+    }
+
+    private func candidateLocked(for baseURL: URL) -> LLMThinkingTuningCandidate? {
         let key = Self.normalizedBaseURLKey(baseURL)
         var states = loadStates()
         let state = states[key] ?? .probing()
@@ -181,73 +271,11 @@ final class LLMThinkingTuningAdaptationStore {
         }
     }
 
-    func applyCandidate(
-        to body: inout [String: Any],
-        for baseURL: URL,
-    ) -> LLMThinkingTuningCandidate? {
-        guard let candidate = candidate(for: baseURL) else { return nil }
-        for (key, value) in candidate.parameters {
-            body[key] = value
-        }
-        return candidate
-    }
-
-    func recordUnsupportedParameter(baseURL: URL, candidate: LLMThinkingTuningCandidate?) {
-        guard let candidate else { return }
-        recordFailure(baseURL: baseURL, candidate: candidate, reason: .unsupportedParameter)
-    }
-
-    func recordSuccess(
-        baseURL: URL,
-        candidate: LLMThinkingTuningCandidate?,
-        containsThinking: Bool,
-    ) {
-        guard let candidate else { return }
-        if containsThinking {
-            let state = state(for: baseURL)
-            let reason: LLMThinkingTuningFailureReason = if state.mode == .locked,
-                                                            state.lockedCandidateID == candidate.id
-            {
-                .regressed
-            } else {
-                .ineffective
-            }
-            recordFailure(baseURL: baseURL, candidate: candidate, reason: reason)
-            return
-        }
-
-        let key = Self.normalizedBaseURLKey(baseURL)
-        var states = loadStates()
-        let failures = states[key]?.failures ?? []
-        states[key] = .locked(candidateID: candidate.id, lockedAt: now(), failures: failures)
-        saveStates(states)
-    }
-
-    func state(for baseURL: URL) -> LLMThinkingTuningAdaptationState {
+    private func stateLocked(for baseURL: URL) -> LLMThinkingTuningAdaptationState {
         loadStates()[Self.normalizedBaseURLKey(baseURL)] ?? .probing()
     }
 
-    func resetAll() {
-        defaults.removeObject(forKey: defaultsKey)
-    }
-
-    static func normalizedBaseURLKey(_ url: URL) -> String {
-        guard var components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
-            return url.absoluteString.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
-        }
-        components.scheme = components.scheme?.lowercased()
-        components.host = components.host?.lowercased()
-        components.query = nil
-        components.fragment = nil
-
-        var value = components.string ?? url.absoluteString
-        while value.hasSuffix("/") {
-            value.removeLast()
-        }
-        return value
-    }
-
-    private func recordFailure(
+    private func recordFailureLocked(
         baseURL: URL,
         candidate: LLMThinkingTuningCandidate,
         reason: LLMThinkingTuningFailureReason,
@@ -288,7 +316,17 @@ final class LLMThinkingTuningAdaptationStore {
     }
 
     private func saveStates(_ states: [String: LLMThinkingTuningAdaptationState]) {
+        guard !states.isEmpty else {
+            defaults.removeObject(forKey: defaultsKey)
+            return
+        }
         guard let data = try? JSONEncoder().encode(states) else { return }
         defaults.set(data, forKey: defaultsKey)
+    }
+
+    private func locked<T>(_ body: () -> T) -> T {
+        lock.lock()
+        defer { lock.unlock() }
+        return body()
     }
 }

--- a/Sources/Typeflux/LLM/LLMThinkingTuningAdaptation.swift
+++ b/Sources/Typeflux/LLM/LLMThinkingTuningAdaptation.swift
@@ -1,0 +1,294 @@
+import Foundation
+
+struct LLMThinkingTuningCandidate: Equatable {
+    let id: String
+    let parameters: [String: Any]
+
+    static let all: [LLMThinkingTuningCandidate] = [
+        LLMThinkingTuningCandidate(
+            id: "thinking-disabled",
+            parameters: ["thinking": ["type": "disabled"]],
+        ),
+        LLMThinkingTuningCandidate(
+            id: "enable-thinking-false",
+            parameters: ["enable_thinking": false],
+        ),
+        LLMThinkingTuningCandidate(
+            id: "reasoning-effort-none",
+            parameters: ["reasoning": ["effort": "none"]],
+        ),
+        LLMThinkingTuningCandidate(
+            id: "openrouter-reasoning-exclude",
+            parameters: [
+                "reasoning": [
+                    "effort": "none",
+                    "exclude": true,
+                ],
+                "include_reasoning": false,
+            ],
+        ),
+        LLMThinkingTuningCandidate(
+            id: "thinking-and-enable-thinking",
+            parameters: [
+                "thinking": ["type": "disabled"],
+                "enable_thinking": false,
+            ],
+        ),
+        LLMThinkingTuningCandidate(
+            id: "thinking-and-reasoning-effort",
+            parameters: [
+                "thinking": ["type": "disabled"],
+                "reasoning": ["effort": "none"],
+            ],
+        ),
+        LLMThinkingTuningCandidate(
+            id: "all-known-thinking-controls",
+            parameters: [
+                "thinking": ["type": "disabled"],
+                "enable_thinking": false,
+                "reasoning": [
+                    "effort": "none",
+                    "exclude": true,
+                ],
+                "include_reasoning": false,
+            ],
+        ),
+    ]
+
+    static func candidate(id: String) -> LLMThinkingTuningCandidate? {
+        all.first { $0.id == id }
+    }
+
+    static func index(of candidateID: String) -> Int? {
+        all.firstIndex { $0.id == candidateID }
+    }
+
+    static func == (lhs: LLMThinkingTuningCandidate, rhs: LLMThinkingTuningCandidate) -> Bool {
+        lhs.id == rhs.id
+    }
+}
+
+enum LLMThinkingTuningFailureReason: String, Codable, Equatable {
+    case unsupportedParameter
+    case ineffective
+    case regressed
+}
+
+struct LLMThinkingTuningCandidateFailure: Codable, Equatable {
+    let candidateID: String
+    let reason: LLMThinkingTuningFailureReason
+    let observedAt: Date
+}
+
+struct LLMThinkingTuningAdaptationState: Codable, Equatable {
+    enum Mode: String, Codable {
+        case probing
+        case locked
+        case unsupported
+    }
+
+    var mode: Mode
+    var nextCandidateIndex: Int
+    var lockedCandidateID: String?
+    var lockedAt: Date?
+    var unsupportedMarkedAt: Date?
+    var failures: [LLMThinkingTuningCandidateFailure]
+
+    static func probing(
+        nextCandidateIndex: Int = 0,
+        failures: [LLMThinkingTuningCandidateFailure] = [],
+    ) -> LLMThinkingTuningAdaptationState {
+        LLMThinkingTuningAdaptationState(
+            mode: .probing,
+            nextCandidateIndex: nextCandidateIndex,
+            lockedCandidateID: nil,
+            lockedAt: nil,
+            unsupportedMarkedAt: nil,
+            failures: failures,
+        )
+    }
+
+    static func locked(
+        candidateID: String,
+        lockedAt: Date,
+        failures: [LLMThinkingTuningCandidateFailure],
+    ) -> LLMThinkingTuningAdaptationState {
+        LLMThinkingTuningAdaptationState(
+            mode: .locked,
+            nextCandidateIndex: 0,
+            lockedCandidateID: candidateID,
+            lockedAt: lockedAt,
+            unsupportedMarkedAt: nil,
+            failures: failures,
+        )
+    }
+
+    static func unsupported(
+        markedAt: Date,
+        failures: [LLMThinkingTuningCandidateFailure],
+    ) -> LLMThinkingTuningAdaptationState {
+        LLMThinkingTuningAdaptationState(
+            mode: .unsupported,
+            nextCandidateIndex: 0,
+            lockedCandidateID: nil,
+            lockedAt: nil,
+            unsupportedMarkedAt: markedAt,
+            failures: failures,
+        )
+    }
+}
+
+final class LLMThinkingTuningAdaptationStore {
+    static let cooldownInterval: TimeInterval = 24 * 60 * 60
+
+    private let defaults: UserDefaults
+    private let now: () -> Date
+    private let defaultsKey = "llm.custom.thinkingTuning.adaptationStates"
+
+    init(defaults: UserDefaults = .standard, now: @escaping () -> Date = Date.init) {
+        self.defaults = defaults
+        self.now = now
+    }
+
+    func candidate(for baseURL: URL) -> LLMThinkingTuningCandidate? {
+        let key = Self.normalizedBaseURLKey(baseURL)
+        var states = loadStates()
+        let state = states[key] ?? .probing()
+
+        switch state.mode {
+        case .locked:
+            guard let candidateID = state.lockedCandidateID else {
+                states[key] = .probing()
+                saveStates(states)
+                return LLMThinkingTuningCandidate.all.first
+            }
+            return LLMThinkingTuningCandidate.candidate(id: candidateID)
+
+        case .unsupported:
+            if let markedAt = state.unsupportedMarkedAt,
+               now().timeIntervalSince(markedAt) < Self.cooldownInterval
+            {
+                return nil
+            }
+            states[key] = .probing()
+            saveStates(states)
+            return LLMThinkingTuningCandidate.all.first
+
+        case .probing:
+            let index = min(max(state.nextCandidateIndex, 0), LLMThinkingTuningCandidate.all.count)
+            guard index < LLMThinkingTuningCandidate.all.count else { return nil }
+            return LLMThinkingTuningCandidate.all[index]
+        }
+    }
+
+    func applyCandidate(
+        to body: inout [String: Any],
+        for baseURL: URL,
+    ) -> LLMThinkingTuningCandidate? {
+        guard let candidate = candidate(for: baseURL) else { return nil }
+        for (key, value) in candidate.parameters {
+            body[key] = value
+        }
+        return candidate
+    }
+
+    func recordUnsupportedParameter(baseURL: URL, candidate: LLMThinkingTuningCandidate?) {
+        guard let candidate else { return }
+        recordFailure(baseURL: baseURL, candidate: candidate, reason: .unsupportedParameter)
+    }
+
+    func recordSuccess(
+        baseURL: URL,
+        candidate: LLMThinkingTuningCandidate?,
+        containsThinking: Bool,
+    ) {
+        guard let candidate else { return }
+        if containsThinking {
+            let state = state(for: baseURL)
+            let reason: LLMThinkingTuningFailureReason = if state.mode == .locked,
+                                                            state.lockedCandidateID == candidate.id
+            {
+                .regressed
+            } else {
+                .ineffective
+            }
+            recordFailure(baseURL: baseURL, candidate: candidate, reason: reason)
+            return
+        }
+
+        let key = Self.normalizedBaseURLKey(baseURL)
+        var states = loadStates()
+        let failures = states[key]?.failures ?? []
+        states[key] = .locked(candidateID: candidate.id, lockedAt: now(), failures: failures)
+        saveStates(states)
+    }
+
+    func state(for baseURL: URL) -> LLMThinkingTuningAdaptationState {
+        loadStates()[Self.normalizedBaseURLKey(baseURL)] ?? .probing()
+    }
+
+    func resetAll() {
+        defaults.removeObject(forKey: defaultsKey)
+    }
+
+    static func normalizedBaseURLKey(_ url: URL) -> String {
+        guard var components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
+            return url.absoluteString.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        }
+        components.scheme = components.scheme?.lowercased()
+        components.host = components.host?.lowercased()
+        components.query = nil
+        components.fragment = nil
+
+        var value = components.string ?? url.absoluteString
+        while value.hasSuffix("/") {
+            value.removeLast()
+        }
+        return value
+    }
+
+    private func recordFailure(
+        baseURL: URL,
+        candidate: LLMThinkingTuningCandidate,
+        reason: LLMThinkingTuningFailureReason,
+    ) {
+        let key = Self.normalizedBaseURLKey(baseURL)
+        var states = loadStates()
+        let state = states[key] ?? .probing()
+        var failures = state.failures.filter { $0.candidateID != candidate.id }
+        failures.append(
+            LLMThinkingTuningCandidateFailure(
+                candidateID: candidate.id,
+                reason: reason,
+                observedAt: now(),
+            ),
+        )
+
+        guard let currentIndex = LLMThinkingTuningCandidate.index(of: candidate.id) else {
+            states[key] = .unsupported(markedAt: now(), failures: failures)
+            saveStates(states)
+            return
+        }
+
+        let failedIDs = Set(failures.map(\.candidateID))
+        let nextIndex = LLMThinkingTuningCandidate.all[(currentIndex + 1)...]
+            .firstIndex { !failedIDs.contains($0.id) }
+
+        if let nextIndex {
+            states[key] = .probing(nextCandidateIndex: nextIndex, failures: failures)
+        } else {
+            states[key] = .unsupported(markedAt: now(), failures: failures)
+        }
+        saveStates(states)
+    }
+
+    private func loadStates() -> [String: LLMThinkingTuningAdaptationState] {
+        guard let data = defaults.data(forKey: defaultsKey) else { return [:] }
+        return (try? JSONDecoder().decode([String: LLMThinkingTuningAdaptationState].self, from: data)) ?? [:]
+    }
+
+    private func saveStates(_ states: [String: LLMThinkingTuningAdaptationState]) {
+        guard let data = try? JSONEncoder().encode(states) else { return }
+        defaults.set(data, forKey: defaultsKey)
+    }
+}

--- a/Sources/Typeflux/LLM/OpenAICompatibleAgentService.swift
+++ b/Sources/Typeflux/LLM/OpenAICompatibleAgentService.swift
@@ -159,6 +159,7 @@ enum RemoteAgentClient {
         switch provider.apiStyle {
         case .openAICompatible:
             try await runOpenAICompatibleTool(
+                provider: provider,
                 baseURL: baseURL,
                 model: model,
                 apiKey: apiKey,
@@ -190,6 +191,7 @@ enum RemoteAgentClient {
     // MARK: - Typed tool call (decode into T)
 
     private static func runOpenAICompatibleTool<T: Decodable & Sendable>(
+        provider: LLMRemoteProvider,
         baseURL: URL,
         model: String,
         apiKey: String,
@@ -198,7 +200,7 @@ enum RemoteAgentClient {
         decoding type: T.Type,
     ) async throws -> T {
         let toolCall = try await fetchOpenAICompatibleToolCall(
-            baseURL: baseURL, model: model, apiKey: apiKey,
+            provider: provider, baseURL: baseURL, model: model, apiKey: apiKey,
             additionalHeaders: additionalHeaders, request: request,
         )
         return try decodeToolArguments(toolCall, expectedToolName: request.forcedToolName, as: type)
@@ -249,7 +251,7 @@ enum RemoteAgentClient {
         switch provider.apiStyle {
         case .openAICompatible:
             try await fetchOpenAICompatibleToolCall(
-                baseURL: baseURL, model: model, apiKey: apiKey,
+                provider: provider, baseURL: baseURL, model: model, apiKey: apiKey,
                 additionalHeaders: additionalHeaders, request: request,
             )
         case .anthropic:
@@ -268,6 +270,7 @@ enum RemoteAgentClient {
     // MARK: - HTTP fetch helpers (provider-specific, return raw LLMAgentToolCall)
 
     private static func fetchOpenAICompatibleToolCall(
+        provider: LLMRemoteProvider,
         baseURL: URL,
         model: String,
         apiKey: String,
@@ -293,10 +296,36 @@ enum RemoteAgentClient {
             tools: request.tools,
             forcedToolName: request.forcedToolName,
         )
-        OpenAICompatibleResponseSupport.applyProviderTuning(body: &body, baseURL: baseURL, model: model)
+        OpenAICompatibleResponseSupport.applyProviderTuning(
+            body: &body,
+            baseURL: baseURL,
+            model: model,
+            provider: provider,
+        )
+        let baseBody = body
+        let tuningCandidate = RemoteLLMClient.applyCustomThinkingTuning(
+            body: &body,
+            provider: provider,
+            baseURL: baseURL,
+        )
         urlRequest.httpBody = try JSONSerialization.data(withJSONObject: body)
 
-        let data = try await RemoteLLMClient.performJSONRequest(urlRequest)
+        let result = try await RemoteLLMClient.performJSONRequestWithCustomThinkingAdaptation(
+            urlRequest,
+            baseBody: baseBody,
+            provider: provider,
+            baseURL: baseURL,
+            candidate: tuningCandidate,
+        )
+        if let text = LLMAgentResponseSupport.extractOpenAICompatibleText(from: result.data) {
+            RemoteLLMClient.recordCustomThinkingTuningSuccess(
+                provider: provider,
+                baseURL: baseURL,
+                candidate: result.candidate,
+                containsThinking: OpenAICompatibleResponseSupport.containsLeadingThinkingTags(text),
+            )
+        }
+        let data = result.data
         guard let toolCall = LLMAgentResponseSupport.extractOpenAICompatibleToolCall(from: data) else {
             if let text = LLMAgentResponseSupport.extractOpenAICompatibleText(from: data) {
                 throw LLMAgentError.textResponse(text: text)

--- a/Sources/Typeflux/LLM/OpenAICompatibleLLMService.swift
+++ b/Sources/Typeflux/LLM/OpenAICompatibleLLMService.swift
@@ -305,6 +305,8 @@ final class OpenAICompatibleLLMService: LLMService {
 }
 
 enum RemoteLLMClient {
+    static var customThinkingTuningStore = LLMThinkingTuningAdaptationStore()
+
     static func streamRewrite(
         provider: LLMRemoteProvider,
         baseURL: URL,
@@ -410,6 +412,7 @@ enum RemoteLLMClient {
         switch provider.apiStyle {
         case .openAICompatible:
             try await requestOpenAICompatible(
+                provider: provider,
                 baseURL: baseURL,
                 model: model,
                 apiKey: apiKey,
@@ -442,7 +445,7 @@ enum RemoteLLMClient {
     }
 
     private static func streamOpenAICompatible(
-        provider _: LLMRemoteProvider,
+        provider: LLMRemoteProvider,
         baseURL: URL,
         model: String,
         apiKey: String,
@@ -468,16 +471,37 @@ enum RemoteLLMClient {
                 ["role": "user", "content": userPrompt],
             ],
         ]
-        OpenAICompatibleResponseSupport.applyProviderTuning(body: &body, baseURL: baseURL, model: model)
+        OpenAICompatibleResponseSupport.applyProviderTuning(
+            body: &body,
+            baseURL: baseURL,
+            model: model,
+            provider: provider,
+        )
+        let baseBody = body
+        let tuningCandidate = applyCustomThinkingTuning(
+            body: &body,
+            provider: provider,
+            baseURL: baseURL,
+        )
 
         urlRequest.httpBody = try JSONSerialization.data(withJSONObject: body)
         NetworkDebugLogger.logRequest(urlRequest)
 
         var final = ""
         var thinkingFilter = OpenAICompatibleResponseSupport.StreamingThinkingFilter()
+        var usedCandidate = tuningCandidate
+        var observedReasoning = false
 
         do {
-            for try await line in try await SSEClient.lines(for: urlRequest) {
+            let stream = try await sseLinesWithCustomThinkingAdaptation(
+                urlRequest,
+                baseBody: baseBody,
+                provider: provider,
+                baseURL: baseURL,
+                candidate: tuningCandidate,
+            )
+            usedCandidate = stream.candidate
+            for try await line in stream.lines {
                 if line == "[DONE]" { break }
 
                 guard let data = line.data(using: .utf8) else { continue }
@@ -488,6 +512,7 @@ enum RemoteLLMClient {
                         continuation.yield(filtered)
                     }
                 } else if OpenAICompatibleResponseSupport.containsReasoningDelta(data) {
+                    observedReasoning = true
                     continue
                 }
             }
@@ -495,6 +520,12 @@ enum RemoteLLMClient {
                 final += remaining
                 continuation.yield(remaining)
             }
+            recordCustomThinkingTuningSuccess(
+                provider: provider,
+                baseURL: baseURL,
+                candidate: usedCandidate,
+                containsThinking: observedReasoning || thinkingFilter.observedThinking,
+            )
         } catch {
             NetworkDebugLogger.logError(context: "LLM stream failed", error: error)
             throw error
@@ -504,7 +535,7 @@ enum RemoteLLMClient {
     }
 
     private static func previewOpenAICompatible(
-        provider _: LLMRemoteProvider,
+        provider: LLMRemoteProvider,
         baseURL: URL,
         model: String,
         apiKey: String,
@@ -525,24 +556,54 @@ enum RemoteLLMClient {
             "max_completion_tokens": 50,
             "messages": [["role": "user", "content": "Hello"]],
         ]
-        OpenAICompatibleResponseSupport.applyProviderTuning(body: &body, baseURL: baseURL, model: model)
+        OpenAICompatibleResponseSupport.applyProviderTuning(
+            body: &body,
+            baseURL: baseURL,
+            model: model,
+            provider: provider,
+        )
+        let baseBody = body
+        let tuningCandidate = applyCustomThinkingTuning(
+            body: &body,
+            provider: provider,
+            baseURL: baseURL,
+        )
         urlRequest.httpBody = try JSONSerialization.data(withJSONObject: body)
 
         var collected = ""
-        for try await chunk in try await SSEClient.lines(for: urlRequest) {
+        var thinkingFilter = OpenAICompatibleResponseSupport.StreamingThinkingFilter()
+        var observedReasoning = false
+        let stream = try await sseLinesWithCustomThinkingAdaptation(
+            urlRequest,
+            baseBody: baseBody,
+            provider: provider,
+            baseURL: baseURL,
+            candidate: tuningCandidate,
+        )
+        for try await chunk in stream.lines {
             if chunk == "[DONE]" { break }
             guard let data = chunk.data(using: .utf8) else { continue }
             if let content = OpenAICompatibleResponseSupport.extractTextDelta(from: data), !content.isEmpty {
-                collected += content
+                let filtered = thinkingFilter.process(content) ?? ""
+                collected += filtered
                 if collected.count >= 60 {
                     break
                 }
+            } else if OpenAICompatibleResponseSupport.containsReasoningDelta(data) {
+                observedReasoning = true
             }
         }
+        recordCustomThinkingTuningSuccess(
+            provider: provider,
+            baseURL: baseURL,
+            candidate: stream.candidate,
+            containsThinking: observedReasoning || thinkingFilter.observedThinking,
+        )
         return collected
     }
 
     private static func requestOpenAICompatible(
+        provider: LLMRemoteProvider,
         baseURL: URL,
         model: String,
         apiKey: String,
@@ -578,12 +639,35 @@ enum RemoteLLMClient {
                 ],
             ]
         }
-        OpenAICompatibleResponseSupport.applyProviderTuning(body: &body, baseURL: baseURL, model: model)
+        OpenAICompatibleResponseSupport.applyProviderTuning(
+            body: &body,
+            baseURL: baseURL,
+            model: model,
+            provider: provider,
+        )
+        let baseBody = body
+        let tuningCandidate = applyCustomThinkingTuning(
+            body: &body,
+            provider: provider,
+            baseURL: baseURL,
+        )
         urlRequest.httpBody = try JSONSerialization.data(withJSONObject: body)
 
-        let data = try await performJSONRequest(urlRequest)
-        let raw = OpenAICompatibleResponseSupport.extractTextDelta(from: data)?
+        let result = try await performJSONRequestWithCustomThinkingAdaptation(
+            urlRequest,
+            baseBody: baseBody,
+            provider: provider,
+            baseURL: baseURL,
+            candidate: tuningCandidate,
+        )
+        let raw = OpenAICompatibleResponseSupport.extractTextDelta(from: result.data)?
             .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        recordCustomThinkingTuningSuccess(
+            provider: provider,
+            baseURL: baseURL,
+            candidate: result.candidate,
+            containsThinking: OpenAICompatibleResponseSupport.containsLeadingThinkingTags(raw),
+        )
         return OpenAICompatibleResponseSupport.stripLeadingThinkingTags(raw)
     }
 
@@ -758,6 +842,138 @@ enum RemoteLLMClient {
             throw NSError(domain: "LLM", code: http.statusCode, userInfo: [NSLocalizedDescriptionKey: "HTTP \(http.statusCode): \(message)"])
         }
         return data
+    }
+
+    struct CustomThinkingJSONResult {
+        let data: Data
+        let candidate: LLMThinkingTuningCandidate?
+    }
+
+    struct CustomThinkingStreamResult {
+        let lines: AsyncThrowingStream<String, Error>
+        let candidate: LLMThinkingTuningCandidate?
+    }
+
+    static func performJSONRequestWithCustomThinkingAdaptation(
+        _ request: URLRequest,
+        baseBody: [String: Any],
+        provider: LLMRemoteProvider,
+        baseURL: URL,
+        candidate: LLMThinkingTuningCandidate?,
+    ) async throws -> CustomThinkingJSONResult {
+        var currentRequest = request
+        var currentCandidate = candidate
+
+        while true {
+            do {
+                let data = try await performJSONRequest(currentRequest)
+                return CustomThinkingJSONResult(data: data, candidate: currentCandidate)
+            } catch {
+                guard let next = try nextCustomThinkingRetry(
+                    after: error,
+                    provider: provider,
+                    baseURL: baseURL,
+                    failedCandidate: currentCandidate,
+                    originalRequest: request,
+                    baseBody: baseBody,
+                ) else {
+                    throw error
+                }
+                currentRequest = next.request
+                currentCandidate = next.candidate
+            }
+        }
+    }
+
+    static func sseLinesWithCustomThinkingAdaptation(
+        _ request: URLRequest,
+        baseBody: [String: Any],
+        provider: LLMRemoteProvider,
+        baseURL: URL,
+        candidate: LLMThinkingTuningCandidate?,
+    ) async throws -> CustomThinkingStreamResult {
+        var currentRequest = request
+        var currentCandidate = candidate
+
+        while true {
+            do {
+                let lines = try await SSEClient.lines(for: currentRequest)
+                return CustomThinkingStreamResult(lines: lines, candidate: currentCandidate)
+            } catch {
+                guard let next = try nextCustomThinkingRetry(
+                    after: error,
+                    provider: provider,
+                    baseURL: baseURL,
+                    failedCandidate: currentCandidate,
+                    originalRequest: request,
+                    baseBody: baseBody,
+                ) else {
+                    throw error
+                }
+                currentRequest = next.request
+                currentCandidate = next.candidate
+            }
+        }
+    }
+
+    static func applyCustomThinkingTuning(
+        body: inout [String: Any],
+        provider: LLMRemoteProvider,
+        baseURL: URL,
+    ) -> LLMThinkingTuningCandidate? {
+        guard provider == .custom else { return nil }
+        return customThinkingTuningStore.applyCandidate(to: &body, for: baseURL)
+    }
+
+    static func recordCustomThinkingTuningSuccess(
+        provider: LLMRemoteProvider,
+        baseURL: URL,
+        candidate: LLMThinkingTuningCandidate?,
+        containsThinking: Bool,
+    ) {
+        guard provider == .custom else { return }
+        customThinkingTuningStore.recordSuccess(
+            baseURL: baseURL,
+            candidate: candidate,
+            containsThinking: containsThinking,
+        )
+    }
+
+    private static func nextCustomThinkingRetry(
+        after error: Error,
+        provider: LLMRemoteProvider,
+        baseURL: URL,
+        failedCandidate: LLMThinkingTuningCandidate?,
+        originalRequest: URLRequest,
+        baseBody: [String: Any],
+    ) throws -> (request: URLRequest, candidate: LLMThinkingTuningCandidate?)? {
+        guard provider == .custom,
+              OpenAICompatibleResponseSupport.shouldRetryWithoutCustomThinkingTuning(error: error)
+        else {
+            return nil
+        }
+
+        customThinkingTuningStore.recordUnsupportedParameter(
+            baseURL: baseURL,
+            candidate: failedCandidate,
+        )
+
+        var nextBody = baseBody
+        let nextCandidate = customThinkingTuningStore.applyCandidate(to: &nextBody, for: baseURL)
+
+        if let nextCandidate {
+            NetworkDebugLogger.logMessage(
+                "Custom LLM rejected thinking tuning parameters; retrying with \(nextCandidate.id).",
+            )
+        } else {
+            NetworkDebugLogger.logMessage(
+                "Custom LLM rejected all thinking tuning candidates; retrying without tuning.",
+            )
+        }
+
+        var retryRequest = originalRequest
+        retryRequest.httpBody = try JSONSerialization.data(withJSONObject: nextBody)
+        return (retryRequest, nextCandidate)
     }
 }
 

--- a/Sources/Typeflux/LLM/OpenAICompatibleLLMService.swift
+++ b/Sources/Typeflux/LLM/OpenAICompatibleLLMService.swift
@@ -305,7 +305,7 @@ final class OpenAICompatibleLLMService: LLMService {
 }
 
 enum RemoteLLMClient {
-    static var customThinkingTuningStore = LLMThinkingTuningAdaptationStore()
+    static let customThinkingTuningStore = LLMThinkingTuningAdaptationStore()
 
     static func streamRewrite(
         provider: LLMRemoteProvider,
@@ -487,51 +487,71 @@ enum RemoteLLMClient {
         urlRequest.httpBody = try JSONSerialization.data(withJSONObject: body)
         NetworkDebugLogger.logRequest(urlRequest)
 
-        var final = ""
-        var thinkingFilter = OpenAICompatibleResponseSupport.StreamingThinkingFilter()
-        var usedCandidate = tuningCandidate
-        var observedReasoning = false
+        var currentRequest = urlRequest
+        var currentCandidate = tuningCandidate
 
-        do {
-            let stream = try await sseLinesWithCustomThinkingAdaptation(
-                urlRequest,
-                baseBody: baseBody,
-                provider: provider,
-                baseURL: baseURL,
-                candidate: tuningCandidate,
-            )
-            usedCandidate = stream.candidate
-            for try await line in stream.lines {
-                if line == "[DONE]" { break }
+        while true {
+            var final = ""
+            var thinkingFilter = OpenAICompatibleResponseSupport.StreamingThinkingFilter()
+            var usedCandidate = currentCandidate
+            var observedReasoning = false
 
-                guard let data = line.data(using: .utf8) else { continue }
-                let content = OpenAICompatibleResponseSupport.extractTextDelta(from: data)
-                if let content, !content.isEmpty {
-                    if let filtered = thinkingFilter.process(content) {
-                        final += filtered
-                        continuation.yield(filtered)
+            do {
+                let stream = try await sseLinesWithCustomThinkingAdaptation(
+                    currentRequest,
+                    baseBody: baseBody,
+                    provider: provider,
+                    baseURL: baseURL,
+                    candidate: currentCandidate,
+                )
+                usedCandidate = stream.candidate
+                for try await line in stream.lines {
+                    if line == "[DONE]" { break }
+
+                    guard let data = line.data(using: .utf8) else { continue }
+                    if let streamError = OpenAICompatibleResponseSupport.streamError(from: data) {
+                        throw streamError
                     }
-                } else if OpenAICompatibleResponseSupport.containsReasoningDelta(data) {
-                    observedReasoning = true
-                    continue
+                    let content = OpenAICompatibleResponseSupport.extractTextDelta(from: data)
+                    if let content, !content.isEmpty {
+                        if let filtered = thinkingFilter.process(content) {
+                            final += filtered
+                            continuation.yield(filtered)
+                        }
+                    } else if OpenAICompatibleResponseSupport.containsReasoningDelta(data) {
+                        observedReasoning = true
+                        continue
+                    }
                 }
+                if let remaining = thinkingFilter.flush() {
+                    final += remaining
+                    continuation.yield(remaining)
+                }
+                recordCustomThinkingTuningSuccess(
+                    provider: provider,
+                    baseURL: baseURL,
+                    candidate: usedCandidate,
+                    containsThinking: observedReasoning || thinkingFilter.observedThinking,
+                )
+                return final
+            } catch {
+                NetworkDebugLogger.logError(context: "LLM stream failed", error: error)
+                guard final.isEmpty,
+                      let next = try nextCustomThinkingRetry(
+                          after: error,
+                          provider: provider,
+                          baseURL: baseURL,
+                          failedCandidate: usedCandidate,
+                          originalRequest: urlRequest,
+                          baseBody: baseBody,
+                      )
+                else {
+                    throw error
+                }
+                currentRequest = next.request
+                currentCandidate = next.candidate
             }
-            if let remaining = thinkingFilter.flush() {
-                final += remaining
-                continuation.yield(remaining)
-            }
-            recordCustomThinkingTuningSuccess(
-                provider: provider,
-                baseURL: baseURL,
-                candidate: usedCandidate,
-                containsThinking: observedReasoning || thinkingFilter.observedThinking,
-            )
-        } catch {
-            NetworkDebugLogger.logError(context: "LLM stream failed", error: error)
-            throw error
         }
-
-        return final
     }
 
     private static func previewOpenAICompatible(
@@ -570,36 +590,64 @@ enum RemoteLLMClient {
         )
         urlRequest.httpBody = try JSONSerialization.data(withJSONObject: body)
 
-        var collected = ""
-        var thinkingFilter = OpenAICompatibleResponseSupport.StreamingThinkingFilter()
-        var observedReasoning = false
-        let stream = try await sseLinesWithCustomThinkingAdaptation(
-            urlRequest,
-            baseBody: baseBody,
-            provider: provider,
-            baseURL: baseURL,
-            candidate: tuningCandidate,
-        )
-        for try await chunk in stream.lines {
-            if chunk == "[DONE]" { break }
-            guard let data = chunk.data(using: .utf8) else { continue }
-            if let content = OpenAICompatibleResponseSupport.extractTextDelta(from: data), !content.isEmpty {
-                let filtered = thinkingFilter.process(content) ?? ""
-                collected += filtered
-                if collected.count >= 60 {
-                    break
+        var currentRequest = urlRequest
+        var currentCandidate = tuningCandidate
+
+        while true {
+            var collected = ""
+            var thinkingFilter = OpenAICompatibleResponseSupport.StreamingThinkingFilter()
+            var observedReasoning = false
+            var usedCandidate = currentCandidate
+
+            do {
+                let stream = try await sseLinesWithCustomThinkingAdaptation(
+                    currentRequest,
+                    baseBody: baseBody,
+                    provider: provider,
+                    baseURL: baseURL,
+                    candidate: currentCandidate,
+                )
+                usedCandidate = stream.candidate
+                for try await chunk in stream.lines {
+                    if chunk == "[DONE]" { break }
+                    guard let data = chunk.data(using: .utf8) else { continue }
+                    if let streamError = OpenAICompatibleResponseSupport.streamError(from: data) {
+                        throw streamError
+                    }
+                    if let content = OpenAICompatibleResponseSupport.extractTextDelta(from: data), !content.isEmpty {
+                        let filtered = thinkingFilter.process(content) ?? ""
+                        collected += filtered
+                        if collected.count >= 60 {
+                            break
+                        }
+                    } else if OpenAICompatibleResponseSupport.containsReasoningDelta(data) {
+                        observedReasoning = true
+                    }
                 }
-            } else if OpenAICompatibleResponseSupport.containsReasoningDelta(data) {
-                observedReasoning = true
+                recordCustomThinkingTuningSuccess(
+                    provider: provider,
+                    baseURL: baseURL,
+                    candidate: usedCandidate,
+                    containsThinking: observedReasoning || thinkingFilter.observedThinking,
+                )
+                return collected
+            } catch {
+                guard collected.isEmpty,
+                      let next = try nextCustomThinkingRetry(
+                          after: error,
+                          provider: provider,
+                          baseURL: baseURL,
+                          failedCandidate: usedCandidate,
+                          originalRequest: urlRequest,
+                          baseBody: baseBody,
+                      )
+                else {
+                    throw error
+                }
+                currentRequest = next.request
+                currentCandidate = next.candidate
             }
         }
-        recordCustomThinkingTuningSuccess(
-            provider: provider,
-            baseURL: baseURL,
-            candidate: stream.candidate,
-            containsThinking: observedReasoning || thinkingFilter.observedThinking,
-        )
-        return collected
     }
 
     private static func requestOpenAICompatible(

--- a/Sources/Typeflux/LLM/OpenAICompatibleResponseSupport.swift
+++ b/Sources/Typeflux/LLM/OpenAICompatibleResponseSupport.swift
@@ -209,6 +209,27 @@ enum OpenAICompatibleResponseSupport {
         return false
     }
 
+    static func streamError(from data: Data) -> Error? {
+        guard let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let error = object["error"] as? [String: Any]
+        else {
+            return nil
+        }
+
+        let message = (error["message"] as? String)
+            ?? (error["code"] as? String)
+            ?? "Unknown stream error"
+        let status = (error["status"] as? Int)
+            ?? (error["status_code"] as? Int)
+            ?? (error["code"] as? Int)
+            ?? 400
+        return NSError(
+            domain: "SSE",
+            code: status,
+            userInfo: [NSLocalizedDescriptionKey: "HTTP \(status): \(message)"],
+        )
+    }
+
     static func shouldDisableThinking(
         baseURL: URL,
         model: String,

--- a/Sources/Typeflux/LLM/OpenAICompatibleResponseSupport.swift
+++ b/Sources/Typeflux/LLM/OpenAICompatibleResponseSupport.swift
@@ -35,6 +35,7 @@ enum OpenAICompatibleResponseSupport {
 
         private var state: State = .initial
         private var buffer = ""
+        private(set) var observedThinking = false
 
         /// Feed the next streaming chunk. Returns the string to emit, or nil if suppressed.
         mutating func process(_ chunk: String) -> String? {
@@ -49,6 +50,7 @@ enum OpenAICompatibleResponseSupport {
 
                 let lower = trimmed.lowercased()
                 if lower.hasPrefix("<thinking>") || lower.hasPrefix("<think>") {
+                    observedThinking = true
                     state = .inThinkBlock
                     return drainThinkBlock()
                 } else {
@@ -88,8 +90,14 @@ enum OpenAICompatibleResponseSupport {
 
     // MARK: - Provider Tuning
 
-    static func applyProviderTuning(body: inout [String: Any], baseURL: URL, model: String) {
-        guard shouldDisableThinking(baseURL: baseURL, model: model) else { return }
+    static func applyProviderTuning(
+        body: inout [String: Any],
+        baseURL: URL,
+        model: String,
+        provider: LLMRemoteProvider? = nil,
+    ) {
+        guard provider != .custom else { return }
+        guard shouldDisableThinking(baseURL: baseURL, model: model, provider: provider) else { return }
         if shouldSendThinkingToggle(baseURL: baseURL, model: model) {
             body["thinking"] = ["type": "disabled"]
         }
@@ -120,6 +128,39 @@ enum OpenAICompatibleResponseSupport {
 
     static func applyAnthropicTuning(body: inout [String: Any]) {
         body["thinking"] = ["type": "disabled"]
+    }
+
+    static func removeCustomThinkingTuning(body: inout [String: Any]) {
+        for key in ["thinking", "enable_thinking", "reasoning", "include_reasoning"] {
+            body.removeValue(forKey: key)
+        }
+    }
+
+    static func shouldRetryWithoutCustomThinkingTuning(error: Error) -> Bool {
+        let nsError = error as NSError
+        guard nsError.domain == "LLM" || nsError.domain == "SSE" else { return false }
+        guard nsError.code == 400 || nsError.code == 422 else { return false }
+
+        let message = nsError.localizedDescription.lowercased()
+        let tuningKeys = ["thinking", "enable_thinking", "reasoning", "include_reasoning"]
+        let unsupportedParameterMarkers = [
+            "unknown parameter",
+            "unrecognized",
+            "unsupported parameter",
+            "invalid parameter",
+            "extra_forbidden",
+            "extra inputs are not permitted",
+            "not permitted",
+            "unexpected",
+        ]
+
+        return tuningKeys.contains(where: { message.contains($0) })
+            && unsupportedParameterMarkers.contains(where: { message.contains($0) })
+    }
+
+    static func containsLeadingThinkingTags(_ text: String) -> Bool {
+        let lower = text.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return lower.hasPrefix("<thinking>") || lower.hasPrefix("<think>")
     }
 
     static func extractTextDelta(from data: Data) -> String? {
@@ -168,7 +209,12 @@ enum OpenAICompatibleResponseSupport {
         return false
     }
 
-    static func shouldDisableThinking(baseURL: URL, model: String) -> Bool {
+    static func shouldDisableThinking(
+        baseURL: URL,
+        model: String,
+        provider: LLMRemoteProvider? = nil,
+    ) -> Bool {
+        if provider == .custom { return false }
         let host = baseURL.host?.lowercased() ?? ""
         let normalizedModel = model.lowercased()
         let disabledHosts = [

--- a/Sources/Typeflux/Settings/SettingsStore.swift
+++ b/Sources/Typeflux/Settings/SettingsStore.swift
@@ -546,8 +546,15 @@ final class SettingsStore {
     }
 
     func setLLMBaseURL(_ value: String, for provider: LLMRemoteProvider) {
-        if provider == .custom, value != llmBaseURL(for: provider) {
-            LLMThinkingTuningAdaptationStore(defaults: defaults).resetAll()
+        let previousValue = llmBaseURL(for: provider)
+        if provider == .custom, value != previousValue {
+            let store = LLMThinkingTuningAdaptationStore(defaults: defaults)
+            if let previousURL = URL(string: previousValue) {
+                store.reset(baseURL: previousURL)
+            }
+            if let nextURL = URL(string: value) {
+                store.reset(baseURL: nextURL)
+            }
         }
         defaults.set(value, forKey: llmRemoteKey(provider, suffix: "baseURL"))
         if provider == llmRemoteProvider {

--- a/Sources/Typeflux/Settings/SettingsStore.swift
+++ b/Sources/Typeflux/Settings/SettingsStore.swift
@@ -546,6 +546,9 @@ final class SettingsStore {
     }
 
     func setLLMBaseURL(_ value: String, for provider: LLMRemoteProvider) {
+        if provider == .custom, value != llmBaseURL(for: provider) {
+            LLMThinkingTuningAdaptationStore(defaults: defaults).resetAll()
+        }
         defaults.set(value, forKey: llmRemoteKey(provider, suffix: "baseURL"))
         if provider == llmRemoteProvider {
             defaults.set(value, forKey: "llm.baseURL")

--- a/Tests/TypefluxTests/LLMAgentResponseSupportTests.swift
+++ b/Tests/TypefluxTests/LLMAgentResponseSupportTests.swift
@@ -98,6 +98,26 @@ final class LLMAgentResponseSupportTests: XCTestCase {
         )
     }
 
+    func testExtractOpenAICompatibleTextReadsStructuredContent() throws {
+        let data = try jsonData([
+            "choices": [
+                [
+                    "message": [
+                        "content": [
+                            ["type": "text", "text": "<think>reasoning</think>"],
+                            ["type": "text", "text": "Final answer"],
+                        ],
+                    ],
+                ],
+            ],
+        ])
+
+        XCTAssertEqual(
+            LLMAgentResponseSupport.extractOpenAICompatibleText(from: data),
+            "<think>reasoning</think>Final answer",
+        )
+    }
+
     func testExtractAnthropicToolCall() throws {
         let data = try jsonData([
             "content": [

--- a/Tests/TypefluxTests/LLMMultiTurnServiceOpenAIParsingTests.swift
+++ b/Tests/TypefluxTests/LLMMultiTurnServiceOpenAIParsingTests.swift
@@ -177,6 +177,28 @@ final class LLMMultiTurnServiceOpenAIParsingTests: XCTestCase {
         XCTAssertEqual(text, "Final answer")
     }
 
+    func testParseOpenAITurnReadsStructuredContent() {
+        let data = jsonData([
+            "choices": [
+                [
+                    "message": [
+                        "role": "assistant",
+                        "content": [
+                            ["type": "text", "text": "<think>reasoning here</think>"],
+                            ["type": "text", "text": "Final answer"],
+                        ],
+                    ],
+                ],
+            ],
+        ])
+        let result = service.parseOpenAITurn(from: data)
+        guard case let .text(text) = result else {
+            XCTFail("Expected .text")
+            return
+        }
+        XCTAssertEqual(text, "Final answer")
+    }
+
     // MARK: - parseAnthropicTurn
 
     func testParseAnthropicTurnReturnsEmptyTextOnInvalidJSON() {

--- a/Tests/TypefluxTests/LLMThinkingTuningAdaptationTests.swift
+++ b/Tests/TypefluxTests/LLMThinkingTuningAdaptationTests.swift
@@ -1,0 +1,104 @@
+@testable import Typeflux
+import XCTest
+
+final class LLMThinkingTuningAdaptationTests: XCTestCase {
+    private var suiteName: String!
+    private var defaults: UserDefaults!
+    private var now: Date!
+    private var store: LLMThinkingTuningAdaptationStore!
+
+    override func setUp() {
+        super.setUp()
+        suiteName = "LLMThinkingTuningAdaptationTests-\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        now = Date(timeIntervalSince1970: 1_000)
+        store = LLMThinkingTuningAdaptationStore(defaults: defaults, now: { self.now })
+    }
+
+    override func tearDown() {
+        defaults.removePersistentDomain(forName: suiteName)
+        store = nil
+        defaults = nil
+        suiteName = nil
+        now = nil
+        super.tearDown()
+    }
+
+    func testStartsWithThinkingDisabledCandidate() throws {
+        let candidate = try XCTUnwrap(store.candidate(for: baseURL))
+
+        XCTAssertEqual(candidate.id, "thinking-disabled")
+        XCTAssertEqual((candidate.parameters["thinking"] as? [String: String])?["type"], "disabled")
+    }
+
+    func testLocksSuccessfulCandidate() throws {
+        let candidate = try XCTUnwrap(store.candidate(for: baseURL))
+
+        store.recordSuccess(baseURL: baseURL, candidate: candidate, containsThinking: false)
+
+        XCTAssertEqual(store.candidate(for: baseURL)?.id, candidate.id)
+        XCTAssertEqual(store.state(for: baseURL).mode, .locked)
+    }
+
+    func testUnsupportedParameterAdvancesToNextCandidate() throws {
+        let first = try XCTUnwrap(store.candidate(for: baseURL))
+
+        store.recordUnsupportedParameter(baseURL: baseURL, candidate: first)
+
+        XCTAssertEqual(store.candidate(for: baseURL)?.id, "enable-thinking-false")
+        XCTAssertEqual(store.state(for: baseURL).mode, .probing)
+    }
+
+    func testLockedCandidateRegressesWhenThinkingReturns() throws {
+        let first = try XCTUnwrap(store.candidate(for: baseURL))
+        store.recordSuccess(baseURL: baseURL, candidate: first, containsThinking: false)
+
+        store.recordSuccess(baseURL: baseURL, candidate: first, containsThinking: true)
+
+        XCTAssertEqual(store.state(for: baseURL).mode, .probing)
+        XCTAssertEqual(store.candidate(for: baseURL)?.id, "enable-thinking-false")
+        XCTAssertEqual(store.state(for: baseURL).failures.first?.reason, .regressed)
+    }
+
+    func testUnsupportedStateCoolsDownForTwentyFourHours() throws {
+        for candidate in LLMThinkingTuningCandidate.all {
+            store.recordUnsupportedParameter(baseURL: baseURL, candidate: candidate)
+        }
+
+        XCTAssertNil(store.candidate(for: baseURL))
+
+        now = now.addingTimeInterval(LLMThinkingTuningAdaptationStore.cooldownInterval + 1)
+
+        XCTAssertEqual(store.candidate(for: baseURL)?.id, "thinking-disabled")
+        XCTAssertEqual(store.state(for: baseURL).mode, .probing)
+    }
+
+    func testNormalizesEquivalentBaseURLs() throws {
+        let upper = try XCTUnwrap(URL(string: "https://EXAMPLE.com/v1/"))
+        let lower = try XCTUnwrap(URL(string: "https://example.com/v1"))
+
+        XCTAssertEqual(
+            LLMThinkingTuningAdaptationStore.normalizedBaseURLKey(upper),
+            LLMThinkingTuningAdaptationStore.normalizedBaseURLKey(lower),
+        )
+    }
+
+    func testSettingsStoreClearsAdaptationWhenCustomBaseURLChanges() throws {
+        let settings = SettingsStore(defaults: defaults)
+        settings.llmRemoteProvider = .custom
+        settings.setLLMBaseURL(baseURL.absoluteString, for: .custom)
+        let candidate = try XCTUnwrap(store.candidate(for: baseURL))
+        store.recordSuccess(baseURL: baseURL, candidate: candidate, containsThinking: false)
+        XCTAssertEqual(store.state(for: baseURL).mode, .locked)
+
+        settings.setLLMBaseURL("https://other.example.com/v1", for: .custom)
+
+        XCTAssertEqual(store.state(for: baseURL).mode, .probing)
+    }
+
+    private var baseURL: URL {
+        URL(string: "https://llm.example.com/v1")!
+    }
+
+}

--- a/Tests/TypefluxTests/LLMThinkingTuningAdaptationTests.swift
+++ b/Tests/TypefluxTests/LLMThinkingTuningAdaptationTests.swift
@@ -97,6 +97,26 @@ final class LLMThinkingTuningAdaptationTests: XCTestCase {
         XCTAssertEqual(store.state(for: baseURL).mode, .probing)
     }
 
+    func testSettingsStoreClearsOnlyPreviousAndNextCustomBaseURLStates() throws {
+        let settings = SettingsStore(defaults: defaults)
+        settings.llmRemoteProvider = .custom
+        let nextBaseURL = try XCTUnwrap(URL(string: "https://other.example.com/v1"))
+        let unrelatedBaseURL = try XCTUnwrap(URL(string: "https://unrelated.example.com/v1"))
+
+        settings.setLLMBaseURL(baseURL.absoluteString, for: .custom)
+        for url in [baseURL, nextBaseURL, unrelatedBaseURL] {
+            let candidate = try XCTUnwrap(store.candidate(for: url))
+            store.recordSuccess(baseURL: url, candidate: candidate, containsThinking: false)
+            XCTAssertEqual(store.state(for: url).mode, .locked)
+        }
+
+        settings.setLLMBaseURL(nextBaseURL.absoluteString, for: .custom)
+
+        XCTAssertEqual(store.state(for: baseURL).mode, .probing)
+        XCTAssertEqual(store.state(for: nextBaseURL).mode, .probing)
+        XCTAssertEqual(store.state(for: unrelatedBaseURL).mode, .locked)
+    }
+
     private var baseURL: URL {
         URL(string: "https://llm.example.com/v1")!
     }

--- a/Tests/TypefluxTests/OpenAICompatibleResponseSupportTests.swift
+++ b/Tests/TypefluxTests/OpenAICompatibleResponseSupportTests.swift
@@ -134,6 +134,19 @@ final class OpenAICompatibleResponseSupportTests: XCTestCase {
         XCTAssertTrue(OpenAICompatibleResponseSupport.shouldRetryWithoutCustomThinkingTuning(error: error))
     }
 
+    func testDetectsUnsupportedThinkingParameterStreamErrorEvents() throws {
+        let data = try jsonData([
+            "error": [
+                "message": "unknown parameter: thinking",
+                "status": 400,
+            ],
+        ])
+
+        let error = try XCTUnwrap(OpenAICompatibleResponseSupport.streamError(from: data))
+
+        XCTAssertTrue(OpenAICompatibleResponseSupport.shouldRetryWithoutCustomThinkingTuning(error: error))
+    }
+
     func testDoesNotRetryForUnrelatedCustomErrors() {
         let error = NSError(
             domain: "LLM",

--- a/Tests/TypefluxTests/OpenAICompatibleResponseSupportTests.swift
+++ b/Tests/TypefluxTests/OpenAICompatibleResponseSupportTests.swift
@@ -87,6 +87,63 @@ final class OpenAICompatibleResponseSupportTests: XCTestCase {
         XCTAssertEqual(body["include_reasoning"] as? Bool, false)
     }
 
+    func testProviderTuningDoesNotUseStaticRulesForCustomProvider() throws {
+        var body: [String: Any] = ["model": "private-model", "stream": true]
+        try OpenAICompatibleResponseSupport.applyProviderTuning(
+            body: &body,
+            baseURL: XCTUnwrap(URL(string: "https://llm.example.com/v1")),
+            model: "private-model",
+            provider: .custom,
+        )
+
+        XCTAssertNil(body["thinking"])
+        XCTAssertNil(body["enable_thinking"])
+        XCTAssertNil(body["reasoning"])
+        XCTAssertNil(body["include_reasoning"])
+        XCTAssertEqual(body["model"] as? String, "private-model")
+        XCTAssertEqual(body["stream"] as? Bool, true)
+    }
+
+    func testRemoveCustomThinkingTuningPreservesOtherBodyKeys() {
+        var body: [String: Any] = [
+            "model": "private-model",
+            "stream": true,
+            "thinking": ["type": "disabled"],
+            "enable_thinking": false,
+            "reasoning": ["effort": "none"],
+            "include_reasoning": false,
+        ]
+
+        OpenAICompatibleResponseSupport.removeCustomThinkingTuning(body: &body)
+
+        XCTAssertEqual(body["model"] as? String, "private-model")
+        XCTAssertEqual(body["stream"] as? Bool, true)
+        XCTAssertNil(body["thinking"])
+        XCTAssertNil(body["enable_thinking"])
+        XCTAssertNil(body["reasoning"])
+        XCTAssertNil(body["include_reasoning"])
+    }
+
+    func testDetectsUnsupportedThinkingParameterErrors() {
+        let error = NSError(
+            domain: "LLM",
+            code: 400,
+            userInfo: [NSLocalizedDescriptionKey: "HTTP 400: unknown parameter: enable_thinking"],
+        )
+
+        XCTAssertTrue(OpenAICompatibleResponseSupport.shouldRetryWithoutCustomThinkingTuning(error: error))
+    }
+
+    func testDoesNotRetryForUnrelatedCustomErrors() {
+        let error = NSError(
+            domain: "LLM",
+            code: 401,
+            userInfo: [NSLocalizedDescriptionKey: "HTTP 401: invalid api key"],
+        )
+
+        XCTAssertFalse(OpenAICompatibleResponseSupport.shouldRetryWithoutCustomThinkingTuning(error: error))
+    }
+
     func testProviderTuningUsesLowestOpenAIReasoningEffort() throws {
         var modernBody: [String: Any] = ["model": "gpt-5.4"]
         try OpenAICompatibleResponseSupport.applyProviderTuning(


### PR DESCRIPTION
## Summary
- Fixes TYP-105 by passing the selected LLM provider into OpenAI-compatible request tuning.
- Applies explicit thinking/reasoning disable flags for the custom LLM provider across rewrite, preview, JSON completion, agent tool, and multi-turn agent calls.
- Adds regression coverage for custom-provider tuning.

## How to test
- swift test --filter TypefluxTests.OpenAICompatibleResponseSupportTests

## Screenshots
- Not applicable; request-body behavior only.