### PR TITLE
feat: add persona ID header for cloud rewrite

### DIFF
--- a/Sources/Typeflux/Networking/TypefluxCloudRequestHeaders.swift
+++ b/Sources/Typeflux/Networking/TypefluxCloudRequestHeaders.swift
@@ -120,6 +120,7 @@ enum TypefluxCloudRequestHeaders {
     static let clientOSField = "x-client-os"
     static let clientOSVersionField = "x-client-os-version"
     static let clientArchitectureField = "x-client-architecture"
+    static let personaIDField = "x-persona-id"
 
     static func applyScenario(_ scenario: TypefluxCloudScenario, to request: inout URLRequest) {
         request.setValue(scenario.rawValue, forHTTPHeaderField: scenarioField)
@@ -140,6 +141,11 @@ enum TypefluxCloudRequestHeaders {
         request.setValue(info.osName, forHTTPHeaderField: clientOSField)
         request.setValue(info.osVersion, forHTTPHeaderField: clientOSVersionField)
         request.setValue(info.architecture, forHTTPHeaderField: clientArchitectureField)
+    }
+
+    static func applyPersonaID(_ personaID: UUID?, to request: inout URLRequest) {
+        guard let personaID else { return }
+        request.setValue(personaID.uuidString, forHTTPHeaderField: personaIDField)
     }
 
     static func applyCloudHeaders(

--- a/Sources/Typeflux/STT/TypefluxOfficialTranscriber.swift
+++ b/Sources/Typeflux/STT/TypefluxOfficialTranscriber.swift
@@ -13,6 +13,15 @@ struct ASRLLMConfig: Encodable {
     /// User prompt template containing "{{transcript}}" as a placeholder for the
     /// final transcription text. The server substitutes it before calling the LLM.
     let userPromptTemplate: String
+    /// Stable identifier for the persona used to build the prompts. This is sent
+    /// as a request header only, not as part of the WebSocket start payload.
+    let personaID: UUID?
+
+    init(systemPrompt: String, userPromptTemplate: String, personaID: UUID? = nil) {
+        self.systemPrompt = systemPrompt
+        self.userPromptTemplate = userPromptTemplate
+        self.personaID = personaID
+    }
 
     enum CodingKeys: String, CodingKey {
         case systemPrompt = "system_prompt"
@@ -563,6 +572,7 @@ enum TypefluxOfficialASRRequestFactory {
         token: String,
         scenario: TypefluxCloudScenario,
         provider: String = "default",
+        personaID: UUID? = nil,
     ) throws -> URLRequest {
         let wsScheme = apiBaseURL.hasPrefix("https") ? "wss" : "ws"
         let host = apiBaseURL
@@ -577,6 +587,7 @@ enum TypefluxOfficialASRRequestFactory {
         var request = URLRequest(url: url)
         request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
         TypefluxCloudRequestHeaders.applyCloudHeaders(scenario: scenario, to: &request)
+        TypefluxCloudRequestHeaders.applyPersonaID(personaID, to: &request)
         return request
     }
 }
@@ -598,6 +609,7 @@ private actor TypefluxOfficialASRSession {
             token: token,
             scenario: scenario,
             provider: provider,
+            personaID: nil,
             onASRUpdate: onUpdate,
             llmConfig: nil,
             onLLMStart: nil,
@@ -623,6 +635,7 @@ private actor TypefluxOfficialASRSession {
             token: token,
             scenario: scenario,
             provider: "default",
+            personaID: llmConfig.personaID,
             onASRUpdate: onASRUpdate,
             llmConfig: llmConfig,
             onLLMStart: onLLMStart,
@@ -636,6 +649,7 @@ private actor TypefluxOfficialASRSession {
     private let token: String
     private let scenario: TypefluxCloudScenario
     private let provider: String
+    private let personaID: UUID?
     private let onASRUpdate: @Sendable (TranscriptionSnapshot) async -> Void
     private let llmConfig: ASRLLMConfig?
     private let onLLMStart: (@Sendable () async -> Void)?
@@ -654,6 +668,7 @@ private actor TypefluxOfficialASRSession {
         token: String,
         scenario: TypefluxCloudScenario,
         provider: String,
+        personaID: UUID?,
         onASRUpdate: @escaping @Sendable (TranscriptionSnapshot) async -> Void,
         llmConfig: ASRLLMConfig?,
         onLLMStart: (@Sendable () async -> Void)?,
@@ -664,6 +679,7 @@ private actor TypefluxOfficialASRSession {
         self.token = token
         self.scenario = scenario
         self.provider = provider
+        self.personaID = personaID
         self.onASRUpdate = onASRUpdate
         self.llmConfig = llmConfig
         self.onLLMStart = onLLMStart
@@ -676,6 +692,7 @@ private actor TypefluxOfficialASRSession {
             token: token,
             scenario: scenario,
             provider: provider,
+            personaID: personaID,
         )
         let session = URLSession(configuration: .default)
         let socketTask = session.webSocketTask(with: request)

--- a/Sources/Typeflux/Workflow/WorkflowController+Processing.swift
+++ b/Sources/Typeflux/Workflow/WorkflowController+Processing.swift
@@ -442,9 +442,12 @@ extension WorkflowController {
                 ? askContextText(from: selectionSnapshot, inputContext: inputContext)
                 : nil
             currentSelectedText = selectedText
-            let personaPrompt = recordingIntent == .askSelection
+            let activePersonaProfile = recordingIntent == .askSelection
                 ? nil
-                : activePersonaPrompt(selectionSnapshot: selectionSnapshot, inputContext: inputContext)
+                : activePersona(selectionSnapshot: selectionSnapshot, inputContext: inputContext)
+            let personaPrompt = activePersonaProfile.map {
+                settingsStore.resolvedPersonaPrompt(for: $0)
+            }
 
             NetworkDebugLogger.logMessage(selectionSnapshotLog(selectionSnapshot))
             if WorkflowOverlayPresentationPolicy.shouldShowProcessingAfterRecording() {
@@ -498,6 +501,7 @@ extension WorkflowController {
                     askContextText: askContextText,
                     inputContext: inputContext,
                     personaPrompt: personaPrompt,
+                    personaID: activePersonaProfile?.id,
                     recordingIntent: recordingIntent,
                     sessionID: sessionID,
                     recordingPreviewText: recordingPreviewText,
@@ -615,6 +619,7 @@ extension WorkflowController {
         askContextText: String?,
         inputContext: InputContextSnapshot?,
         personaPrompt: String?,
+        personaID: UUID? = nil,
         recordingIntent: RecordingIntent,
         sessionID: UUID,
         forceResultDialogOnSuccess: Bool = false,
@@ -680,6 +685,7 @@ extension WorkflowController {
                 let mergedResult = try await performMergedCloudTranscription(
                     audioFile: audioFile,
                     personaPrompt: resolvedPersonaPrompt,
+                    personaID: personaID,
                     selectionSnapshot: selectionSnapshot,
                     cloudScenario: cloudScenario,
                     sessionID: sessionID,
@@ -1319,6 +1325,7 @@ extension WorkflowController {
     /// placeholder for the actual transcript text.
     private func buildASRLLMConfig(
         personaPrompt: String,
+        personaID: UUID?,
         selectionSnapshot: TextSelectionSnapshot,
     ) -> ASRLLMConfig {
         let placeholderRequest = LLMRewriteRequest(
@@ -1346,6 +1353,7 @@ extension WorkflowController {
         return ASRLLMConfig(
             systemPrompt: effectiveSystemPrompt,
             userPromptTemplate: prompts.user,
+            personaID: personaID,
         )
     }
 
@@ -1355,11 +1363,16 @@ extension WorkflowController {
     private func performMergedCloudTranscription(
         audioFile: AudioFile,
         personaPrompt: String,
+        personaID: UUID?,
         selectionSnapshot: TextSelectionSnapshot,
         cloudScenario: TypefluxCloudScenario,
         sessionID: UUID,
     ) async throws -> (transcript: String, rewritten: String?) {
-        let llmConfig = buildASRLLMConfig(personaPrompt: personaPrompt, selectionSnapshot: selectionSnapshot)
+        let llmConfig = buildASRLLMConfig(
+            personaPrompt: personaPrompt,
+            personaID: personaID,
+            selectionSnapshot: selectionSnapshot,
+        )
         let llmBuffer = LLMStreamBuffer()
         let suppressStreamingPreview = shouldSuppressPostRecordingStreamingPreviewForCurrentSTTProvider
 
@@ -1718,7 +1731,17 @@ extension WorkflowController {
         selectionSnapshot: TextSelectionSnapshot,
         inputContext: InputContextSnapshot?,
     ) -> String? {
-        settingsStore.effectivePersonaPrompt(
+        guard let persona = activePersona(selectionSnapshot: selectionSnapshot, inputContext: inputContext) else {
+            return nil
+        }
+        return settingsStore.resolvedPersonaPrompt(for: persona)
+    }
+
+    func activePersona(
+        selectionSnapshot: TextSelectionSnapshot,
+        inputContext: InputContextSnapshot?,
+    ) -> PersonaProfile? {
+        settingsStore.effectivePersona(
             appName: inputContext?.appName ?? selectionSnapshot.processName,
             bundleIdentifier: inputContext?.bundleIdentifier ?? selectionSnapshot.bundleIdentifier,
         )

--- a/Tests/TypefluxTests/SettingsStorePersonaTests.swift
+++ b/Tests/TypefluxTests/SettingsStorePersonaTests.swift
@@ -17,6 +17,21 @@ final class SettingsStorePersonaTests: XCTestCase {
         XCTAssertTrue(translatorPersona.prompt.contains("always produce the final output in natural English"))
     }
 
+    func testBuiltInPersonasUseStableCloudIdentifiers() throws {
+        let suiteName = "SettingsStorePersonaTests.stableIDs.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+        let store = SettingsStore(defaults: defaults)
+
+        let typefluxPersona = try XCTUnwrap(store.personas.first(where: { $0.name == "Typeflux" }))
+        let translatorPersona = try XCTUnwrap(store.personas.first(where: { $0.name == "English Translator" }))
+
+        XCTAssertEqual(typefluxPersona.id, UUID(uuidString: "2A7A4A74-A8AC-4F3C-9FB1-5A433EDFA001"))
+        XCTAssertEqual(translatorPersona.id, UUID(uuidString: "2A7A4A74-A8AC-4F3C-9FB1-5A433EDFA002"))
+        XCTAssertTrue(typefluxPersona.isSystem)
+        XCTAssertTrue(translatorPersona.isSystem)
+    }
+
     func testResolvedTypefluxPersonaUsesAppLanguagePrompt() throws {
         let suiteName = "SettingsStorePersonaTests.localizedTypeflux.\(UUID().uuidString)"
         let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))

--- a/Tests/TypefluxTests/TypefluxCloudRequestHeadersTests.swift
+++ b/Tests/TypefluxTests/TypefluxCloudRequestHeadersTests.swift
@@ -59,6 +59,26 @@ final class TypefluxCloudRequestHeadersTests: XCTestCase {
         XCTAssertNil(headers["User-Agent"])
         XCTAssertNil(headers[TypefluxCloudRequestHeaders.clientIDField])
     }
+
+    func testApplyPersonaIDAddsPersonaHeader() {
+        let personaID = UUID(uuidString: "2A7A4A74-A8AC-4F3C-9FB1-5A433EDFA001")!
+        var request = URLRequest(url: URL(string: "https://cloud.typeflux.dev/api/v1/asr/ws/default")!)
+
+        TypefluxCloudRequestHeaders.applyPersonaID(personaID, to: &request)
+
+        XCTAssertEqual(
+            request.value(forHTTPHeaderField: TypefluxCloudRequestHeaders.personaIDField),
+            personaID.uuidString,
+        )
+    }
+
+    func testApplyPersonaIDSkipsNilPersonaID() {
+        var request = URLRequest(url: URL(string: "https://cloud.typeflux.dev/api/v1/asr/ws/default")!)
+
+        TypefluxCloudRequestHeaders.applyPersonaID(nil, to: &request)
+
+        XCTAssertNil(request.value(forHTTPHeaderField: TypefluxCloudRequestHeaders.personaIDField))
+    }
 }
 
 private extension TypefluxCloudClientInfoProvider {

--- a/Tests/TypefluxTests/TypefluxOfficialTranscriberTests.swift
+++ b/Tests/TypefluxTests/TypefluxOfficialTranscriberTests.swift
@@ -19,6 +19,22 @@ final class TypefluxOfficialTranscriberTests: XCTestCase {
         XCTAssertNotNil(request.value(forHTTPHeaderField: TypefluxCloudRequestHeaders.clientIDField))
     }
 
+    func testWebSocketRequestIncludesPersonaIDHeaderWhenProvided() throws {
+        let personaID = SettingsStore.defaultPersonaID
+
+        let request = try TypefluxOfficialASRRequestFactory.makeWebSocketRequest(
+            apiBaseURL: "https://cloud.typeflux.dev",
+            token: "token-123",
+            scenario: .voiceInput,
+            personaID: personaID,
+        )
+
+        XCTAssertEqual(
+            request.value(forHTTPHeaderField: TypefluxCloudRequestHeaders.personaIDField),
+            personaID.uuidString,
+        )
+    }
+
     func testReceiveFailureIsUnexpectedBeforeCompletionWithoutFinalSegments() {
         XCTAssertTrue(
             TypefluxOfficialASRClosePolicy.shouldTreatReceiveFailureAsUnexpectedClose(

--- a/Tests/TypefluxTests/WorkflowControllerProcessingTests.swift
+++ b/Tests/TypefluxTests/WorkflowControllerProcessingTests.swift
@@ -164,6 +164,38 @@ final class WorkflowControllerProcessingTests: XCTestCase {
         XCTAssertEqual(personaPrompt, customPersona.prompt)
     }
 
+    func testActivePersonaUsesFocusedAppBindingPersonaID() {
+        let appPersona = PersonaProfile(name: "Chat Reply", prompt: "Keep it warm and casual.")
+        let controller = makeWorkflowController(configureSettings: { settingsStore in
+            let globalPersona = settingsStore.personas[0]
+            settingsStore.personas = settingsStore.personas + [appPersona]
+            settingsStore.applyPersonaSelection(globalPersona.id)
+            settingsStore.savePersonaAppBinding(
+                appIdentifier: "com.tinyspeck.slackmacgap",
+                personaID: appPersona.id,
+            )
+        })
+        let selectionSnapshot = TextSelectionSnapshot(
+            processID: 1,
+            processName: "Slack",
+            bundleIdentifier: "com.tinyspeck.slackmacgap",
+            selectedRange: nil,
+            selectedText: nil,
+            source: "accessibility",
+            isEditable: true,
+            role: "AXTextArea",
+            windowTitle: "DM",
+            isFocusedTarget: true,
+        )
+
+        let persona = controller.activePersona(
+            selectionSnapshot: selectionSnapshot,
+            inputContext: nil,
+        )
+
+        XCTAssertEqual(persona?.id, appPersona.id)
+    }
+
     func testActivePersonaPromptUsesNoPersonaAppBindingOverDefaultPersona() {
         let controller = makeWorkflowController(configureSettings: { settingsStore in
             let defaultPersona = settingsStore.personas[0]


### PR DESCRIPTION
## Summary

- References TYP-110.
- Adds `x-persona-id` support to Typeflux Cloud request headers.
- Carries the active persona ID through Typeflux Official merged ASR+LLM WebSocket requests.
- Resolves the active persona profile once so the prompt and header ID stay aligned, including app-specific persona bindings.
- Adds tests for stable built-in persona UUIDs, header emission, WebSocket propagation, and app-binding precedence.

## How to test

- `swift test --filter TypefluxTests.TypefluxCloudRequestHeadersTests --filter TypefluxTests.TypefluxOfficialTranscriberTests --filter TypefluxTests.SettingsStorePersonaTests --filter TypefluxTests.WorkflowControllerProcessingTests`
- `git diff --check`

## Notes

- `make format` could not be run in the Paperclip worktree because `swiftformat` is not installed there (`swiftformat: command not found`).
- No screenshots; no UI changes.
