### PR TITLE
fix: include persona ID on cloud LLM rewrites

### DIFF
--- a/Sources/Typeflux/Batch/TypefluxBatchCommand.swift
+++ b/Sources/Typeflux/Batch/TypefluxBatchCommand.swift
@@ -435,6 +435,7 @@ private final class SingleAudioProcessor {
             finalText = try await rewrite(
                 transcript: transcript,
                 personaPrompt: trimmedPersona,
+                personaID: persona.id,
                 llmService: llmService,
             )
             llmMilliseconds = milliseconds(since: llmStartedAt)
@@ -599,12 +600,18 @@ private final class SingleAudioProcessor {
         return AudioFile(fileURL: url, duration: duration)
     }
 
-    private func rewrite(transcript: String, personaPrompt: String, llmService: LLMService) async throws -> String {
+    private func rewrite(
+        transcript: String,
+        personaPrompt: String,
+        personaID: UUID?,
+        llmService: LLMService,
+    ) async throws -> String {
         let request = LLMRewriteRequest(
             mode: .rewriteTranscript,
             sourceText: transcript,
             spokenInstruction: nil,
             personaPrompt: personaPrompt,
+            personaID: personaID,
             vocabularyTerms: VocabularyStore.activeTerms(),
         )
 
@@ -765,6 +772,7 @@ private final class WAVPersonaBenchmark {
                     record.personaResult = try await rewrite(
                         transcript: transcript,
                         personaPrompt: persona.prompt,
+                        personaID: persona.id,
                         llmService: llmService,
                     )
                     record.llmMilliseconds = milliseconds(since: startedAt)
@@ -843,9 +851,9 @@ private final class WAVPersonaBenchmark {
         )
     }
 
-    private func resolvePersona(settingsStore: SettingsStore) throws -> (name: String, prompt: String) {
+    private func resolvePersona(settingsStore: SettingsStore) throws -> (name: String, prompt: String, id: UUID?) {
         if config.noPersona {
-            return ("none", "")
+            return ("none", "", nil)
         }
 
         switch config.personaSelector {
@@ -853,20 +861,20 @@ private final class WAVPersonaBenchmark {
             guard let persona = settingsStore.personas.first(where: { $0.id == id }) else {
                 throw BatchCommandError(message: "No saved persona found for id: \(id.uuidString)")
             }
-            return (persona.name, settingsStore.resolvedPersonaPrompt(for: persona))
+            return (persona.name, settingsStore.resolvedPersonaPrompt(for: persona), persona.id)
         case .name(let name):
             guard let persona = settingsStore.personas.first(where: { $0.name == name }) else {
                 throw BatchCommandError(message: "No saved persona found named: \(name)")
             }
-            return (persona.name, settingsStore.resolvedPersonaPrompt(for: persona))
+            return (persona.name, settingsStore.resolvedPersonaPrompt(for: persona), persona.id)
         case .promptFile(let url):
             let prompt = try String(contentsOf: url, encoding: .utf8)
-            return (url.lastPathComponent, prompt)
+            return (url.lastPathComponent, prompt, nil)
         case .none:
             guard let persona = settingsStore.activePersona else {
-                return ("none", "")
+                return ("none", "", nil)
             }
-            return (persona.name, settingsStore.resolvedPersonaPrompt(for: persona))
+            return (persona.name, settingsStore.resolvedPersonaPrompt(for: persona), persona.id)
         }
     }
 
@@ -900,12 +908,18 @@ private final class WAVPersonaBenchmark {
         return AudioFile(fileURL: url, duration: duration)
     }
 
-    private func rewrite(transcript: String, personaPrompt: String, llmService: LLMService) async throws -> String {
+    private func rewrite(
+        transcript: String,
+        personaPrompt: String,
+        personaID: UUID?,
+        llmService: LLMService,
+    ) async throws -> String {
         let request = LLMRewriteRequest(
             mode: .rewriteTranscript,
             sourceText: transcript,
             spokenInstruction: nil,
             personaPrompt: personaPrompt,
+            personaID: personaID,
             vocabularyTerms: VocabularyStore.activeTerms(),
         )
 

--- a/Sources/Typeflux/LLM/LLMRewriteRequest.swift
+++ b/Sources/Typeflux/LLM/LLMRewriteRequest.swift
@@ -33,6 +33,7 @@ struct LLMRewriteRequest {
     let sourceText: String
     let spokenInstruction: String?
     let personaPrompt: String?
+    let personaID: UUID?
     let appSystemContext: AppSystemContext?
     let inputContext: InputContextSnapshot?
     let vocabularyTerms: [String]
@@ -42,6 +43,7 @@ struct LLMRewriteRequest {
         sourceText: String,
         spokenInstruction: String?,
         personaPrompt: String?,
+        personaID: UUID? = nil,
         appSystemContext: AppSystemContext? = nil,
         inputContext: InputContextSnapshot? = nil,
         vocabularyTerms: [String] = [],
@@ -50,6 +52,7 @@ struct LLMRewriteRequest {
         self.sourceText = sourceText
         self.spokenInstruction = spokenInstruction
         self.personaPrompt = personaPrompt
+        self.personaID = personaID
         self.appSystemContext = appSystemContext
         self.inputContext = inputContext
         self.vocabularyTerms = vocabularyTerms

--- a/Sources/Typeflux/LLM/OpenAICompatibleLLMService.swift
+++ b/Sources/Typeflux/LLM/OpenAICompatibleLLMService.swift
@@ -164,8 +164,9 @@ final class OpenAICompatibleLLMService: LLMService {
     private func headers(
         for connection: ResolvedLLMConnection,
         scenario: TypefluxCloudScenario,
+        personaID: UUID? = nil,
     ) -> [String: String] {
-        connection.headers(for: scenario)
+        connection.headers(for: scenario, personaID: personaID)
     }
 
     func streamRewrite(request rewriteRequest: LLMRewriteRequest) -> AsyncThrowingStream<String, Error> {
@@ -262,7 +263,7 @@ final class OpenAICompatibleLLMService: LLMService {
     ) async throws -> String {
         let llmConfig = settingsStore.textLLMConfiguration()
         let call = try await resolveConnection(for: llmConfig)
-        let additionalHeaders = headers(for: call.connection, scenario: .textRewrite)
+        let additionalHeaders = headers(for: call.connection, scenario: .textRewrite, personaID: rewriteRequest.personaID)
 
         let prompts = PromptCatalog.rewritePrompts(for: rewriteRequest)
         var effectiveSystemPrompt = PromptCatalog.appendUserEnvironmentContext(

--- a/Sources/Typeflux/Networking/TypefluxCloudRequestHeaders.swift
+++ b/Sources/Typeflux/Networking/TypefluxCloudRequestHeaders.swift
@@ -148,6 +148,18 @@ enum TypefluxCloudRequestHeaders {
         request.setValue(personaID.uuidString, forHTTPHeaderField: personaIDField)
     }
 
+    static func applyingPersonaID(
+        _ personaID: UUID?,
+        to headers: [String: String] = [:],
+        provider: LLMRemoteProvider,
+    ) -> [String: String] {
+        guard provider == .typefluxCloud, let personaID else { return headers }
+
+        var merged = headers
+        merged[personaIDField] = personaID.uuidString
+        return merged
+    }
+
     static func applyCloudHeaders(
         scenario: TypefluxCloudScenario,
         to request: inout URLRequest,
@@ -191,10 +203,15 @@ enum TypefluxCloudRequestHeaders {
 }
 
 extension ResolvedLLMConnection {
-    func headers(for scenario: TypefluxCloudScenario) -> [String: String] {
-        TypefluxCloudRequestHeaders.applyingScenario(
+    func headers(for scenario: TypefluxCloudScenario, personaID: UUID? = nil) -> [String: String] {
+        let scenarioHeaders = TypefluxCloudRequestHeaders.applyingScenario(
             scenario,
             to: additionalHeaders,
+            provider: provider,
+        )
+        return TypefluxCloudRequestHeaders.applyingPersonaID(
+            personaID,
+            to: scenarioHeaders,
             provider: provider,
         )
     }

--- a/Sources/Typeflux/Workflow/WorkflowController+Persona.swift
+++ b/Sources/Typeflux/Workflow/WorkflowController+Persona.swift
@@ -203,6 +203,7 @@ extension WorkflowController {
                         sourceText: context.selectedText,
                         spokenInstruction: nil,
                         personaPrompt: personaPrompt,
+                        personaID: persona.id,
                         appSystemContext: AppSystemContext(snapshot: context.snapshot),
                     ),
                     sessionID: sessionID,

--- a/Sources/Typeflux/Workflow/WorkflowController+Processing.swift
+++ b/Sources/Typeflux/Workflow/WorkflowController+Processing.swift
@@ -762,6 +762,7 @@ extension WorkflowController {
                 try await processPersonaRewriteFlow(
                     transcribedText: transcribedText,
                     personaPrompt: personaPrompt ?? "",
+                    personaID: personaID,
                     selectionSnapshot: selectionSnapshot,
                     inputContext: inputContext,
                     multimodalHandlesPersona: multimodalHandlesPersona && !hasInputContext,
@@ -1333,6 +1334,7 @@ extension WorkflowController {
             sourceText: "{{transcript}}",
             spokenInstruction: nil,
             personaPrompt: personaPrompt,
+            personaID: personaID,
             appSystemContext: AppSystemContext(snapshot: selectionSnapshot),
             vocabularyTerms: VocabularyStore.activeTerms(),
         )
@@ -1406,6 +1408,7 @@ extension WorkflowController {
     private func processPersonaRewriteFlow(
         transcribedText: String,
         personaPrompt: String,
+        personaID: UUID?,
         selectionSnapshot: TextSelectionSnapshot,
         inputContext: InputContextSnapshot?,
         multimodalHandlesPersona: Bool,
@@ -1462,6 +1465,7 @@ extension WorkflowController {
                         sourceText: transcribedText,
                         spokenInstruction: nil,
                         personaPrompt: personaPrompt,
+                        personaID: personaID,
                         appSystemContext: AppSystemContext(snapshot: selectionSnapshot),
                         inputContext: inputContext,
                         vocabularyTerms: VocabularyStore.activeTerms(),

--- a/Tests/TypefluxTests/LLMConnectionResolverTests.swift
+++ b/Tests/TypefluxTests/LLMConnectionResolverTests.swift
@@ -225,6 +225,23 @@ extension LLMConnectionResolverTests {
         XCTAssertEqual(headers[TypefluxCloudRequestHeaders.scenarioField], TypefluxCloudScenario.askAnything.rawValue)
     }
 
+    func testTypefluxCloudHeadersIncludePersonaIDWhenProvided() {
+        let personaID = UUID(uuidString: "2A7A4A74-A8AC-4F3C-9FB1-5A433EDFA001")!
+        let connection = ResolvedLLMConnection(
+            provider: .typefluxCloud,
+            baseURL: URL(string: "https://api.typeflux.dev/api/v1")!,
+            model: "default",
+            apiKey: "token",
+            additionalHeaders: ["x-request-id": "req-1"],
+        )
+
+        let headers = connection.headers(for: .textRewrite, personaID: personaID)
+
+        XCTAssertEqual(headers["x-request-id"], "req-1")
+        XCTAssertEqual(headers[TypefluxCloudRequestHeaders.scenarioField], TypefluxCloudScenario.textRewrite.rawValue)
+        XCTAssertEqual(headers[TypefluxCloudRequestHeaders.personaIDField], personaID.uuidString)
+    }
+
     func testNonTypefluxCloudHeadersDoNotInjectScenario() {
         let connection = ResolvedLLMConnection(
             provider: .openAI,
@@ -238,6 +255,7 @@ extension LLMConnectionResolverTests {
 
         XCTAssertEqual(headers["x-request-id"], "req-1")
         XCTAssertNil(headers[TypefluxCloudRequestHeaders.scenarioField])
+        XCTAssertNil(headers[TypefluxCloudRequestHeaders.personaIDField])
     }
 
     // MARK: - Free model whitespace handling

--- a/Tests/TypefluxTests/LLMRewriteRequestTests.swift
+++ b/Tests/TypefluxTests/LLMRewriteRequestTests.swift
@@ -11,17 +11,20 @@ final class LLMRewriteRequestTests: XCTestCase {
     }
 
     func testCanCreateRequestWithAllParameters() {
+        let personaID = UUID(uuidString: "2A7A4A74-A8AC-4F3C-9FB1-5A433EDFA001")!
         let request = LLMRewriteRequest(
             mode: .editSelection,
             sourceText: "source",
             spokenInstruction: "make it better",
             personaPrompt: "formal tone",
+            personaID: personaID,
             vocabularyTerms: ["Typeflux"],
         )
 
         XCTAssertEqual(request.sourceText, "source")
         XCTAssertEqual(request.spokenInstruction, "make it better")
         XCTAssertEqual(request.personaPrompt, "formal tone")
+        XCTAssertEqual(request.personaID, personaID)
         XCTAssertEqual(request.vocabularyTerms, ["Typeflux"])
     }
 
@@ -36,6 +39,7 @@ final class LLMRewriteRequestTests: XCTestCase {
         XCTAssertEqual(request.sourceText, "raw text")
         XCTAssertNil(request.spokenInstruction)
         XCTAssertNil(request.personaPrompt)
+        XCTAssertNil(request.personaID)
         XCTAssertTrue(request.vocabularyTerms.isEmpty)
     }
 

--- a/Tests/TypefluxTests/TypefluxCloudRequestHeadersTests.swift
+++ b/Tests/TypefluxTests/TypefluxCloudRequestHeadersTests.swift
@@ -79,6 +79,26 @@ final class TypefluxCloudRequestHeadersTests: XCTestCase {
 
         XCTAssertNil(request.value(forHTTPHeaderField: TypefluxCloudRequestHeaders.personaIDField))
     }
+
+    func testApplyingPersonaIDMergesOnlyForTypefluxCloud() {
+        let personaID = UUID(uuidString: "2A7A4A74-A8AC-4F3C-9FB1-5A433EDFA001")!
+
+        let cloudHeaders = TypefluxCloudRequestHeaders.applyingPersonaID(
+            personaID,
+            to: ["x-request-id": "req-1"],
+            provider: .typefluxCloud,
+        )
+        let openAIHeaders = TypefluxCloudRequestHeaders.applyingPersonaID(
+            personaID,
+            to: ["x-request-id": "req-1"],
+            provider: .openAI,
+        )
+
+        XCTAssertEqual(cloudHeaders["x-request-id"], "req-1")
+        XCTAssertEqual(cloudHeaders[TypefluxCloudRequestHeaders.personaIDField], personaID.uuidString)
+        XCTAssertEqual(openAIHeaders["x-request-id"], "req-1")
+        XCTAssertNil(openAIHeaders[TypefluxCloudRequestHeaders.personaIDField])
+    }
 }
 
 private extension TypefluxCloudClientInfoProvider {


### PR DESCRIPTION
## Summary
- Thread personaID through non-merged Typeflux Cloud LLM rewrite requests.
- Add x-persona-id to Typeflux Cloud LLM headers when a persona is active.
- Cover selection persona application and batch rewrite flows.

## How to test
- swift test --filter TypefluxTests.LLMRewriteRequestTests --filter TypefluxTests.LLMConnectionResolverTests --filter TypefluxTests.TypefluxCloudRequestHeadersTests
- git diff --check

Refs TYP-110