### PR TITLE
fix: stop ASR billing errors from failing over

### DIFF
--- a/Sources/Typeflux/Networking/CloudRequestExecutor.swift
+++ b/Sources/Typeflux/Networking/CloudRequestExecutor.swift
@@ -124,6 +124,8 @@ struct CloudRequestExecutor: Sendable {
                 throw CancellationError()
             } catch let error as URLError where error.code == .cancelled {
                 throw CancellationError()
+            } catch let error where TypefluxCloudBillingError.fromError(error) != nil {
+                throw TypefluxCloudBillingError.fromError(error) ?? error
             } catch {
                 await selector.reportFailure(endpoint, error: error)
                 lastError = error

--- a/Sources/Typeflux/Networking/TypefluxCloudBillingError.swift
+++ b/Sources/Typeflux/Networking/TypefluxCloudBillingError.swift
@@ -69,6 +69,10 @@ struct TypefluxCloudBillingError: LocalizedError, Equatable {
         }
 
         let nsError = error as NSError
+        if let response = nsError.userInfo["NSErrorFailingURLResponseKey"] as? HTTPURLResponse,
+           response.statusCode == 402 {
+            return TypefluxCloudBillingError(reason: .subscriptionRequired, serverMessage: nsError.localizedDescription)
+        }
         if nsError.code == 402, let error = fromMessage(error.localizedDescription) {
             return error
         }

--- a/Sources/Typeflux/STT/Transcriber.swift
+++ b/Sources/Typeflux/STT/Transcriber.swift
@@ -315,6 +315,9 @@ final class STTRouter {
                         )
                     } catch {
                         NetworkDebugLogger.logError(context: "Typeflux Cloud fallback failed", error: error)
+                        if let billingError = TypefluxCloudBillingError.fromError(error) {
+                            throw billingError
+                        }
                         if settingsStore.useAppleSpeechFallback {
                             NetworkDebugLogger.logMessage(
                                 "Falling back to Apple Speech after Typeflux Cloud fallback failure",
@@ -438,6 +441,9 @@ final class STTRouter {
                 )
             } catch {
                 NetworkDebugLogger.logError(context: "Typeflux Official STT failed", error: error)
+                if let billingError = TypefluxCloudBillingError.fromError(error) {
+                    throw billingError
+                }
                 if let localResult = await transcribeWithAutoModelIfReady(audioFile: audioFile, onUpdate: onUpdate) {
                     NetworkDebugLogger.logMessage("Auto local model succeeded after Typeflux Official STT failure")
                     return localResult
@@ -492,6 +498,9 @@ final class STTRouter {
                     "Integrated Typeflux Cloud LLM failed after ASR completed; using transcript fallback",
                 )
                 return (transcript: integratedError.transcript, rewritten: nil)
+            }
+            if let billingError = TypefluxCloudBillingError.fromError(error) {
+                throw billingError
             }
             if let localResult = await transcribeWithAutoModelIfReady(audioFile: audioFile, onUpdate: onASRUpdate) {
                 NetworkDebugLogger.logMessage("Auto local model succeeded after integrated Typeflux Official failure")

--- a/Sources/Typeflux/STT/TypefluxOfficialTranscriber.swift
+++ b/Sources/Typeflux/STT/TypefluxOfficialTranscriber.swift
@@ -273,6 +273,8 @@ final class TypefluxOfficialTranscriber: TypefluxCloudScenarioAwareTranscriber, 
                 return try await operation(baseURL.absoluteString)
             } catch is CancellationError {
                 throw CancellationError()
+            } catch let error where TypefluxCloudBillingError.fromError(error) != nil {
+                throw TypefluxCloudBillingError.fromError(error) ?? error
             } catch let error as TypefluxOfficialASRError {
                 await CloudEndpointRegistry.shared.reportFailure(baseURL, error: error)
                 lastError = error
@@ -763,7 +765,9 @@ private actor TypefluxOfficialASRSession {
                     finalSegments: finalSegments
                 ) {
                     logger.error("WebSocket receive error: \(error.localizedDescription)")
-                    sessionError = sessionError ?? TypefluxOfficialASRError.unexpectedClose
+                    sessionError = sessionError
+                        ?? TypefluxCloudBillingError.fromError(error)
+                        ?? TypefluxOfficialASRError.unexpectedClose
                 }
                 completed = true
             }
@@ -949,7 +953,9 @@ private actor TypefluxOfficialRealtimePCMStream: PCM16RealtimeTranscriptionSessi
                        finalSegments: finalSegments,
                    ) {
                     logger.error("WebSocket receive error: \(error.localizedDescription)")
-                    sessionError = sessionError ?? TypefluxOfficialASRError.unexpectedClose
+                    sessionError = sessionError
+                        ?? TypefluxCloudBillingError.fromError(error)
+                        ?? TypefluxOfficialASRError.unexpectedClose
                 }
                 completed = true
             }

--- a/Tests/TypefluxTests/CloudRequestExecutorTests.swift
+++ b/Tests/TypefluxTests/CloudRequestExecutorTests.swift
@@ -101,6 +101,35 @@ final class CloudRequestExecutorTests: XCTestCase {
         XCTAssertEqual(calls, [urlA, urlB])
     }
 
+    func testExecuteDoesNotFailoverOrReportEndpointFailureOnBillingError() async throws {
+        let billingError = TypefluxCloudBillingError(reason: .subscriptionRequired, serverMessage: nil)
+        let session = StubSession()
+        await session.setHandler { _ in
+            throw billingError
+        }
+        let selector = CloudEndpointSelector(baseURLs: [urlA, urlB], prober: NoOpProber())
+        let executor = CloudRequestExecutor(selector: selector, session: session)
+
+        do {
+            _ = try await executor.execute(apiPath: "/api/v1/asr/aliyun/token") { base in
+                URLRequest(url: base.appendingPathComponent("api/v1/asr/aliyun/token"))
+            }
+            XCTFail("Expected billing error")
+        } catch let error as TypefluxCloudBillingError {
+            XCTAssertEqual(error, billingError)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+
+        let calls = await session.callOrder
+        XCTAssertEqual(calls, [urlA])
+        let status = await selector.snapshot()
+        XCTAssertEqual(status[0].consecutiveFailures, 0)
+        XCTAssertNil(status[0].lastError)
+        XCTAssertEqual(status[1].consecutiveFailures, 0)
+        XCTAssertNil(status[1].lastError)
+    }
+
     func testExecuteThrowsAllEndpointsFailedWhenEveryAttemptFails() async throws {
         let session = StubSession()
         await session.setHandler { request in

--- a/Tests/TypefluxTests/STTRouterTests.swift
+++ b/Tests/TypefluxTests/STTRouterTests.swift
@@ -334,6 +334,26 @@ final class STTRouterTests: XCTestCase {
         XCTAssertEqual(appleSpeech.transcribeCallCount, 0)
     }
 
+    func testTypefluxOfficialBillingFailureDoesNotFallBackToAppleSpeech() async throws {
+        let billingError = TypefluxCloudBillingError(reason: .subscriptionRequired, serverMessage: nil)
+        settings.sttProvider = .typefluxOfficial
+        settings.useAppleSpeechFallback = true
+        typefluxOfficial.errorToThrow = billingError
+        let router = makeRouter()
+
+        do {
+            _ = try await router.transcribe(audioFile: dummyAudioFile())
+            XCTFail("Expected billing error")
+        } catch let error as TypefluxCloudBillingError {
+            XCTAssertEqual(error, billingError)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+
+        XCTAssertEqual(typefluxOfficial.transcribeCallCount, 1)
+        XCTAssertEqual(appleSpeech.transcribeCallCount, 0)
+    }
+
     func testDoesNotUseTypefluxCloudForUnpreparedLocalModelWhenLoggedOut() async {
         settings.sttProvider = .localModel
         settings.useAppleSpeechFallback = false

--- a/Tests/TypefluxTests/TypefluxCloudServerErrorMessageTests.swift
+++ b/Tests/TypefluxTests/TypefluxCloudServerErrorMessageTests.swift
@@ -35,6 +35,22 @@ final class TypefluxCloudServerErrorMessageTests: XCTestCase {
         XCTAssertEqual(error?.reason, .subscriptionRequired)
     }
 
+    func testBillingErrorParsesFailingHTTP402ResponseFromNSError() throws {
+        let response = try XCTUnwrap(HTTPURLResponse(
+            url: URL(string: "https://api.example/asr")!,
+            statusCode: 402,
+            httpVersion: "HTTP/1.1",
+            headerFields: nil
+        ))
+        let error = NSError(
+            domain: NSURLErrorDomain,
+            code: URLError.badServerResponse.rawValue,
+            userInfo: ["NSErrorFailingURLResponseKey": response]
+        )
+
+        XCTAssertEqual(TypefluxCloudBillingError.fromError(error)?.reason, .subscriptionRequired)
+    }
+
     func testBillingErrorParsesQuotaAndPaymentCodes() {
         XCTAssertEqual(
             TypefluxCloudBillingError.fromServerCode("INSUFFICIENT_CREDITS", message: nil)?.reason,


### PR DESCRIPTION
## Summary

Fixes TYP-107.

- Stop `TypefluxCloudBillingError` from being treated as a cloud endpoint failure in `CloudRequestExecutor`.
- Stop Typeflux Official ASR WebSocket failover when billing denial errors are detected.
- Preserve Typeflux Official ASR billing denials in `STTRouter` instead of falling back to local/Apple Speech.
- Classify attached HTTP 402 WebSocket handshake failures as billing errors when Foundation exposes the failing response.
- Add focused regression tests for endpoint failover, STT fallback suppression, and HTTP 402 billing extraction.

## How to Test

```bash
swift test --filter TypefluxTests.CloudRequestExecutorTests --filter TypefluxTests.STTRouterTests --filter TypefluxTests.TypefluxOfficialASRRoutingClientTests --filter TypefluxTests.TypefluxOfficialTranscriberRoutingTests --filter TypefluxTests.TypefluxCloudServerErrorMessageTests
```

Result locally: 50 tests passed.

## Screenshots

N/A. No UI changes.

## Review

Please review billing/error propagation and fallback behavior, especially the WebSocket handshake 402 classification path.
