### PR TITLE
Use live preview when final STT reports no speech

### DIFF
--- a/Sources/Typeflux/Workflow/WorkflowController+Processing.swift
+++ b/Sources/Typeflux/Workflow/WorkflowController+Processing.swift
@@ -695,14 +695,23 @@ extension WorkflowController {
                 do {
                     rawTranscribedText = try await realtimeTranscriptionSession.finish()
                 } catch {
-                    NetworkDebugLogger.logError(
-                        context: "Realtime STT session failed; falling back to recorded audio",
-                        error: error
-                    )
-                    rawTranscribedText = try await sttRouter.transcribeStream(
-                        audioFile: audioFile,
-                        scenario: cloudScenario
-                    ) { _ in }
+                    if Self.shouldUseRecordingPreviewOnTranscriptionFailure(error),
+                       !fallbackPreviewText.isEmpty {
+                        NetworkDebugLogger.logError(
+                            context: "Realtime STT session failed; using recording preview text",
+                            error: error
+                        )
+                        rawTranscribedText = ""
+                    } else {
+                        NetworkDebugLogger.logError(
+                            context: "Realtime STT session failed; falling back to recorded audio",
+                            error: error
+                        )
+                        rawTranscribedText = try await sttRouter.transcribeStream(
+                            audioFile: audioFile,
+                            scenario: cloudScenario
+                        ) { _ in }
+                    }
                 }
             } else if canMergeWithLLM,
                       let resolvedPersonaPrompt = personaPrompt?.trimmingCharacters(in: .whitespacesAndNewlines),
@@ -718,10 +727,23 @@ extension WorkflowController {
                 rawTranscribedText = mergedResult.transcript
                 mergedLLMResult = mergedResult.rewritten
             } else {
-                rawTranscribedText = try await sttRouter.transcribeStream(
-                    audioFile: audioFile,
-                    scenario: cloudScenario
-                ) { _ in }
+                do {
+                    rawTranscribedText = try await sttRouter.transcribeStream(
+                        audioFile: audioFile,
+                        scenario: cloudScenario
+                    ) { _ in }
+                } catch {
+                    guard Self.shouldUseRecordingPreviewOnTranscriptionFailure(error),
+                          !fallbackPreviewText.isEmpty
+                    else {
+                        throw error
+                    }
+                    NetworkDebugLogger.logError(
+                        context: "Final STT failed; using recording preview text",
+                        error: error
+                    )
+                    rawTranscribedText = ""
+                }
             }
             NetworkDebugLogger.logMessage(
                 "[Ask Timing] transcription completed in \(Self.formatDurationSince(transcriptionStartedAt))"
@@ -997,6 +1019,19 @@ extension WorkflowController {
         case raw
         case emptyFinalUsedPreview
         case finalWasPreviewSuffix
+    }
+
+    static func shouldUseRecordingPreviewOnTranscriptionFailure(_ error: Error) -> Bool {
+        let message = error.localizedDescription.lowercased()
+        return message.contains("no speech")
+            || message.contains("no transcription")
+            || message.contains("empty transcript")
+            || message.contains("empty transcription")
+            || message.contains("silent audio")
+            || message.contains("silence")
+            || message.contains("socket is not connected")
+            || message.contains("socket was not connected")
+            || message.contains("not connected")
     }
 
     private func processAskFlowWithSelection(

--- a/Tests/TypefluxTests/WorkflowControllerProcessingTests.swift
+++ b/Tests/TypefluxTests/WorkflowControllerProcessingTests.swift
@@ -984,6 +984,40 @@ final class WorkflowControllerProcessingTests: XCTestCase {
         XCTAssertTrue(controller.latestRecordingPreviewText.isEmpty)
     }
 
+    func testFinishRecordingUsesPreviewTextWhenFinalTranscriptionReportsNoSpeech() async throws {
+        let audioURL = try writeSilentTestAudio(duration: 1.0)
+        defer { try? FileManager.default.removeItem(at: audioURL) }
+
+        let textInjector = MockProcessingTextInjector()
+        let historyStore = MockProcessingHistoryStore()
+        let audioRecorder = FileReturningAudioRecorder(fileURL: audioURL)
+        let noSpeechError = NSError(
+            domain: "STT",
+            code: 204,
+            userInfo: [NSLocalizedDescriptionKey: "No speech detected in audio."]
+        )
+        let controller = makeWorkflowController(
+            textInjector: textInjector,
+            audioRecorder: audioRecorder,
+            sttTranscriber: MockProcessingTranscriber(error: noSpeechError),
+            historyStore: historyStore,
+            sleep: { _ in }
+        )
+        controller.latestRecordingPreviewText = "preview transcript"
+        controller.isAudioRecorderStarted = true
+
+        await controller.finishRecordingAndProcess(recordingStoppedAt: Date())
+        await waitUntil {
+            textInjector.insertedTexts == ["preview transcript"]
+        }
+
+        XCTAssertEqual(audioRecorder.stopCallCount, 1)
+        XCTAssertEqual(textInjector.insertedTexts, ["preview transcript"])
+        XCTAssertEqual(historyStore.list().last?.transcriptText, "preview transcript")
+        XCTAssertTrue(controller.latestRecordingPreviewText.isEmpty)
+        XCTAssertNil(controller.lastRetryableFailureRecord)
+    }
+
     func testFinishRecordingUsesPreviewTextWhenFinalTranscriptionIsPreviewSuffix() async throws {
         let audioURL = try writeSilentTestAudio(duration: 1.0)
         defer { try? FileManager.default.removeItem(at: audioURL) }
@@ -2013,13 +2047,18 @@ private final class MockWorkflowLocalModelManager: LocalSTTModelManaging {
 
 private final class MockProcessingTranscriber: Transcriber {
     private let transcript: String
+    private let error: Error?
 
-    init(transcript: String = "") {
+    init(transcript: String = "", error: Error? = nil) {
         self.transcript = transcript
+        self.error = error
     }
 
     func transcribe(audioFile _: AudioFile) async throws -> String {
-        transcript
+        if let error {
+            throw error
+        }
+        return transcript
     }
 }
 


### PR DESCRIPTION
## Problem
When the user's voice is quiet, realtime transcription can still produce usable preview text during recording. However, the final STT pass may classify the saved audio as no speech / unclear speech / silence and force the workflow into the cancellation path.

That means the app can show the error notice "未检测到清晰语音，本次转写已取消。" even though realtime transcription has already recognized useful text. This feels unnecessary and interrupts a workflow that could otherwise continue with the preview transcript.

## Summary
- Use recording preview text when final realtime/file STT reports no-speech, empty, or silence-style errors
- Keep existing fallback/error handling for non-speech-related STT failures
- Add regression coverage for the quiet-voice scenario where final STT reports no speech but preview text exists

## Tests
- swift test --filter TypefluxTests.WorkflowControllerProcessingTests/testFinishRecordingUsesPreviewTextWhenFinalTranscriptionReportsNoSpeech