### PR TITLE
fix: enforce settings window minimum size

### DIFF
--- a/Sources/Typeflux/Settings/SettingsWindowController.swift
+++ b/Sources/Typeflux/Settings/SettingsWindowController.swift
@@ -94,10 +94,12 @@ final class SettingsWindowController: NSObject {
         window.contentView = hosting
         window.isReleasedWhenClosed = false
         window.delegate = self
-        window.minSize = NSSize(
+        let minimumWindowSize = NSSize(
             width: StudioTheme.Layout.settingsWindowMinWidth,
             height: StudioTheme.Layout.settingsWindowMinHeight
         )
+        window.minSize = minimumWindowSize
+        window.contentMinSize = minimumWindowSize
         window.appearance = AppAppearance.nsAppearance(for: settingsStore.appearanceMode)
 
         self.viewModel = viewModel

--- a/Sources/Typeflux/UI/StudioTheme.swift
+++ b/Sources/Typeflux/UI/StudioTheme.swift
@@ -18,7 +18,7 @@ enum StudioTheme {
         static let contentInset: CGFloat = 24
         static let settingsWindowWidth: CGFloat = 1100
         static let settingsWindowHeight: CGFloat = 800
-        static let settingsWindowMinWidth: CGFloat = 1080
+        static let settingsWindowMinWidth: CGFloat = 1100
         static let settingsWindowMinHeight: CGFloat = 620
         static let overlayWidth: CGFloat = 320
         static let overlayHeight: CGFloat = 92

--- a/Tests/TypefluxTests/StudioThemeTests.swift
+++ b/Tests/TypefluxTests/StudioThemeTests.swift
@@ -24,6 +24,18 @@ final class StudioThemeTests: XCTestCase {
         XCTAssertEqual(StudioTheme.Layout.settingsWindowWidth, 1100)
     }
 
+    func testSettingsWindowMinimumWidthKeepsOverviewOutOfCompactLayout() {
+        let minimumContentWidth = StudioTheme.Layout.settingsWindowMinWidth
+            - StudioTheme.Layout.sidebarWidth
+            - StudioTheme.Layout.contentInset * 2
+
+        XCTAssertEqual(StudioTheme.Layout.settingsWindowMinWidth, StudioTheme.Layout.settingsWindowWidth)
+        XCTAssertGreaterThanOrEqual(
+            minimumContentWidth,
+            StudioOverviewPanelLayoutCalculator.compactBreakpoint
+        )
+    }
+
     func testOverlayWidth() {
         XCTAssertEqual(StudioTheme.Layout.overlayWidth, 320)
     }


### PR DESCRIPTION
## Summary

- Follow-up for TYP-115 after review feedback requested restricting the minimum settings window size.
- Raises `settingsWindowMinWidth` to match the default `1100pt` window width.
- Applies the minimum as both `NSWindow.minSize` and `NSWindow.contentMinSize` so AppKit prevents resizing the settings content below the supported layout width.
- Adds a regression test ensuring the minimum window width keeps the overview content at or above its non-compact breakpoint.

## How to test

- `swift test --filter TypefluxTests.StudioThemeTests`

## Screenshots

Not included; this is an AppKit minimum-window-size guard.
