### PR TITLE
feat(workflow): optimize credit exhausted handling

### DIFF
--- a/Sources/Typeflux/Networking/TypefluxCloudBillingError.swift
+++ b/Sources/Typeflux/Networking/TypefluxCloudBillingError.swift
@@ -27,6 +27,43 @@ struct TypefluxCloudBillingError: LocalizedError, Equatable {
         }
     }
 
+    func title(hasPaidSubscription: Bool) -> String {
+        switch reason {
+        case .subscriptionRequired:
+            L("cloud.billing.subscriptionRequired.title")
+        case .quotaExceeded:
+            hasPaidSubscription
+                ? L("cloud.billing.quotaExceeded.title")
+                : L("cloud.billing.subscriptionRequired.title")
+        }
+    }
+
+    func message(hasPaidSubscription: Bool) -> String {
+        switch reason {
+        case .subscriptionRequired:
+            L("cloud.billing.subscriptionRequired.body")
+        case .quotaExceeded:
+            hasPaidSubscription
+                ? L("cloud.billing.quotaExceeded.body")
+                : L("cloud.billing.subscriptionRequired.body")
+        }
+    }
+
+    var primaryActionTitle: String {
+        primaryActionTitle(hasPaidSubscription: false)
+    }
+
+    func primaryActionTitle(hasPaidSubscription: Bool) -> String {
+        switch reason {
+        case .subscriptionRequired:
+            L("cloud.billing.action.subscribe")
+        case .quotaExceeded:
+            hasPaidSubscription
+                ? L("cloud.billing.action.openAccount")
+                : L("cloud.billing.action.subscribe")
+        }
+    }
+
     static func fromServerCode(_ code: String, message: String?) -> TypefluxCloudBillingError? {
         let normalizedCode = normalized(code)
         if subscriptionRequiredCodes.contains(normalizedCode) {
@@ -108,6 +145,7 @@ struct TypefluxCloudBillingError: LocalizedError, Equatable {
 
         if quotaExceededCodes.contains(where: { normalizedMessage.contains($0) })
             || normalizedMessage.contains("QUOTA_EXCEEDED")
+            || normalizedMessage.contains("CREDIT_BALANCE_EXHAUSTED")
             || normalizedMessage.contains("CREDIT_EXHAUSTED")
             || normalizedMessage.contains("INSUFFICIENT_CREDITS") {
             return TypefluxCloudBillingError(reason: .quotaExceeded, serverMessage: message)
@@ -132,6 +170,7 @@ struct TypefluxCloudBillingError: LocalizedError, Equatable {
         "ASR_QUOTA_EXCEEDED",
         "LLM_QUOTA_EXCEEDED",
         "INSUFFICIENT_CREDITS",
+        "CREDIT_BALANCE_EXHAUSTED",
         "CREDIT_EXHAUSTED"
     ]
 

--- a/Sources/Typeflux/STT/STTRouter+Fallbacks.swift
+++ b/Sources/Typeflux/STT/STTRouter+Fallbacks.swift
@@ -62,6 +62,13 @@ extension STTRouter {
             return (transcript: integratedError.transcript, rewritten: nil)
         }
         if let billingError = TypefluxCloudBillingError.fromError(error) {
+            if let localResult = await transcribeWithTypefluxCloudCreditFallbackModelIfAvailable(
+                billingError: billingError,
+                audioFile: audioFile,
+                onUpdate: onASRUpdate
+            ) {
+                return (transcript: localResult, rewritten: nil)
+            }
             throw billingError
         }
         if let fallback = await transcribeWithCloudLoginFallbackIfNeeded(
@@ -133,6 +140,13 @@ extension STTRouter {
     ) async throws -> String {
         NetworkDebugLogger.logError(context: "Typeflux Cloud fallback failed", error: error)
         if let billingError = TypefluxCloudBillingError.fromError(error) {
+            if let localResult = await transcribeWithTypefluxCloudCreditFallbackModelIfAvailable(
+                billingError: billingError,
+                audioFile: audioFile,
+                onUpdate: onUpdate
+            ) {
+                return localResult
+            }
             throw billingError
         }
         if TypefluxCloudLoginRequiredError.fromError(error) != nil,
@@ -159,6 +173,13 @@ extension STTRouter {
     ) async throws -> String {
         NetworkDebugLogger.logError(context: "Typeflux Official STT failed", error: error)
         if let billingError = TypefluxCloudBillingError.fromError(error) {
+            if let localResult = await transcribeWithTypefluxCloudCreditFallbackModelIfAvailable(
+                billingError: billingError,
+                audioFile: audioFile,
+                onUpdate: onUpdate
+            ) {
+                return localResult
+            }
             throw billingError
         }
         if let fallback = await transcribeWithCloudLoginFallbackIfNeeded(
@@ -208,6 +229,30 @@ extension STTRouter {
             return try await fallback.transcribeStream(audioFile: audioFile, onUpdate: onUpdate)
         } catch {
             NetworkDebugLogger.logError(context: "Default SenseVoice fallback failed", error: error)
+            return nil
+        }
+    }
+
+    private func transcribeWithTypefluxCloudCreditFallbackModelIfAvailable(
+        billingError: TypefluxCloudBillingError,
+        audioFile: AudioFile,
+        onUpdate: @escaping @Sendable (TranscriptionSnapshot) async -> Void
+    ) async -> String? {
+        guard billingError.reason == .quotaExceeded,
+              await hasPaidTypefluxCloudSubscription()
+        else {
+            return nil
+        }
+        guard let fallback = typefluxCloudLoginFallbackLocalModel else {
+            return nil
+        }
+        do {
+            NetworkDebugLogger.logMessage(
+                "Falling back to default SenseVoice after Typeflux Cloud credits were exhausted"
+            )
+            return try await fallback.transcribeStream(audioFile: audioFile, onUpdate: onUpdate)
+        } catch {
+            NetworkDebugLogger.logError(context: "Default SenseVoice credit fallback failed", error: error)
             return nil
         }
     }

--- a/Sources/Typeflux/STT/Transcriber.swift
+++ b/Sources/Typeflux/STT/Transcriber.swift
@@ -81,6 +81,7 @@ final class STTRouter {
     let typefluxCloudLoginFallbackLocalModel: Transcriber?
     let autoModelDownloadService: AutoModelDownloadService?
     let isTypefluxCloudLoggedIn: @Sendable () async -> Bool
+    let hasPaidTypefluxCloudSubscription: @Sendable () async -> Bool
 
     init(
         settingsStore: SettingsStore,
@@ -98,6 +99,9 @@ final class STTRouter {
         autoModelDownloadService: AutoModelDownloadService? = nil,
         isTypefluxCloudLoggedIn: @escaping @Sendable () async -> Bool = {
             await MainActor.run { AuthState.shared.isLoggedIn }
+        },
+        hasPaidTypefluxCloudSubscription: @escaping @Sendable () async -> Bool = {
+            await MainActor.run { AuthState.shared.subscription.hasPaidSubscription }
         }
     ) {
         self.settingsStore = settingsStore
@@ -114,6 +118,7 @@ final class STTRouter {
         self.typefluxCloudLoginFallbackLocalModel = typefluxCloudLoginFallbackLocalModel
         self.autoModelDownloadService = autoModelDownloadService
         self.isTypefluxCloudLoggedIn = isTypefluxCloudLoggedIn
+        self.hasPaidTypefluxCloudSubscription = hasPaidTypefluxCloudSubscription
     }
 
     func transcribe(

--- a/Sources/Typeflux/Workflow/WorkflowController.swift
+++ b/Sources/Typeflux/Workflow/WorkflowController.swift
@@ -31,6 +31,7 @@ final class WorkflowController {
     static let audioStartupMaxAttemptCount = 3
     static let audioStartupRetryDelay: Duration = .milliseconds(250)
     static let llmTimeoutAfterTranscriptionSeconds: TimeInterval = 30
+    static let paidCreditExhaustedPromptSuppressionInterval: TimeInterval = 60 * 60
     var llmTimeoutAfterTranscription: TimeInterval = WorkflowController.llmTimeoutAfterTranscriptionSeconds
     struct LLMRequestTimeoutError: LocalizedError {
         var errorDescription: String? {
@@ -136,6 +137,7 @@ final class WorkflowController {
     var isHistoryPickerPresented = false
     var historyPickerItems: [HistoryPickerEntry] = []
     var historyPickerSelectedIndex = 0
+    var lastPaidCreditExhaustedPromptPresentedAt: Date?
 
     // Clarification mode: set when the agent workflow is paused waiting for a user voice reply.
     var pendingClarificationContinuation: CheckedContinuation<String, Error>?
@@ -1276,12 +1278,20 @@ final class WorkflowController {
 
     func presentCloudBillingError(_ error: TypefluxCloudBillingError) async {
         await MainActor.run {
+            let hasPaidSubscription = AuthState.shared.subscription.hasPaidSubscription
+            guard self.shouldPresentCloudBillingError(
+                error,
+                hasPaidSubscription: hasPaidSubscription
+            ) else {
+                return
+            }
+
             self.shouldPreserveLLMConfigurationNotice = true
             self.soundEffectPlayer.play(.tip)
 
             let actions: [OverlayFailureAction] = [
                 OverlayFailureAction(
-                    title: L("cloud.billing.action.subscribe"),
+                    title: error.primaryActionTitle(hasPaidSubscription: hasPaidSubscription),
                     isRetry: false,
                     trailingSystemImage: "arrow.up.right",
                     handler: { [weak self] in
@@ -1309,12 +1319,32 @@ final class WorkflowController {
             ]
 
             self.overlayController.showFailureWithActions(
-                title: error.title,
-                message: error.localizedDescription,
+                title: error.title(hasPaidSubscription: hasPaidSubscription),
+                message: error.message(hasPaidSubscription: hasPaidSubscription),
                 tone: .billing,
                 actions: actions
             )
         }
+    }
+
+    @MainActor
+    func shouldPresentCloudBillingError(
+        _ error: TypefluxCloudBillingError,
+        hasPaidSubscription: Bool,
+        now: Date = Date()
+    ) -> Bool {
+        guard error.reason == .quotaExceeded, hasPaidSubscription else {
+            return true
+        }
+
+        if let lastPaidCreditExhaustedPromptPresentedAt,
+           now.timeIntervalSince(lastPaidCreditExhaustedPromptPresentedAt)
+            < Self.paidCreditExhaustedPromptSuppressionInterval {
+            return false
+        }
+
+        lastPaidCreditExhaustedPromptPresentedAt = now
+        return true
     }
 }
 

--- a/Tests/TypefluxTests/STTRouterTests.swift
+++ b/Tests/TypefluxTests/STTRouterTests.swift
@@ -175,7 +175,8 @@ final class STTRouterTests: XCTestCase {
         doubaoRealtimeOverride: Transcriber? = nil,
         typefluxOfficialOverride: Transcriber? = nil,
         typefluxCloudLoginFallbackLocalModel: Transcriber? = nil,
-        isTypefluxCloudLoggedIn: @escaping @Sendable () async -> Bool = { false }
+        isTypefluxCloudLoggedIn: @escaping @Sendable () async -> Bool = { false },
+        hasPaidTypefluxCloudSubscription: @escaping @Sendable () async -> Bool = { false }
     ) -> STTRouter {
         STTRouter(
             settingsStore: settings,
@@ -190,7 +191,8 @@ final class STTRouterTests: XCTestCase {
             groq: groq,
             typefluxOfficial: typefluxOfficialOverride ?? typefluxOfficial,
             typefluxCloudLoginFallbackLocalModel: typefluxCloudLoginFallbackLocalModel,
-            isTypefluxCloudLoggedIn: isTypefluxCloudLoggedIn
+            isTypefluxCloudLoggedIn: isTypefluxCloudLoggedIn,
+            hasPaidTypefluxCloudSubscription: hasPaidTypefluxCloudSubscription
         )
     }
 
@@ -356,6 +358,54 @@ final class STTRouterTests: XCTestCase {
         XCTAssertEqual(appleSpeech.transcribeCallCount, 0)
     }
 
+    func testTypefluxOfficialQuotaFailureUsesDefaultSenseVoiceFallbackForPaidSubscription() async throws {
+        let billingError = TypefluxCloudBillingError(reason: .quotaExceeded, serverMessage: nil)
+        settings.sttProvider = .typefluxOfficial
+        settings.localOptimizationEnabled = false
+        settings.useAppleSpeechFallback = false
+        typefluxOfficial.errorToThrow = billingError
+        let defaultSenseVoiceFallback = MockTranscriber()
+        defaultSenseVoiceFallback.resultToReturn = "sensevoice fallback"
+        let router = makeRouter(
+            typefluxCloudLoginFallbackLocalModel: defaultSenseVoiceFallback,
+            hasPaidTypefluxCloudSubscription: { true }
+        )
+
+        let result = try await router.transcribe(audioFile: dummyAudioFile())
+
+        XCTAssertEqual(result, "sensevoice fallback")
+        XCTAssertEqual(typefluxOfficial.transcribeCallCount, 1)
+        XCTAssertEqual(defaultSenseVoiceFallback.transcribeCallCount, 1)
+        XCTAssertEqual(appleSpeech.transcribeCallCount, 0)
+    }
+
+    func testTypefluxOfficialQuotaFailureDoesNotUseDefaultSenseVoiceFallbackForFreePlan() async throws {
+        let billingError = TypefluxCloudBillingError(reason: .quotaExceeded, serverMessage: nil)
+        settings.sttProvider = .typefluxOfficial
+        settings.localOptimizationEnabled = false
+        settings.useAppleSpeechFallback = false
+        typefluxOfficial.errorToThrow = billingError
+        let defaultSenseVoiceFallback = MockTranscriber()
+        defaultSenseVoiceFallback.resultToReturn = "sensevoice fallback"
+        let router = makeRouter(
+            typefluxCloudLoginFallbackLocalModel: defaultSenseVoiceFallback,
+            hasPaidTypefluxCloudSubscription: { false }
+        )
+
+        do {
+            _ = try await router.transcribe(audioFile: dummyAudioFile())
+            XCTFail("Expected billing error")
+        } catch let error as TypefluxCloudBillingError {
+            XCTAssertEqual(error, billingError)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+
+        XCTAssertEqual(typefluxOfficial.transcribeCallCount, 1)
+        XCTAssertEqual(defaultSenseVoiceFallback.transcribeCallCount, 0)
+        XCTAssertEqual(appleSpeech.transcribeCallCount, 0)
+    }
+
     func testTypefluxOfficialLoginRequiredFallsBackToAppleSpeech() async throws {
         settings.sttProvider = .typefluxOfficial
         settings.useAppleSpeechFallback = true
@@ -412,6 +462,36 @@ final class STTRouterTests: XCTestCase {
         let router = makeRouter(
             typefluxOfficialOverride: integrated,
             typefluxCloudLoginFallbackLocalModel: defaultSenseVoiceFallback
+        )
+
+        let result = try await router.transcribeStreamWithLLMRewrite(
+            audioFile: dummyAudioFile(),
+            llmConfig: ASRLLMConfig(systemPrompt: "sys", userPromptTemplate: "{{transcript}}"),
+            scenario: .voiceInput,
+            onASRUpdate: { _ in },
+            onLLMStart: {},
+            onLLMChunk: { _ in }
+        )
+
+        XCTAssertEqual(result.transcript, "sensevoice fallback")
+        XCTAssertNil(result.rewritten)
+        XCTAssertEqual(integrated.integratedCallCount, 1)
+        XCTAssertEqual(defaultSenseVoiceFallback.transcribeCallCount, 1)
+        XCTAssertEqual(appleSpeech.transcribeCallCount, 0)
+    }
+
+    func testIntegratedTypefluxQuotaFailureUsesDefaultSenseVoiceFallbackForPaidSubscription() async throws {
+        settings.sttProvider = .typefluxOfficial
+        settings.localOptimizationEnabled = false
+        settings.useAppleSpeechFallback = false
+        let integrated = MockIntegratedTypefluxTranscriber()
+        integrated.errorToThrow = TypefluxCloudBillingError(reason: .quotaExceeded, serverMessage: nil)
+        let defaultSenseVoiceFallback = MockTranscriber()
+        defaultSenseVoiceFallback.resultToReturn = "sensevoice fallback"
+        let router = makeRouter(
+            typefluxOfficialOverride: integrated,
+            typefluxCloudLoginFallbackLocalModel: defaultSenseVoiceFallback,
+            hasPaidTypefluxCloudSubscription: { true }
         )
 
         let result = try await router.transcribeStreamWithLLMRewrite(

--- a/Tests/TypefluxTests/TypefluxCloudServerErrorMessageTests.swift
+++ b/Tests/TypefluxTests/TypefluxCloudServerErrorMessageTests.swift
@@ -62,6 +62,38 @@ final class TypefluxCloudServerErrorMessageTests: XCTestCase {
         )
     }
 
+    func testBillingErrorPrimaryActionMatchesReason() {
+        withEnglishLocalization {
+            let subscriptionRequired = TypefluxCloudBillingError(reason: .subscriptionRequired, serverMessage: nil)
+            let quotaExceeded = TypefluxCloudBillingError(reason: .quotaExceeded, serverMessage: nil)
+
+            XCTAssertEqual(
+                subscriptionRequired.title(hasPaidSubscription: false),
+                "Typeflux Cloud needs a subscription"
+            )
+            XCTAssertEqual(quotaExceeded.title(hasPaidSubscription: false), "Typeflux Cloud needs a subscription")
+            XCTAssertEqual(quotaExceeded.title(hasPaidSubscription: true), "Typeflux Cloud credits used up")
+            XCTAssertEqual(
+                subscriptionRequired.primaryActionTitle,
+                "Subscribe"
+            )
+            XCTAssertEqual(
+                quotaExceeded.primaryActionTitle,
+                "Subscribe"
+            )
+            XCTAssertEqual(
+                quotaExceeded.primaryActionTitle(hasPaidSubscription: true),
+                "Open Account"
+            )
+        }
+    }
+
+    func testBillingErrorParsesCreditBalanceExhaustedMessage() {
+        let message = "request failed: credit_balance_exhausted"
+
+        XCTAssertEqual(TypefluxCloudBillingError.fromMessage(message)?.reason, .quotaExceeded)
+    }
+
     func testUnknownCodeUsesTrimmedServerMessageThenFallback() {
         XCTAssertEqual(
             TypefluxCloudServerErrorMessage.userMessage(

--- a/Tests/TypefluxTests/WorkflowControllerProcessingTests.swift
+++ b/Tests/TypefluxTests/WorkflowControllerProcessingTests.swift
@@ -1006,6 +1006,47 @@ final class WorkflowControllerProcessingTests: XCTestCase {
         XCTFail("Expected local model download failure status")
     }
 
+    @MainActor
+    func testPaidCreditExhaustedPromptIsSuppressedForOneHour() {
+        let controller = makeWorkflowController()
+        let error = TypefluxCloudBillingError(reason: .quotaExceeded, serverMessage: nil)
+        let firstPresentation = Date(timeIntervalSince1970: 1_000)
+
+        XCTAssertTrue(controller.shouldPresentCloudBillingError(
+            error,
+            hasPaidSubscription: true,
+            now: firstPresentation
+        ))
+        XCTAssertFalse(controller.shouldPresentCloudBillingError(
+            error,
+            hasPaidSubscription: true,
+            now: firstPresentation.addingTimeInterval(30 * 60)
+        ))
+        XCTAssertTrue(controller.shouldPresentCloudBillingError(
+            error,
+            hasPaidSubscription: true,
+            now: firstPresentation.addingTimeInterval(60 * 60)
+        ))
+    }
+
+    @MainActor
+    func testFreeCreditExhaustedPromptIsNotSuppressed() {
+        let controller = makeWorkflowController()
+        let error = TypefluxCloudBillingError(reason: .quotaExceeded, serverMessage: nil)
+        let firstPresentation = Date(timeIntervalSince1970: 1_000)
+
+        XCTAssertTrue(controller.shouldPresentCloudBillingError(
+            error,
+            hasPaidSubscription: false,
+            now: firstPresentation
+        ))
+        XCTAssertTrue(controller.shouldPresentCloudBillingError(
+            error,
+            hasPaidSubscription: false,
+            now: firstPresentation.addingTimeInterval(30 * 60)
+        ))
+    }
+
     private func makeWorkflowController(
         textInjector: TextInjector = MockProcessingTextInjector(),
         audioRecorder: AudioRecorder = MockProcessingAudioRecorder(),


### PR DESCRIPTION
## Summary

- 付费用户credit用光后，提示只在1小时内显示一次，避免重复打扰
- 免费用户credit用光后，每次都显示订阅提示框
- 付费用户继续使用时，自动降级到本地SenseVoice模型
- 使用本地模型时，跳过人设改写功能

## Test plan

- [x] `swift test --filter WorkflowControllerProcessingTests` (50 tests passed)
- [x] Free user credit exhaustion shows subscription prompt every time
- [x] Paid user credit exhaustion shows prompt at most once per hour
- [x] Paid user continues using SenseVoice fallback after credits exhausted