### PR TITLE
feat(stt): 接入 Soniox V5 实时语音识别

### DIFF
--- a/Sources/Typeflux/App/DIContainer.swift
+++ b/Sources/Typeflux/App/DIContainer.swift
@@ -97,6 +97,7 @@ final class DIContainer {
                 apiKeyOverride: { [settingsStore] in settingsStore.groqSTTAPIKey },
                 modelOverride: { [settingsStore] in settingsStore.groqSTTModel }
             ),
+            soniox: SonioxTranscriber(settingsStore: settingsStore),
             typefluxOfficial: TypefluxOfficialTranscriber(),
             typefluxCloudLoginFallbackLocalModel: DefaultSenseVoiceFallbackTranscriber(
                 modelManager: localModelManager

--- a/Sources/Typeflux/Batch/TypefluxBatchCommand.swift
+++ b/Sources/Typeflux/Batch/TypefluxBatchCommand.swift
@@ -519,6 +519,8 @@ private final class SingleAudioProcessor {
             defaults.set(model, forKey: "stt.google.model")
         case .groq:
             defaults.set(model, forKey: "stt.groq.model")
+        case .soniox:
+            defaults.set(model, forKey: "stt.soniox.model")
         case .appleSpeech, .aliCloud, .typefluxOfficial:
             throw BatchCommandError(message: "--stt-model is not supported for provider \(provider.rawValue).")
         }
@@ -542,6 +544,7 @@ private final class SingleAudioProcessor {
                 apiKeyOverride: { [settingsStore] in settingsStore.groqSTTAPIKey },
                 modelOverride: { [settingsStore] in settingsStore.groqSTTModel }
             ),
+            soniox: SonioxTranscriber(settingsStore: settingsStore),
             typefluxOfficial: TypefluxOfficialTranscriber(),
             typefluxCloudLoginFallbackLocalModel: DefaultSenseVoiceFallbackTranscriber(
                 modelManager: localModelManager
@@ -659,6 +662,8 @@ private final class SingleAudioProcessor {
             settingsStore.googleCloudModel
         case .groq:
             settingsStore.groqSTTModel
+        case .soniox:
+            settingsStore.sonioxModel
         case .typefluxOfficial:
             "default"
         }
@@ -853,6 +858,7 @@ private final class WAVPersonaBenchmark {
                 apiKeyOverride: { [settingsStore] in settingsStore.groqSTTAPIKey },
                 modelOverride: { [settingsStore] in settingsStore.groqSTTModel }
             ),
+            soniox: SonioxTranscriber(settingsStore: settingsStore),
             typefluxOfficial: TypefluxOfficialTranscriber(),
             typefluxCloudLoginFallbackLocalModel: DefaultSenseVoiceFallbackTranscriber(
                 modelManager: localModelManager
@@ -1088,6 +1094,8 @@ private final class WAVPersonaBenchmark {
             settingsStore.googleCloudModel
         case .groq:
             settingsStore.groqSTTModel
+        case .soniox:
+            settingsStore.sonioxModel
         case .typefluxOfficial:
             "default"
         }

--- a/Sources/Typeflux/Onboarding/OnboardingView.swift
+++ b/Sources/Typeflux/Onboarding/OnboardingView.swift
@@ -445,6 +445,8 @@ struct OnboardingView: View {
             googleCloudConfigFields
         case .groq:
             groqSTTConfigFields
+        case .soniox:
+            sonioxConfigFields
         case .appleSpeech, .typefluxOfficial:
             EmptyView()
         }
@@ -822,6 +824,25 @@ struct OnboardingView: View {
         }
     }
 
+    private var sonioxConfigFields: some View {
+        onboardingConfigCard {
+            VStack(spacing: 12) {
+                StudioTextInputCard(
+                    label: L("common.apiKey"),
+                    placeholder: "sk-...",
+                    text: $viewModel.sonioxAPIKey,
+                    secure: true
+                )
+                StudioSuggestedTextInputCard(
+                    label: L("common.model"),
+                    placeholder: SonioxASRDefaults.model,
+                    text: $viewModel.sonioxModel,
+                    suggestions: SonioxASRDefaults.suggestedModels
+                )
+            }
+        }
+    }
+
     private var llmRemoteConfigFields: some View {
         let provider = viewModel.llmRemoteProvider
         let endpointSuggestions = ([viewModel.llmBaseURL, provider.defaultBaseURL]
@@ -1051,7 +1072,7 @@ struct OnboardingView: View {
 
     private func sttProviderSupportsTest(_ provider: STTProvider) -> Bool {
         switch provider {
-        case .whisperAPI, .multimodalLLM, .aliCloud, .doubaoRealtime, .googleCloud, .groq, .freeModel:
+        case .whisperAPI, .multimodalLLM, .aliCloud, .doubaoRealtime, .googleCloud, .groq, .soniox, .freeModel:
             true
         case .localModel, .appleSpeech, .typefluxOfficial:
             false
@@ -1064,6 +1085,8 @@ struct OnboardingView: View {
             URL(string: "https://platform.openai.com/api-keys")
         case .groq:
             URL(string: "https://console.groq.com/keys")
+        case .soniox:
+            URL(string: "https://console.soniox.com/")
         case .aliCloud:
             URL(string: "https://bailian.console.aliyun.com/")
         case .doubaoRealtime:
@@ -1181,6 +1204,7 @@ struct OnboardingView: View {
         case .doubaoRealtime: .doubaoRealtime
         case .googleCloud: .googleCloud
         case .groq: .groqSTT
+        case .soniox: .soniox
         case .appleSpeech: .appleSpeech
         case .typefluxOfficial: .typefluxOfficial
         }
@@ -1256,6 +1280,7 @@ struct OnboardingView: View {
         case .multimodalLLM: "brain.filled.head.profile"
         case .aliCloud: "antenna.radiowaves.left.and.right"
         case .doubaoRealtime: "bolt.horizontal.circle"
+        case .soniox: "waveform.and.mic"
         case .typefluxOfficial: "infinity"
         case .typefluxCloud: "infinity"
         }
@@ -1279,6 +1304,7 @@ struct OnboardingView: View {
         case .doubaoRealtime: L("settings.models.card.doubao.summary")
         case .googleCloud: L("settings.models.card.googleCloud.summary")
         case .groq: L("settings.models.card.groq.summary")
+        case .soniox: L("settings.models.card.soniox.summary")
         case .appleSpeech: ""
         case .typefluxOfficial: L("settings.models.card.typefluxOfficial.summary")
         }

--- a/Sources/Typeflux/Onboarding/OnboardingViewModel.swift
+++ b/Sources/Typeflux/Onboarding/OnboardingViewModel.swift
@@ -78,6 +78,8 @@ final class OnboardingViewModel: ObservableObject {
     @Published var googleCloudModel: String
     @Published var groqSTTAPIKey: String
     @Published var groqSTTModel: String
+    @Published var sonioxAPIKey: String
+    @Published var sonioxModel: String
 
     // LLM Config
     @Published var llmProvider: LLMProvider
@@ -162,6 +164,8 @@ final class OnboardingViewModel: ObservableObject {
         googleCloudModel = settingsStore.googleCloudModel
         groqSTTAPIKey = settingsStore.groqSTTAPIKey
         groqSTTModel = settingsStore.groqSTTModel
+        sonioxAPIKey = settingsStore.sonioxAPIKey
+        sonioxModel = settingsStore.sonioxModel
 
         let initialLLMProvider = settingsStore.llmProvider
         let storedRemoteProvider = settingsStore.llmRemoteProvider
@@ -253,6 +257,8 @@ final class OnboardingViewModel: ObservableObject {
             hasText(googleCloudProjectID) && hasText(googleCloudModel)
         case .groq:
             hasText(groqSTTAPIKey) && hasText(groqSTTModel)
+        case .soniox:
+            hasText(sonioxAPIKey)
         }
     }
 
@@ -402,6 +408,8 @@ final class OnboardingViewModel: ObservableObject {
         let language = appLanguage
         let groqKey = groqSTTAPIKey
         let groqModel = groqSTTModel
+        let sonioxKey = sonioxAPIKey
+        let sonioxModelValue = sonioxModel
         let freeModel = freeSTTModel
 
         sttTestTask = Task {
@@ -444,6 +452,11 @@ final class OnboardingViewModel: ObservableObject {
                             baseURL: "https://api.groq.com/openai/v1",
                             model: effectiveModel,
                             apiKey: groqKey
+                        )
+                    case .soniox:
+                        preview = try await SonioxTranscriber.testConnection(
+                            apiKey: sonioxKey,
+                            model: sonioxModelValue
                         )
                     case .freeModel:
                         preview = try await FreeSTTTranscriber.testConnection(modelName: freeModel)
@@ -638,6 +651,9 @@ final class OnboardingViewModel: ObservableObject {
             case .groq:
                 settingsStore.groqSTTAPIKey = groqSTTAPIKey
                 settingsStore.groqSTTModel = groqSTTModel
+            case .soniox:
+                settingsStore.sonioxAPIKey = sonioxAPIKey
+                settingsStore.sonioxModel = sonioxModel
             case .appleSpeech, .typefluxOfficial:
                 break
             }

--- a/Sources/Typeflux/Resources/en.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/en.lproj/Localizable.strings
@@ -249,6 +249,7 @@
 "provider.stt.doubaoRealtime" = "Doubao Realtime ASR";
 "provider.stt.googleCloud" = "Google Speech-to-Text";
 "provider.stt.groq" = "Groq";
+"provider.stt.soniox" = "Soniox";
 "provider.stt.typefluxOfficial" = "Typeflux Cloud";
 "provider.llm.openAICompatible" = "OpenAI-Compatible";
 "provider.llm.custom" = "Custom";
@@ -638,6 +639,7 @@
 "settings.models.useAliCloud" = "Use Alibaba Cloud";
 "settings.models.useDoubao" = "Use Doubao";
 "settings.models.useGroq" = "Use Groq";
+"settings.models.useSoniox" = "Use Soniox";
 "settings.models.useTypefluxOfficial" = "Use Typeflux Official";
 "settings.models.useTypefluxCloud" = "Use Typeflux Cloud";
 "settings.models.badge.local" = "Local";
@@ -654,6 +656,7 @@
 "settings.models.card.doubao.summary" = "Low-latency streaming recognition through Doubao Speech Recognition 2.0 with ByteDance's native binary WebSocket protocol.";
 "settings.models.card.googleCloud.summary" = "Real-time streaming recognition through Google Cloud Speech-to-Text.";
 "settings.models.card.groq.summary" = "Fast Whisper transcription via Groq's inference endpoint with whisper-large-v3-turbo as the default model.";
+"settings.models.card.soniox.summary" = "Real-time streaming recognition via Soniox V5 with high accuracy across 60+ languages and low-latency WebSocket streaming.";
 "settings.models.card.typefluxOfficial.summary" = "Typeflux's built-in speech recognition service. Sign in with your Typeflux account to use it — no extra API keys required.";
 "settings.models.card.typefluxCloud.summary" = "Typeflux's built-in LLM service. Sign in with your Typeflux account to use it — no extra API keys required.";
 "settings.models.card.ollama.summary" = "Runs rewrite and edit commands locally, with optional automatic model preparation.";
@@ -711,6 +714,7 @@
 "settings.models.overview.doubao" = "Speech recognition is streamed in real time to Doubao Speech Recognition 2.0 via ByteDance WebSocket.";
 "settings.models.overview.googleCloud" = "Speech recognition is streamed in real time directly to Google Cloud Speech-to-Text.";
 "settings.models.overview.groq" = "Speech recognition is handled by Groq's fast inference endpoint using the Whisper model.";
+"settings.models.overview.soniox" = "Speech recognition is streamed in real time to Soniox V5 via WebSocket with support for 60+ languages.";
 "settings.models.overview.typefluxOfficial" = "Speech recognition is handled by Typeflux's built-in service.";
 "settings.models.overview.typefluxCloud" = "Rewriting and editing are handled by Typeflux's built-in LLM service.";
 "settings.models.mode.local" = "Local";
@@ -732,6 +736,7 @@
 "settings.models.focused.doubao" = "Use this when you want the lowest-latency cloud dictation path through Doubao Speech Recognition 2.0.";
 "settings.models.focused.googleCloud" = "Use this when you want Google Cloud Speech-to-Text with realtime streaming recognition.";
 "settings.models.focused.groq" = "Use this when you want fast cloud transcription with Groq's accelerated Whisper inference.";
+"settings.models.focused.soniox" = "Use this when you want accurate real-time cloud transcription via Soniox V5 across 60+ languages.";
 "settings.models.focused.typefluxOfficial" = "Use Typeflux's built-in speech recognition service. Just sign in — no extra configuration needed.";
 "settings.models.focused.typefluxCloud" = "Use Typeflux's built-in LLM service for rewriting and editing. Just sign in — no extra configuration needed.";
 "settings.models.routing" = "Routing behaviour";
@@ -748,6 +753,7 @@
 "settings.models.routing.doubao" = "Doubao Speech Recognition 2.0 handles real-time streaming ASR via ByteDance's binary WebSocket protocol.";
 "settings.models.routing.googleCloud" = "Google Cloud Speech-to-Text handles real-time streaming ASR directly from this Mac.";
 "settings.models.routing.groq" = "Groq handles dictation through the Whisper-compatible transcription endpoint with accelerated inference.";
+"settings.models.routing.soniox" = "Soniox V5 handles real-time streaming ASR via WebSocket with high accuracy across 60+ languages.";
 "settings.models.googleCloud.streaming" = "StreamingRecognize";
 "settings.models.googleCloud.projectID" = "Project ID";
 "settings.models.googleCloud.oauth.authorize" = "Authorize Google";

--- a/Sources/Typeflux/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/ja.lproj/Localizable.strings
@@ -245,6 +245,7 @@
 "provider.stt.doubaoRealtime" = "Doubao Realtime ASR";
 "provider.stt.googleCloud" = "Google Speech-to-Text";
 "provider.stt.groq" = "Groq";
+"provider.stt.soniox" = "Soniox";
 "provider.stt.typefluxOfficial" = "Typeflux Cloud";
 "provider.llm.openAICompatible" = "OpenAI-Compatible";
 "provider.llm.custom" = "カスタム";
@@ -629,6 +630,7 @@
 "settings.models.useAliCloud" = "アリババクラウドを利用する";
 "settings.models.useDoubao" = "豆包を使用する";
 "settings.models.useGroq" = "Groq を使用する";
+"settings.models.useSoniox" = "Use Soniox";
 "settings.models.useTypefluxOfficial" = "Typeflux 公式を使用する";
 "settings.models.useTypefluxCloud" = "Typeflux Cloud を使用する";
 "settings.models.badge.local" = "ローカル";
@@ -645,6 +647,7 @@
 "settings.models.card.doubao.summary" = "ByteDance のネイティブ バイナリ WebSocket プロトコルを使用した Doubao Speech Recognition 2.0 による低遅延ストリーミング認識。";
 "settings.models.card.googleCloud.summary" = "Google Cloud Speech-to-Text によるリアルタイムのストリーミング音声認識。";
 "settings.models.card.groq.summary" = "Groq の推論エンドポイントによる高速な Whisper 文字起こし。既定モデルは whisper-large-v3-turbo。";
+"settings.models.card.soniox.summary" = "Real-time streaming recognition via Soniox V5 with high accuracy across 60+ languages.";
 "settings.models.card.typefluxOfficial.summary" = "Typeflux 内蔵の音声認識サービスです。Typeflux アカウントでサインインするだけで使用できます。追加の API キーは不要です。";
 "settings.models.card.typefluxCloud.summary" = "Typeflux 内蔵の大規模言語モデルサービスです。Typeflux アカウントでサインインするだけで使用できます。追加の API キーは不要です。";
 "settings.models.card.ollama.summary" = "オプションの自動モデル準備を使用して、ローカルで書き換えおよび編集コマンドを実行します。";
@@ -700,6 +703,7 @@
 "settings.models.overview.doubao" = "音声認識は、ByteDance WebSocket 経由で Doubao Speech Recognition 2.0 にリアルタイムでストリーミングされます。";
 "settings.models.overview.googleCloud" = "音声認識は Google Cloud Speech-to-Text に直接リアルタイムでストリーミングされます。";
 "settings.models.overview.groq" = "音声認識は、Groq の高速推論エンドポイントが Whisper モデルを使用して処理します。";
+"settings.models.overview.soniox" = "Speech recognition is streamed in real time to Soniox V5 via WebSocket.";
 "settings.models.overview.typefluxOfficial" = "音声認識は Typeflux の内蔵サービスで処理されます。";
 "settings.models.overview.typefluxCloud" = "テキストの書き直しと編集は Typeflux の内蔵 LLM サービスで処理されます。";
 "settings.models.mode.local" = "ローカル";
@@ -721,6 +725,7 @@
 "settings.models.focused.doubao" = "Doubao Speech Recognition 2.0 を介した遅延の最も低いクラウド ディクテーション パスが必要な場合は、これを使用します。";
 "settings.models.focused.googleCloud" = "Google Cloud Speech-to-Text のリアルタイム ストリーミング認識が必要な場合にこれを使用します。";
 "settings.models.focused.groq" = "Groq の高速推論を使用した迅速なクラウド文字起こしが必要な場合にこれを使用します。";
+"settings.models.focused.soniox" = "Use this for accurate real-time cloud transcription via Soniox V5 across 60+ languages.";
 "settings.models.focused.typefluxOfficial" = "Typeflux 内蔵の音声認識サービスを使用します。サインインするだけで、追加の設定は不要です。";
 "settings.models.focused.typefluxCloud" = "Typeflux 内蔵の LLM サービスを使用してテキストの書き直しと編集を行います。サインインするだけで、追加の設定は不要です。";
 "settings.models.routing" = "ルーティング動作";
@@ -737,6 +742,7 @@
 "settings.models.routing.doubao" = "Doubao Speech Recognition 2.0 は、ByteDance のバイナリ WebSocket プロトコルを介してリアルタイム ストリーミング ASR を処理します。";
 "settings.models.routing.googleCloud" = "Google Cloud Speech-to-Text はこの Mac から直接リアルタイム ストリーミング ASR を処理します。";
 "settings.models.routing.groq" = "Groq は、Whisper 互換の文字起こしエンドポイントを使用した高速推論でディクテーションを処理します。";
+"settings.models.routing.soniox" = "Soniox V5 handles real-time streaming ASR via WebSocket with high accuracy across 60+ languages.";
 "settings.models.googleCloud.streaming" = "StreamingRecognize";
 "settings.models.googleCloud.projectID" = "Project ID";
 "settings.models.googleCloud.oauth.authorize" = "Google を認可";

--- a/Sources/Typeflux/Resources/ko.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/ko.lproj/Localizable.strings
@@ -245,6 +245,7 @@
 "provider.stt.doubaoRealtime" = "Doubao Realtime ASR";
 "provider.stt.googleCloud" = "Google Speech-to-Text";
 "provider.stt.groq" = "Groq";
+"provider.stt.soniox" = "Soniox";
 "provider.stt.typefluxOfficial" = "Typeflux Cloud";
 "provider.llm.openAICompatible" = "OpenAI-Compatible";
 "provider.llm.custom" = "맞춤";
@@ -629,6 +630,7 @@
 "settings.models.useAliCloud" = "알리바바 클라우드 사용";
 "settings.models.useDoubao" = "두바오 사용";
 "settings.models.useGroq" = "Groq 사용";
+"settings.models.useSoniox" = "Use Soniox";
 "settings.models.useTypefluxOfficial" = "Typeflux 공식 사용";
 "settings.models.useTypefluxCloud" = "Typeflux Cloud 사용";
 "settings.models.badge.local" = "지역";
@@ -645,6 +647,7 @@
 "settings.models.card.doubao.summary" = "ByteDance의 기본 바이너리 WebSocket 프로토콜을 사용하는 Doubao Speech Recognition 2.0을 통한 저지연 스트리밍 인식.";
 "settings.models.card.googleCloud.summary" = "Google Cloud Speech-to-Text를 통한 실시간 스트리밍 음성 인식.";
 "settings.models.card.groq.summary" = "Groq 추론 엔드포인트를 통한 빠른 Whisper 전사. 기본 모델은 whisper-large-v3-turbo입니다.";
+"settings.models.card.soniox.summary" = "Real-time streaming recognition via Soniox V5 with high accuracy across 60+ languages.";
 "settings.models.card.typefluxOfficial.summary" = "Typeflux 내장 음성 인식 서비스입니다. Typeflux 계정으로 로그인하면 바로 사용할 수 있습니다. 추가 API 키가 필요 없습니다.";
 "settings.models.card.typefluxCloud.summary" = "Typeflux 내장 대형 언어 모델 서비스입니다. Typeflux 계정으로 로그인하면 바로 사용할 수 있습니다. 추가 API 키가 필요 없습니다.";
 "settings.models.card.ollama.summary" = "선택적 자동 모델 준비를 통해 재작성 및 편집 명령을 로컬로 실행합니다.";
@@ -700,6 +703,7 @@
 "settings.models.overview.doubao" = "음성 인식은 ByteDance WebSocket을 통해 Doubao Speech Recognition 2.0으로 실시간 스트리밍됩니다.";
 "settings.models.overview.googleCloud" = "음성 인식은 Google Cloud Speech-to-Text로 직접 실시간 스트리밍됩니다.";
 "settings.models.overview.groq" = "음성 인식은 Groq의 고속 추론 엔드포인트가 Whisper 모델을 사용하여 처리합니다.";
+"settings.models.overview.soniox" = "Speech recognition is streamed in real time to Soniox V5 via WebSocket.";
 "settings.models.overview.typefluxOfficial" = "음성 인식은 Typeflux 내장 서비스로 처리됩니다.";
 "settings.models.overview.typefluxCloud" = "텍스트 재작성과 편집은 Typeflux 내장 LLM 서비스로 처리됩니다.";
 "settings.models.mode.local" = "지역";
@@ -721,6 +725,7 @@
 "settings.models.focused.doubao" = "Doubao Speech Recognition 2.0을 통해 대기 시간이 가장 짧은 클라우드 받아쓰기 경로를 원하는 경우 이 기능을 사용하세요.";
 "settings.models.focused.googleCloud" = "Google Cloud Speech-to-Text의 실시간 스트리밍 인식을 원할 때 사용하세요.";
 "settings.models.focused.groq" = "Groq의 고속 추론을 사용한 빠른 클라우드 전사를 원할 때 이 기능을 사용하세요.";
+"settings.models.focused.soniox" = "Use this for accurate real-time cloud transcription via Soniox V5 across 60+ languages.";
 "settings.models.focused.typefluxOfficial" = "Typeflux 내장 음성 인식 서비스를 사용합니다. 로그인만 하면 추가 설정 없이 사용 가능합니다.";
 "settings.models.focused.typefluxCloud" = "Typeflux 내장 LLM 서비스로 텍스트 재작성과 편집을 사용합니다. 로그인만 하면 추가 설정 없이 사용 가능합니다.";
 "settings.models.routing" = "라우팅 동작";
@@ -737,6 +742,7 @@
 "settings.models.routing.doubao" = "Doubao Speech Recognition 2.0은 ByteDance의 바이너리 WebSocket 프로토콜을 통해 실시간 스트리밍 ASR을 처리합니다.";
 "settings.models.routing.googleCloud" = "Google Cloud Speech-to-Text는 이 Mac에서 직접 실시간 스트리밍 ASR을 처리합니다.";
 "settings.models.routing.groq" = "Groq는 Whisper 호환 전사 엔드포인트를 통한 고속 추론으로 받아쓰기를 처리합니다.";
+"settings.models.routing.soniox" = "Soniox V5 handles real-time streaming ASR via WebSocket with high accuracy across 60+ languages.";
 "settings.models.googleCloud.streaming" = "StreamingRecognize";
 "settings.models.googleCloud.projectID" = "Project ID";
 "settings.models.googleCloud.oauth.authorize" = "Google 인증";

--- a/Sources/Typeflux/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/zh-Hans.lproj/Localizable.strings
@@ -249,6 +249,7 @@
 "provider.stt.doubaoRealtime" = "豆包实时 ASR";
 "provider.stt.googleCloud" = "Google 语音转文字";
 "provider.stt.groq" = "Groq";
+"provider.stt.soniox" = "Soniox";
 "provider.stt.typefluxOfficial" = "Typeflux Cloud";
 "provider.llm.openAICompatible" = "OpenAI 兼容";
 "provider.llm.custom" = "自定义";
@@ -638,6 +639,7 @@
 "settings.models.useAliCloud" = "使用阿里云";
 "settings.models.useDoubao" = "使用豆包";
 "settings.models.useGroq" = "使用 Groq";
+"settings.models.useSoniox" = "使用 Soniox";
 "settings.models.useTypefluxOfficial" = "使用 Typeflux 官方";
 "settings.models.useTypefluxCloud" = "使用 Typeflux Cloud";
 "settings.models.badge.local" = "本地";
@@ -654,6 +656,7 @@
 "settings.models.card.doubao.summary" = "通过豆包语音识别 2.0 和字节原生二进制 WebSocket 协议进行低延迟流式识别。";
 "settings.models.card.googleCloud.summary" = "通过 Google Cloud Speech-to-Text 执行实时流式语音识别。";
 "settings.models.card.groq.summary" = "通过 Groq 推理接口进行高速 Whisper 转写，默认模型为 whisper-large-v3-turbo。";
+"settings.models.card.soniox.summary" = "通过 Soniox V5 进行实时流式语音识别，支持 60+ 种语言，低延迟 WebSocket 连接。";
 "settings.models.card.typefluxOfficial.summary" = "Typeflux 内置语音识别服务。登录 Typeflux 账号即可使用，无需额外的 API 密钥。";
 "settings.models.card.typefluxCloud.summary" = "Typeflux 内置大语言模型服务。登录 Typeflux 账号即可使用，无需额外的 API 密钥。";
 "settings.models.card.ollama.summary" = "本地执行改写和编辑任务，并可选自动准备模型。";
@@ -711,6 +714,7 @@
 "settings.models.overview.doubao" = "语音识别会通过字节 WebSocket 实时流式发送到豆包语音识别 2.0。";
 "settings.models.overview.googleCloud" = "语音识别会直接实时流式发送到 Google Cloud Speech-to-Text。";
 "settings.models.overview.groq" = "语音识别由 Groq 的高速推理接口通过 Whisper 模型处理。";
+"settings.models.overview.soniox" = "语音识别通过 WebSocket 实时流式传输至 Soniox V5，支持 60+ 种语言。";
 "settings.models.overview.typefluxOfficial" = "语音识别由 Typeflux 内置服务处理。";
 "settings.models.overview.typefluxCloud" = "文字改写和编辑由 Typeflux 内置大语言模型服务处理。";
 "settings.models.mode.local" = "本地";
@@ -732,6 +736,7 @@
 "settings.models.focused.doubao" = "适合希望通过豆包语音识别 2.0 获得最低延迟云端听写路径的场景。";
 "settings.models.focused.googleCloud" = "适合希望使用 Google Cloud Speech-to-Text 进行实时流式识别的场景。";
 "settings.models.focused.groq" = "适合希望使用 Groq 加速推理进行快速云端转写的场景。";
+"settings.models.focused.soniox" = "适合需要通过 Soniox V5 进行高精度实时云端语音识别、支持 60+ 种语言的场景。";
 "settings.models.focused.typefluxOfficial" = "使用 Typeflux 内置语音识别服务，只需登录即可，无需额外配置。";
 "settings.models.focused.typefluxCloud" = "使用 Typeflux 内置大语言模型服务进行文字改写和编辑。只需登录即可，无需额外配置。";
 "settings.models.routing" = "路由行为";
@@ -748,6 +753,7 @@
 "settings.models.routing.doubao" = "豆包语音识别 2.0 会通过字节二进制 WebSocket 协议处理实时流式 ASR。";
 "settings.models.routing.googleCloud" = "Google Cloud Speech-to-Text 会直接从此 Mac 处理实时流式 ASR。";
 "settings.models.routing.groq" = "Groq 会通过 Whisper 兼容转写接口以加速推理处理听写。";
+"settings.models.routing.soniox" = "Soniox V5 通过 WebSocket 实时流式处理语音识别，支持 60+ 种语言，准确率高。";
 "settings.models.googleCloud.streaming" = "StreamingRecognize";
 "settings.models.googleCloud.projectID" = "Project ID";
 "settings.models.googleCloud.oauth.authorize" = "授权 Google";

--- a/Sources/Typeflux/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/zh-Hant.lproj/Localizable.strings
@@ -247,6 +247,7 @@
 "provider.stt.doubaoRealtime" = "豆包即時 ASR";
 "provider.stt.googleCloud" = "Google 語音轉文字";
 "provider.stt.groq" = "Groq";
+"provider.stt.soniox" = "Soniox";
 "provider.stt.typefluxOfficial" = "Typeflux Cloud";
 "provider.llm.openAICompatible" = "OpenAI 相容";
 "provider.llm.custom" = "自訂";
@@ -636,6 +637,7 @@
 "settings.models.useAliCloud" = "使用阿里雲";
 "settings.models.useDoubao" = "使用豆包";
 "settings.models.useGroq" = "使用 Groq";
+"settings.models.useSoniox" = "Use Soniox";
 "settings.models.useTypefluxOfficial" = "使用 Typeflux 官方";
 "settings.models.useTypefluxCloud" = "使用 Typeflux Cloud";
 "settings.models.badge.local" = "本地";
@@ -652,6 +654,7 @@
 "settings.models.card.doubao.summary" = "透過豆包語音辨識 2.0 與位元組原生二進位 WebSocket 協議進行低延遲串流辨識。";
 "settings.models.card.googleCloud.summary" = "透過 Google Cloud Speech-to-Text 執行即時串流語音辨識。";
 "settings.models.card.groq.summary" = "透過 Groq 推理介面進行高速 Whisper 轉寫，預設模型為 whisper-large-v3-turbo。";
+"settings.models.card.soniox.summary" = "Real-time streaming recognition via Soniox V5 with high accuracy across 60+ languages.";
 "settings.models.card.typefluxOfficial.summary" = "Typeflux 內建語音辨識服務。登入 Typeflux 帳號即可使用，無需額外的 API 金鑰。";
 "settings.models.card.typefluxCloud.summary" = "Typeflux 內建大型語言模型服務。登入 Typeflux 帳號即可使用，無需額外的 API 金鑰。";
 "settings.models.card.ollama.summary" = "在本地執行改寫與編輯任務，並可選擇自動準備模型。";
@@ -707,6 +710,7 @@
 "settings.models.overview.doubao" = "語音辨識會透過位元組 WebSocket 即時串流到豆包語音辨識 2.0。";
 "settings.models.overview.googleCloud" = "語音辨識會直接即時串流到 Google Cloud Speech-to-Text。";
 "settings.models.overview.groq" = "語音辨識由 Groq 的高速推理介面透過 Whisper 模型處理。";
+"settings.models.overview.soniox" = "Speech recognition is streamed in real time to Soniox V5 via WebSocket.";
 "settings.models.overview.typefluxOfficial" = "語音辨識由 Typeflux 內建服務處理。";
 "settings.models.overview.typefluxCloud" = "文字改寫和編輯由 Typeflux 內建大型語言模型服務處理。";
 "settings.models.mode.local" = "本地";
@@ -728,6 +732,7 @@
 "settings.models.focused.doubao" = "適合希望透過豆包語音辨識 2.0 獲得最低延遲雲端聽寫路徑的情境。";
 "settings.models.focused.googleCloud" = "適合希望使用 Google Cloud Speech-to-Text 進行即時串流辨識的情境。";
 "settings.models.focused.groq" = "適合希望使用 Groq 加速推理進行快速雲端轉寫的情境。";
+"settings.models.focused.soniox" = "Use this for accurate real-time cloud transcription via Soniox V5 across 60+ languages.";
 "settings.models.focused.typefluxOfficial" = "使用 Typeflux 內建語音辨識服務，只需登入即可，無需額外設定。";
 "settings.models.focused.typefluxCloud" = "使用 Typeflux 內建大型語言模型服務進行文字改寫和編輯。只需登入即可，無需額外設定。";
 "settings.models.routing" = "路由行為";
@@ -744,6 +749,7 @@
 "settings.models.routing.doubao" = "豆包語音辨識 2.0 會透過位元組二進位 WebSocket 協議處理即時串流 ASR。";
 "settings.models.routing.googleCloud" = "Google Cloud Speech-to-Text 會直接從此 Mac 處理即時串流 ASR。";
 "settings.models.routing.groq" = "Groq 會透過 Whisper 相容轉寫介面以加速推理處理聽寫。";
+"settings.models.routing.soniox" = "Soniox V5 handles real-time streaming ASR via WebSocket with high accuracy across 60+ languages.";
 "settings.models.googleCloud.streaming" = "StreamingRecognize";
 "settings.models.googleCloud.projectID" = "Project ID";
 "settings.models.googleCloud.oauth.authorize" = "授權 Google";

--- a/Sources/Typeflux/STT/STTRouter+Recording.swift
+++ b/Sources/Typeflux/STT/STTRouter+Recording.swift
@@ -47,6 +47,13 @@ extension STTRouter {
                 onUpdate: onUpdate,
                 failureContext: "Google Cloud realtime session setup failed"
             )
+        case .soniox:
+            return await makeRealtimeTranscriptionSession(
+                provider: soniox,
+                scenario: scenario,
+                onUpdate: onUpdate,
+                failureContext: "Soniox realtime session setup failed"
+            )
         case .typefluxOfficial:
             return await makeRealtimeTranscriptionSession(
                 provider: typefluxOfficial,

--- a/Sources/Typeflux/STT/STTRouter+Transcription.swift
+++ b/Sources/Typeflux/STT/STTRouter+Transcription.swift
@@ -15,7 +15,7 @@ extension STTRouter {
         onUpdate: @escaping @Sendable (TranscriptionSnapshot) async -> Void
     ) async throws -> String {
         switch settingsStore.sttProvider {
-        case .freeModel, .whisperAPI, .aliCloud, .doubaoRealtime, .googleCloud:
+        case .freeModel, .whisperAPI, .aliCloud, .doubaoRealtime, .googleCloud, .soniox:
             try await transcribeWithRemoteProvider(
                 route: remoteSTTRoute(for: settingsStore.sttProvider),
                 audioFile: audioFile,
@@ -199,6 +199,14 @@ extension STTRouter {
                 failureContext: "Google Cloud Speech-to-Text failed",
                 autoModelSuccessMessage: "Auto local model succeeded after Google Cloud STT failure",
                 appleFallbackMessage: "Falling back to Apple Speech after Google Cloud STT failure"
+            )
+        case .soniox:
+            return RemoteSTTRoute(
+                provider: soniox,
+                operationName: "Soniox STT request",
+                failureContext: "Soniox ASR failed",
+                autoModelSuccessMessage: "Auto local model succeeded after Soniox ASR failure",
+                appleFallbackMessage: "Falling back to Apple Speech after Soniox ASR failure"
             )
         default:
             assertionFailure("Unexpected non-remote STT provider")

--- a/Sources/Typeflux/STT/SonioxTranscriber.swift
+++ b/Sources/Typeflux/STT/SonioxTranscriber.swift
@@ -1,0 +1,607 @@
+import AVFoundation
+import Foundation
+
+// MARK: - Defaults
+
+enum SonioxASRDefaults {
+    static let model = "stt-rt-v5"
+    static let suggestedModels = ["stt-rt-v5"]
+    static let websocketURL = "wss://stt-rt.soniox.com/transcribe-websocket"
+    /// 100ms of PCM16 at 16kHz mono: 16000 * 0.1 * 2 bytes = 3200
+    static let chunkSize = 3200
+    /// 1500ms of silence appended before sending the stop signal so the server
+    /// can finalize any pending tokens before the stream ends.
+    static let trailingSilenceBytes = 48000
+    /// Timeout waiting for the server to emit `finished: true` after we send the
+    /// empty-string stop signal.
+    static let finishTimeout: Duration = .seconds(5)
+}
+
+// MARK: - Main Transcriber
+
+final class SonioxTranscriber: Transcriber, RealtimeTranscriptionSessionFactory {
+    private let settingsStore: SettingsStore
+
+    init(settingsStore: SettingsStore) {
+        self.settingsStore = settingsStore
+    }
+
+    static func testConnection(apiKey: String, model: String = SonioxASRDefaults.model) async throws -> String {
+        let trimmedKey = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedKey.isEmpty else {
+            throw NSError(
+                domain: "SonioxTranscriber",
+                code: 1001,
+                userInfo: [NSLocalizedDescriptionKey: "Soniox API key is not configured."]
+            )
+        }
+        let resolvedModel = model.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            ? SonioxASRDefaults.model
+            : model.trimmingCharacters(in: .whitespacesAndNewlines)
+        let pcmData = RemoteSTTTestAudio.pcm16MonoSilence()
+        return try await SonioxSession.run(pcmData: pcmData, model: resolvedModel, apiKey: trimmedKey) { _ in }
+    }
+
+    func transcribe(audioFile: AudioFile) async throws -> String {
+        try await transcribeStream(audioFile: audioFile) { _ in }
+    }
+
+    func transcribeStream(
+        audioFile: AudioFile,
+        onUpdate: @escaping @Sendable (TranscriptionSnapshot) async -> Void
+    ) async throws -> String {
+        let apiKey = settingsStore.sonioxAPIKey.trimmingCharacters(in: .whitespacesAndNewlines)
+        let model = settingsStore.sonioxModel
+
+        guard !apiKey.isEmpty else {
+            throw NSError(
+                domain: "SonioxTranscriber",
+                code: 1,
+                userInfo: [NSLocalizedDescriptionKey: "Soniox API key is not configured."]
+            )
+        }
+
+        let pcmData = try SonioxAudioConverter.convert(url: audioFile.fileURL)
+        return try await SonioxSession.run(pcmData: pcmData, model: model, apiKey: apiKey, onUpdate: onUpdate)
+    }
+
+    func makeRealtimeTranscriptionSession(
+        scenario _: TypefluxCloudScenario,
+        onUpdate: @escaping @Sendable (TranscriptionSnapshot) async -> Void
+    ) async throws -> any RealtimeTranscriptionSession {
+        let apiKey = settingsStore.sonioxAPIKey.trimmingCharacters(in: .whitespacesAndNewlines)
+        let model = settingsStore.sonioxModel
+
+        guard !apiKey.isEmpty else {
+            throw NSError(
+                domain: "SonioxTranscriber",
+                code: 1,
+                userInfo: [NSLocalizedDescriptionKey: "Soniox API key is not configured."]
+            )
+        }
+
+        let upstream = SonioxSession(model: model, apiKey: apiKey, onUpdate: onUpdate)
+        return BufferedRealtimeTranscriptionSession(upstream: upstream)
+    }
+}
+
+// MARK: - Audio Converter
+
+private enum SonioxAudioConverter {
+    static let targetSampleRate: Double = 16000
+
+    static func convert(url: URL) throws -> Data {
+        let sourceFile = try AVAudioFile(forReading: url)
+        let sourceFormat = sourceFile.processingFormat
+        let totalSourceFrames = AVAudioFrameCount(sourceFile.length)
+
+        guard let targetFormat = AVAudioFormat(
+            commonFormat: .pcmFormatInt16,
+            sampleRate: targetSampleRate,
+            channels: 1,
+            interleaved: true
+        ) else {
+            throw NSError(
+                domain: "SonioxAudioConverter",
+                code: 1,
+                userInfo: [NSLocalizedDescriptionKey: "Failed to create target audio format."]
+            )
+        }
+
+        guard let converter = AVAudioConverter(from: sourceFormat, to: targetFormat) else {
+            throw NSError(
+                domain: "SonioxAudioConverter",
+                code: 2,
+                userInfo: [NSLocalizedDescriptionKey: "Failed to create audio converter."]
+            )
+        }
+
+        guard let sourceBuffer = AVAudioPCMBuffer(pcmFormat: sourceFormat, frameCapacity: totalSourceFrames) else {
+            throw NSError(
+                domain: "SonioxAudioConverter",
+                code: 3,
+                userInfo: [NSLocalizedDescriptionKey: "Failed to allocate source buffer."]
+            )
+        }
+        try sourceFile.read(into: sourceBuffer)
+
+        let ratio = targetSampleRate / sourceFormat.sampleRate
+        let targetCapacity = AVAudioFrameCount(Double(totalSourceFrames) * ratio) + 512
+        guard let targetBuffer = AVAudioPCMBuffer(pcmFormat: targetFormat, frameCapacity: targetCapacity) else {
+            throw NSError(
+                domain: "SonioxAudioConverter",
+                code: 4,
+                userInfo: [NSLocalizedDescriptionKey: "Failed to allocate target buffer."]
+            )
+        }
+
+        var hasProvidedInput = false
+        var convertError: NSError?
+        let status = converter.convert(to: targetBuffer, error: &convertError) { _, outStatus in
+            if hasProvidedInput {
+                outStatus.pointee = .noDataNow
+                return nil
+            }
+            hasProvidedInput = true
+            outStatus.pointee = .haveData
+            return sourceBuffer
+        }
+
+        if let convertError { throw convertError }
+        guard status != .error else {
+            throw NSError(
+                domain: "SonioxAudioConverter",
+                code: 5,
+                userInfo: [NSLocalizedDescriptionKey: "Audio conversion failed."]
+            )
+        }
+
+        let bytesPerFrame = Int(targetFormat.streamDescription.pointee.mBytesPerFrame)
+        let byteCount = Int(targetBuffer.frameLength) * bytesPerFrame
+        guard let channelData = targetBuffer.int16ChannelData else { return Data() }
+        return Data(bytes: channelData[0], count: byteCount)
+    }
+}
+
+// MARK: - WebSocket Session
+
+/// Soniox real-time WebSocket session.
+///
+/// Protocol summary:
+/// 1. Connect to `wss://stt-rt.soniox.com/transcribe-websocket`
+/// 2. Send one JSON config message as the very first message
+/// 3. Stream raw PCM16-le 16kHz mono binary frames
+/// 4. Send an empty string `""` to signal end-of-stream
+/// 5. Server streams back JSON responses with `tokens[]` until it sends `finished: true`
+actor SonioxSession: PCM16RealtimeTranscriptionSession {
+    static func run(
+        pcmData: Data,
+        model: String,
+        apiKey: String,
+        onUpdate: @escaping @Sendable (TranscriptionSnapshot) async -> Void
+    ) async throws -> String {
+        let session = SonioxSession(model: model, apiKey: apiKey, onUpdate: onUpdate)
+        try await session.start()
+        try await session.appendPCM16(pcmData)
+        return try await session.finish()
+    }
+
+    private let model: String
+    private let apiKey: String
+    private let onUpdate: @Sendable (TranscriptionSnapshot) async -> Void
+    private let snapshotDispatcher: SonioxSnapshotDispatcher
+
+    // Text accumulation: `finalText` collects tokens where `is_final == true`.
+    // `partialText` holds the current non-final tokens that update continuously.
+    private var finalText: String = ""
+    private var partialText: String = ""
+    private var lastEmitted: String = ""
+
+    private var sessionReady = false
+    private var sessionFinished = false
+    private var sessionError: Error?
+    private var sessionReadyCont: CheckedContinuation<Void, Error>?
+    private var sessionFinishedCont: CheckedContinuation<Void, Error>?
+
+    private var urlSession: URLSession?
+    private var socketTask: URLSessionWebSocketTask?
+    private var receiveTask: Task<Void, Never>?
+
+    init(
+        model: String,
+        apiKey: String,
+        onUpdate: @escaping @Sendable (TranscriptionSnapshot) async -> Void
+    ) {
+        self.model = model
+        self.apiKey = apiKey
+        self.onUpdate = onUpdate
+        snapshotDispatcher = SonioxSnapshotDispatcher(onUpdate: onUpdate)
+    }
+
+    func start() async throws {
+        let url = URL(string: SonioxASRDefaults.websocketURL)!
+        let request = URLRequest(url: url)
+        NetworkDebugLogger.logRequest(request, bodyDescription: "<websocket handshake>")
+        NetworkDebugLogger.logWebSocketEvent(provider: "Soniox", phase: "connect", details: "model=\(model)")
+
+        let socketDelegate = SonioxWSDelegate()
+        let urlSession = URLSession(configuration: .default, delegate: socketDelegate, delegateQueue: nil)
+        let socketTask = urlSession.webSocketTask(with: request)
+        self.urlSession = urlSession
+        self.socketTask = socketTask
+        socketTask.resume()
+
+        try await socketDelegate.waitUntilOpen(timeout: .seconds(10))
+        NetworkDebugLogger.logWebSocketEvent(provider: "Soniox", phase: "open")
+
+        // Send the initial config as the very first message.
+        let config: [String: Any] = [
+            "api_key": apiKey,
+            "model": model,
+            "audio_format": "pcm_s16le",
+            "sample_rate": 16000,
+            "num_channels": 1
+        ]
+        try await sendJSON(config, to: socketTask)
+
+        // Start background receive loop — the server does not send a separate
+        // "session ready" event; it just starts accepting audio immediately after
+        // the config is sent, so we mark the session as ready right away.
+        receiveTask = Task { [weak self] in
+            await self?.receiveLoop(socketTask: socketTask)
+        }
+
+        sessionReady = true
+        sessionReadyCont?.resume()
+        sessionReadyCont = nil
+    }
+
+    func appendPCM16(_ data: Data) async throws {
+        guard let socketTask else {
+            throw NSError(
+                domain: "SonioxSession",
+                code: 6,
+                userInfo: [NSLocalizedDescriptionKey: "Soniox WebSocket is not connected."]
+            )
+        }
+        var offset = data.startIndex
+        let chunkSize = SonioxASRDefaults.chunkSize
+        while offset < data.endIndex {
+            let end = data.index(offset, offsetBy: chunkSize, limitedBy: data.endIndex) ?? data.endIndex
+            try await socketTask.send(.data(Data(data[offset ..< end])))
+            offset = end
+        }
+    }
+
+    func finish() async throws -> String {
+        defer {
+            receiveTask?.cancel()
+            receiveTask = nil
+            socketTask?.cancel(with: .normalClosure, reason: nil)
+            socketTask = nil
+            urlSession?.invalidateAndCancel()
+            urlSession = nil
+        }
+
+        guard let socketTask else {
+            throw NSError(
+                domain: "SonioxSession",
+                code: 7,
+                userInfo: [NSLocalizedDescriptionKey: "Soniox WebSocket is not connected."]
+            )
+        }
+
+        // Append trailing silence so the server can finalize any pending tokens
+        // before the stream ends.
+        let silencePadding = Data(count: SonioxASRDefaults.trailingSilenceBytes)
+        var silenceOffset = silencePadding.startIndex
+        let chunkSize = SonioxASRDefaults.chunkSize
+        while silenceOffset < silencePadding.endIndex {
+            let end = silencePadding.index(
+                silenceOffset,
+                offsetBy: chunkSize,
+                limitedBy: silencePadding.endIndex
+            ) ?? silencePadding.endIndex
+            try await socketTask.send(.data(Data(silencePadding[silenceOffset ..< end])))
+            silenceOffset = end
+        }
+
+        // Soniox protocol: sending an empty string signals end-of-stream.
+        NetworkDebugLogger.logWebSocketEvent(provider: "Soniox", phase: "send", details: "<end-of-stream>")
+        try await socketTask.send(.string(""))
+
+        // Wait for the server to emit `finished: true`.
+        try await waitForSessionFinished()
+        await snapshotDispatcher.flush()
+
+        return composedText().trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    func cancel() async {
+        receiveTask?.cancel()
+        receiveTask = nil
+        socketTask?.cancel(with: .normalClosure, reason: nil)
+        socketTask = nil
+        urlSession?.invalidateAndCancel()
+        urlSession = nil
+        sessionReadyCont?.resume(throwing: CancellationError())
+        sessionReadyCont = nil
+        sessionFinishedCont?.resume(throwing: CancellationError())
+        sessionFinishedCont = nil
+    }
+
+    // MARK: - Receive loop
+
+    private func receiveLoop(socketTask: URLSessionWebSocketTask) async {
+        while !Task.isCancelled {
+            do {
+                let message = try await socketTask.receive()
+                let data: Data? = switch message {
+                case let .data(d): d
+                case let .string(s): s.data(using: .utf8)
+                @unknown default: nil
+                }
+                guard let data else { continue }
+                NetworkDebugLogger.logWebSocketEvent(
+                    provider: "Soniox",
+                    phase: "receive",
+                    details: String(data: data, encoding: .utf8) ?? "<\(data.count) bytes>"
+                )
+                await handleEvent(data: data)
+            } catch {
+                if !Task.isCancelled {
+                    NetworkDebugLogger.logError(context: "Soniox receive loop failed", error: error)
+                    signalError(error)
+                }
+                break
+            }
+        }
+    }
+
+    private func handleEvent(data: Data) async {
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { return }
+
+        // Handle error response from server.
+        if let errorMessage = json["error_message"] as? String {
+            let errorType = json["error_type"] as? String ?? "UNKNOWN"
+            NetworkDebugLogger.logWebSocketEvent(
+                provider: "Soniox",
+                phase: "error",
+                details: "type=\(errorType) message=\(errorMessage)"
+            )
+            signalError(NSError(
+                domain: "SonioxSession",
+                code: -1,
+                userInfo: [NSLocalizedDescriptionKey: "[\(errorType)] \(errorMessage)"]
+            ))
+            return
+        }
+
+        // Handle `finished: true` — session complete.
+        if let isFinished = json["finished"] as? Bool, isFinished {
+            NetworkDebugLogger.logWebSocketEvent(provider: "Soniox", phase: "finished")
+            // Promote any remaining partial text to final before closing.
+            if !partialText.isEmpty {
+                finalText += partialText
+                partialText = ""
+            }
+            let preview = composedText()
+            if preview != lastEmitted {
+                lastEmitted = preview
+                await snapshotDispatcher.submit(TranscriptionSnapshot(text: preview, isFinal: true))
+            }
+            sessionFinished = true
+            sessionFinishedCont?.resume()
+            sessionFinishedCont = nil
+            return
+        }
+
+        // Handle token updates.
+        guard let tokens = json["tokens"] as? [[String: Any]], !tokens.isEmpty else { return }
+
+        var newFinalText = ""
+        var newPartialText = ""
+
+        for token in tokens {
+            let text = token["text"] as? String ?? ""
+            let isFinal = token["is_final"] as? Bool ?? false
+            if isFinal {
+                newFinalText += text
+            } else {
+                newPartialText += text
+            }
+        }
+
+        // Soniox sends the full window each time — `newFinalText` contains all
+        // confirmed tokens received in this message, and `newPartialText` contains
+        // the current non-final hypothesis. We accumulate confirmed tokens into
+        // `finalText` only from the delta, while `partialText` is replaced wholesale.
+        if !newFinalText.isEmpty {
+            finalText += newFinalText
+        }
+        partialText = newPartialText
+
+        let preview = composedText()
+        guard preview != lastEmitted else { return }
+        lastEmitted = preview
+        await snapshotDispatcher.submit(TranscriptionSnapshot(text: preview, isFinal: false))
+    }
+
+    private func composedText() -> String {
+        if partialText.isEmpty {
+            return finalText
+        }
+        return finalText + partialText
+    }
+
+    private func signalError(_ error: Error) {
+        sessionError = error
+        sessionReadyCont?.resume(throwing: error)
+        sessionReadyCont = nil
+        sessionFinishedCont?.resume(throwing: error)
+        sessionFinishedCont = nil
+    }
+
+    private func waitForSessionFinished() async throws {
+        if sessionFinished { return }
+        if let error = sessionError { throw error }
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            group.addTask {
+                try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
+                    Task { await self.storeFinishedContinuation(cont) }
+                }
+            }
+            group.addTask {
+                try await Task.sleep(for: SonioxASRDefaults.finishTimeout)
+                throw NSError(
+                    domain: "SonioxSession",
+                    code: 8,
+                    userInfo: [NSLocalizedDescriptionKey: "Timed out waiting for Soniox session to finish."]
+                )
+            }
+            try await group.next()
+            group.cancelAll()
+        }
+    }
+
+    private func storeFinishedContinuation(_ cont: CheckedContinuation<Void, Error>) {
+        if sessionFinished {
+            cont.resume()
+        } else if let error = sessionError {
+            cont.resume(throwing: error)
+        } else {
+            sessionFinishedCont = cont
+        }
+    }
+
+    private func sendJSON(_ json: [String: Any], to socketTask: URLSessionWebSocketTask) async throws {
+        let data = try JSONSerialization.data(withJSONObject: json)
+        guard let text = String(data: data, encoding: .utf8) else {
+            throw NSError(
+                domain: "SonioxSession",
+                code: 2,
+                userInfo: [NSLocalizedDescriptionKey: "Failed to encode JSON payload."]
+            )
+        }
+        NetworkDebugLogger.logWebSocketEvent(provider: "Soniox", phase: "send", details: text)
+        try await socketTask.send(.string(text))
+    }
+}
+
+// MARK: - Snapshot Dispatcher
+
+private actor SonioxSnapshotDispatcher {
+    private let onUpdate: @Sendable (TranscriptionSnapshot) async -> Void
+    private var pendingSnapshot: TranscriptionSnapshot?
+    private var isDispatching = false
+    private var flushContinuations: [CheckedContinuation<Void, Never>] = []
+
+    init(onUpdate: @escaping @Sendable (TranscriptionSnapshot) async -> Void) {
+        self.onUpdate = onUpdate
+    }
+
+    func submit(_ snapshot: TranscriptionSnapshot) {
+        pendingSnapshot = merge(existing: pendingSnapshot, incoming: snapshot)
+        guard !isDispatching else { return }
+        isDispatching = true
+        Task { await drain() }
+    }
+
+    func flush() async {
+        if !isDispatching, pendingSnapshot == nil { return }
+        await withCheckedContinuation { continuation in
+            flushContinuations.append(continuation)
+        }
+    }
+
+    private func drain() async {
+        while true {
+            guard let snapshot = pendingSnapshot else {
+                isDispatching = false
+                let continuations = flushContinuations
+                flushContinuations.removeAll()
+                for continuation in continuations { continuation.resume() }
+                return
+            }
+            pendingSnapshot = nil
+            await onUpdate(snapshot)
+        }
+    }
+
+    private func merge(
+        existing: TranscriptionSnapshot?,
+        incoming: TranscriptionSnapshot
+    ) -> TranscriptionSnapshot {
+        guard let existing else { return incoming }
+        if incoming.isFinal || !existing.isFinal { return incoming }
+        return existing
+    }
+}
+
+// MARK: - WebSocket Delegate
+
+private actor SonioxWSDelegateState {
+    private var opened = false
+    private var continuation: CheckedContinuation<Void, Error>?
+
+    func waitUntilOpen(timeout: Duration) async throws {
+        if opened { return }
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            group.addTask {
+                try await withCheckedThrowingContinuation { continuation in
+                    Task { await self.store(continuation: continuation) }
+                }
+            }
+            group.addTask {
+                try await Task.sleep(for: timeout)
+                throw NSError(
+                    domain: "SonioxWSDelegate",
+                    code: 1,
+                    userInfo: [NSLocalizedDescriptionKey: "WebSocket handshake timed out."]
+                )
+            }
+            try await group.next()
+            group.cancelAll()
+        }
+    }
+
+    func markOpened() {
+        opened = true
+        continuation?.resume()
+        continuation = nil
+    }
+
+    func markFailed(_ error: Error) {
+        continuation?.resume(throwing: error)
+        continuation = nil
+    }
+
+    private func store(continuation: CheckedContinuation<Void, Error>) {
+        self.continuation = continuation
+    }
+}
+
+private final class SonioxWSDelegate: NSObject, URLSessionWebSocketDelegate, URLSessionTaskDelegate {
+    private let state = SonioxWSDelegateState()
+
+    func waitUntilOpen(timeout: Duration) async throws {
+        try await state.waitUntilOpen(timeout: timeout)
+    }
+
+    func urlSession(
+        _: URLSession,
+        webSocketTask _: URLSessionWebSocketTask,
+        didOpenWithProtocol _: String?
+    ) {
+        Task { await state.markOpened() }
+    }
+
+    func urlSession(
+        _: URLSession,
+        task _: URLSessionTask,
+        didCompleteWithError error: Error?
+    ) {
+        guard let error else { return }
+        Task { await state.markFailed(error) }
+    }
+}

--- a/Sources/Typeflux/STT/Transcriber.swift
+++ b/Sources/Typeflux/STT/Transcriber.swift
@@ -77,6 +77,7 @@ final class STTRouter {
     let doubaoRealtime: Transcriber
     let googleCloud: Transcriber
     let groq: Transcriber
+    let soniox: Transcriber
     let typefluxOfficial: Transcriber
     let typefluxCloudLoginFallbackLocalModel: Transcriber?
     let autoModelDownloadService: AutoModelDownloadService?
@@ -94,6 +95,7 @@ final class STTRouter {
         doubaoRealtime: Transcriber,
         googleCloud: Transcriber,
         groq: Transcriber,
+        soniox: Transcriber,
         typefluxOfficial: Transcriber,
         typefluxCloudLoginFallbackLocalModel: Transcriber? = nil,
         autoModelDownloadService: AutoModelDownloadService? = nil,
@@ -114,6 +116,7 @@ final class STTRouter {
         self.doubaoRealtime = doubaoRealtime
         self.googleCloud = googleCloud
         self.groq = groq
+        self.soniox = soniox
         self.typefluxOfficial = typefluxOfficial
         self.typefluxCloudLoginFallbackLocalModel = typefluxCloudLoginFallbackLocalModel
         self.autoModelDownloadService = autoModelDownloadService

--- a/Sources/Typeflux/Settings/AppPreferences.swift
+++ b/Sources/Typeflux/Settings/AppPreferences.swift
@@ -30,6 +30,7 @@ enum STTProvider: String, CaseIterable, Codable {
     case googleCloud
     case groq
     case typefluxOfficial
+    case soniox
 
     static let defaultProvider: STTProvider = .localModel
 
@@ -37,6 +38,7 @@ enum STTProvider: String, CaseIterable, Codable {
         .typefluxOfficial,
         .freeModel,
         .localModel,
+        .soniox,
         .aliCloud,
         .doubaoRealtime,
         .googleCloud,
@@ -71,6 +73,8 @@ enum STTProvider: String, CaseIterable, Codable {
             L("provider.stt.groq")
         case .typefluxOfficial:
             L("provider.stt.typefluxOfficial")
+        case .soniox:
+            L("provider.stt.soniox")
         }
     }
 

--- a/Sources/Typeflux/Settings/SettingsStore.swift
+++ b/Sources/Typeflux/Settings/SettingsStore.swift
@@ -329,6 +329,27 @@ final class SettingsStore {
         set { defaults.set(newValue, forKey: "stt.groq.model") }
     }
 
+    var sonioxAPIKey: String {
+        get { defaults.string(forKey: "stt.soniox.apiKey") ?? "" }
+        set { defaults.set(newValue, forKey: "stt.soniox.apiKey") }
+    }
+
+    var sonioxModel: String {
+        get {
+            let stored = defaults.string(forKey: "stt.soniox.model")?
+                .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            return stored.isEmpty ? SonioxASRDefaults.model : stored
+        }
+        set {
+            let trimmed = newValue.trimmingCharacters(in: .whitespacesAndNewlines)
+            if trimmed.isEmpty {
+                defaults.removeObject(forKey: "stt.soniox.model")
+            } else {
+                defaults.set(trimmed, forKey: "stt.soniox.model")
+            }
+        }
+    }
+
     var multimodalLLMModel: String {
         get { defaults.string(forKey: "stt.multimodal.model") ?? "" }
         set { defaults.set(newValue, forKey: "stt.multimodal.model") }

--- a/Sources/Typeflux/Settings/SettingsView.swift
+++ b/Sources/Typeflux/Settings/SettingsView.swift
@@ -4421,6 +4421,8 @@ struct StudioView: View {
                 .googleCloud
             case .groq:
                 .groqSTT
+            case .soniox:
+                .soniox
             case .typefluxOfficial:
                 .typefluxOfficial
             }
@@ -4543,6 +4545,17 @@ struct StudioView: View {
                     isSelected: viewModel.sttProvider == .groq,
                     isMuted: false,
                     actionTitle: L("settings.models.useGroq")
+                ),
+                StudioModelCard(
+                    id: StudioModelProviderID.soniox.rawValue,
+                    name: STTProvider.soniox.displayName,
+                    summary: L("settings.models.card.soniox.summary"),
+                    badge: L("settings.models.badge.api"),
+                    metadata: viewModel.sonioxModel.isEmpty
+                        ? L("settings.models.modelNotConfigured") : viewModel.sonioxModel,
+                    isSelected: viewModel.sttProvider == .soniox,
+                    isMuted: false,
+                    actionTitle: L("settings.models.useSoniox")
                 )
             ]
         )
@@ -4730,7 +4743,7 @@ struct StudioView: View {
 
                 if [
                     StudioModelProviderID.freeSTT, .whisperAPI, .multimodalLLM, .ollama, .aliCloud,
-                    .doubaoRealtime, .googleCloud, .groqSTT, .typefluxOfficial
+                    .doubaoRealtime, .googleCloud, .groqSTT, .soniox, .typefluxOfficial
                 ].contains(viewModel.focusedModelProvider) || focusedLLMRemoteProvider != nil {
                     HStack(spacing: StudioTheme.Spacing.small) {
                         Spacer()
@@ -4749,7 +4762,7 @@ struct StudioView: View {
                             }
                         } else if [
                             StudioModelProviderID.freeSTT, .whisperAPI, .multimodalLLM, .aliCloud,
-                            .doubaoRealtime, .googleCloud, .groqSTT, .typefluxOfficial
+                            .doubaoRealtime, .googleCloud, .groqSTT, .soniox, .typefluxOfficial
                         ].contains(viewModel.focusedModelProvider),
                             !viewModel.focusedModelProvider.requiresLoginForConnectionTest || authState.isLoggedIn {
                             StudioButton(
@@ -4778,7 +4791,7 @@ struct StudioView: View {
                         connectionTestResultView(viewModel.llmConnectionTestState)
                     } else if [
                         StudioModelProviderID.freeSTT, .whisperAPI, .multimodalLLM, .aliCloud,
-                        .doubaoRealtime, .googleCloud, .groqSTT, .typefluxOfficial
+                        .doubaoRealtime, .googleCloud, .groqSTT, .soniox, .typefluxOfficial
                     ].contains(viewModel.focusedModelProvider),
                         !viewModel.focusedModelProvider.requiresLoginForConnectionTest || authState.isLoggedIn {
                         connectionTestResultView(viewModel.sttConnectionTestState)
@@ -5210,6 +5223,25 @@ struct StudioView: View {
                         placeholder: OpenAIAudioModelCatalog.groqWhisperModels[0],
                         text: Binding(get: { viewModel.groqSTTModel }, set: viewModel.setGroqSTTModel),
                         suggestions: OpenAIAudioModelCatalog.groqWhisperModels
+                    )
+                }
+
+            case .soniox:
+                VStack(alignment: .leading, spacing: StudioTheme.Spacing.small) {
+                    StudioTextInputCard(
+                        label: L("common.apiKey"), placeholder: "sk-...",
+                        text: Binding(get: { viewModel.sonioxAPIKey }, set: viewModel.setSonioxAPIKey),
+                        secure: true
+                    ) {
+                        if let url = sttProviderAPIKeyURL(.soniox) {
+                            apiKeyHelpButton(url: url)
+                        }
+                    }
+                    StudioSuggestedTextInputCard(
+                        label: L("common.model"),
+                        placeholder: SonioxASRDefaults.model,
+                        text: Binding(get: { viewModel.sonioxModel }, set: viewModel.setSonioxModel),
+                        suggestions: SonioxASRDefaults.suggestedModels
                     )
                 }
             }
@@ -5746,6 +5778,8 @@ struct StudioView: View {
                 && viewModel.googleCloudOAuthAuthorized
         case .groqSTT:
             !viewModel.groqSTTAPIKey.isEmpty
+        case .soniox:
+            !viewModel.sonioxAPIKey.isEmpty
         case .typefluxOfficial:
             authState.isLoggedIn
         case .typefluxCloud:
@@ -5804,6 +5838,8 @@ struct StudioView: View {
             viewModel.setSTTProvider(.googleCloud)
         case .groqSTT:
             viewModel.setSTTProvider(.groq)
+        case .soniox:
+            viewModel.setSTTProvider(.soniox)
         case .typefluxOfficial:
             viewModel.setSTTProvider(.typefluxOfficial)
         case .typefluxCloud:
@@ -5865,6 +5901,8 @@ struct StudioView: View {
             "bolt.horizontal.circle"
         case .googleCloud:
             "cloud"
+        case .soniox:
+            "waveform.and.mic"
         case .typefluxOfficial:
             "infinity"
         case .typefluxCloud:
@@ -5915,6 +5953,8 @@ struct StudioView: View {
             L("settings.models.overview.googleCloud")
         case .groqSTT:
             L("settings.models.overview.groq")
+        case .soniox:
+            L("settings.models.overview.soniox")
         case .typefluxOfficial:
             L("settings.models.overview.typefluxOfficial")
         }
@@ -5947,6 +5987,8 @@ struct StudioView: View {
             STTProvider.googleCloud.displayName
         case .groqSTT:
             STTProvider.groq.displayName
+        case .soniox:
+            STTProvider.soniox.displayName
         case .typefluxOfficial:
             STTProvider.typefluxOfficial.displayName
         }
@@ -5958,7 +6000,7 @@ struct StudioView: View {
             L("settings.models.mode.local")
         case .freeSTT, .whisperAPI, .freeModel, .customLLM, .openRouter, .openAI, .anthropic,
              .gemini, .deepSeek, .kimi, .qwen, .zhipu, .minimax, .grok, .groq, .xiaomi, .openCodeZen, .openCodeGo,
-             .multimodalLLM, .aliCloud, .doubaoRealtime, .googleCloud, .groqSTT, .typefluxOfficial, .typefluxCloud:
+             .multimodalLLM, .aliCloud, .doubaoRealtime, .googleCloud, .groqSTT, .soniox, .typefluxOfficial, .typefluxCloud:
             L("settings.models.mode.remote")
         }
     }
@@ -5969,7 +6011,7 @@ struct StudioView: View {
             StudioTheme.success
         case .freeSTT, .whisperAPI, .freeModel, .customLLM, .openRouter, .openAI, .anthropic,
              .gemini, .deepSeek, .kimi, .qwen, .zhipu, .minimax, .grok, .groq, .xiaomi, .openCodeZen, .openCodeGo,
-             .multimodalLLM, .aliCloud, .doubaoRealtime, .googleCloud, .groqSTT, .typefluxOfficial, .typefluxCloud:
+             .multimodalLLM, .aliCloud, .doubaoRealtime, .googleCloud, .groqSTT, .soniox, .typefluxOfficial, .typefluxCloud:
             StudioTheme.accent
         }
     }
@@ -5980,7 +6022,7 @@ struct StudioView: View {
             StudioTheme.success.opacity(0.12)
         case .freeSTT, .whisperAPI, .freeModel, .customLLM, .openRouter, .openAI, .anthropic,
              .gemini, .deepSeek, .kimi, .qwen, .zhipu, .minimax, .grok, .groq, .xiaomi, .openCodeZen, .openCodeGo,
-             .multimodalLLM, .aliCloud, .doubaoRealtime, .googleCloud, .groqSTT, .typefluxOfficial, .typefluxCloud:
+             .multimodalLLM, .aliCloud, .doubaoRealtime, .googleCloud, .groqSTT, .soniox, .typefluxOfficial, .typefluxCloud:
             StudioTheme.accentSoft
         }
     }
@@ -6012,6 +6054,8 @@ struct StudioView: View {
             URL(string: "https://bailian.console.aliyun.com?tab=model#/api-key")
         case .multimodalLLM:
             URL(string: "https://platform.openai.com/api-keys")
+        case .soniox:
+            URL(string: "https://console.soniox.com/")
         case .doubaoRealtime, .googleCloud, .freeModel, .localModel, .appleSpeech, .typefluxOfficial:
             nil
         }
@@ -6096,6 +6140,8 @@ struct StudioView: View {
         case .groqSTT:
             viewModel.groqSTTModel.isEmpty
                 ? OpenAIAudioModelCatalog.groqWhisperModels[0] : viewModel.groqSTTModel
+        case .soniox:
+            viewModel.sonioxModel.isEmpty ? SonioxASRDefaults.model : viewModel.sonioxModel
         case .typefluxOfficial:
             STTProvider.typefluxOfficial.displayName
         case .typefluxCloud:
@@ -6133,6 +6179,8 @@ struct StudioView: View {
             STTProvider.googleCloud.displayName
         case .groqSTT:
             STTProvider.groq.displayName
+        case .soniox:
+            STTProvider.soniox.displayName
         case .typefluxOfficial:
             STTProvider.typefluxOfficial.displayName
         case .typefluxCloud:
@@ -6168,6 +6216,8 @@ struct StudioView: View {
             L("settings.models.focused.googleCloud")
         case .groqSTT:
             L("settings.models.focused.groq")
+        case .soniox:
+            L("settings.models.focused.soniox")
         case .typefluxOfficial:
             L("settings.models.focused.typefluxOfficial")
         case .typefluxCloud:
@@ -6206,6 +6256,8 @@ struct StudioView: View {
             L("settings.models.routing.googleCloud")
         case .groqSTT:
             L("settings.models.routing.groq")
+        case .soniox:
+            L("settings.models.routing.soniox")
         case .typefluxOfficial:
             L("settings.models.routing.typefluxOfficial")
         case .typefluxCloud:

--- a/Sources/Typeflux/Settings/SettingsViewModel.swift
+++ b/Sources/Typeflux/Settings/SettingsViewModel.swift
@@ -137,6 +137,8 @@ final class StudioViewModel: ObservableObject {
     @Published private(set) var isAuthorizingGoogleCloudOAuth = false
     @Published var groqSTTAPIKey: String
     @Published var groqSTTModel: String
+    @Published var sonioxAPIKey: String
+    @Published var sonioxModel: String
 
     @Published var localSTTModel: LocalSTTModel
     @Published var localSTTFocusedModel: LocalSTTModel
@@ -309,6 +311,8 @@ final class StudioViewModel: ObservableObject {
             focusedModelProvider = .googleCloud
         case .groq:
             focusedModelProvider = .groqSTT
+        case .soniox:
+            focusedModelProvider = .soniox
         case .typefluxOfficial:
             focusedModelProvider = .typefluxOfficial
         }
@@ -341,6 +345,8 @@ final class StudioViewModel: ObservableObject {
         googleCloudOAuthAuthorized = GoogleCloudSpeechCredentialResolver.isStoredAuthorizationAvailable()
         groqSTTAPIKey = settingsStore.groqSTTAPIKey
         groqSTTModel = settingsStore.groqSTTModel
+        sonioxAPIKey = settingsStore.sonioxAPIKey
+        sonioxModel = settingsStore.sonioxModel
         localSTTModel = settingsStore.localSTTModel
         localSTTFocusedModel = settingsStore.localSTTModel
         localSTTModelIdentifier = settingsStore.localSTTModelIdentifier
@@ -779,7 +785,7 @@ final class StudioViewModel: ObservableObject {
             case .appleSpeech, .localModel:
                 "Local Processing"
             case .freeModel, .whisperAPI, .multimodalLLM, .aliCloud, .doubaoRealtime, .googleCloud, .groq,
-                 .typefluxOfficial:
+                 .soniox, .typefluxOfficial:
                 "Remote API"
             }
         case .llm:
@@ -809,6 +815,8 @@ final class StudioViewModel: ObservableObject {
                 "Streaming audio directly to Google Cloud Speech-to-Text over gRPC."
             case .groq:
                 "Streaming audio to Groq for ultra-fast Whisper transcription."
+            case .soniox:
+                "Streaming audio to Soniox for real-time speech recognition."
             case .typefluxOfficial:
                 "Using Typeflux's built-in speech recognition service."
             }
@@ -1005,6 +1013,8 @@ final class StudioViewModel: ObservableObject {
             focusedModelProvider = .googleCloud
         case .groq:
             focusedModelProvider = .groqSTT
+        case .soniox:
+            focusedModelProvider = .soniox
         case .typefluxOfficial:
             focusedModelProvider = .typefluxOfficial
         }
@@ -1298,6 +1308,14 @@ final class StudioViewModel: ObservableObject {
 
     func setGroqSTTModel(_ value: String) {
         groqSTTModel = value; sttConnectionTestState = .idle
+    }
+
+    func setSonioxAPIKey(_ value: String) {
+        sonioxAPIKey = value; sttConnectionTestState = .idle
+    }
+
+    func setSonioxModel(_ value: String) {
+        sonioxModel = value; sttConnectionTestState = .idle
     }
 
     func setLocalSTTModelIdentifier(_ value: String) {
@@ -2394,6 +2412,9 @@ final class StudioViewModel: ObservableObject {
         case .groqSTT:
             settingsStore.groqSTTAPIKey = groqSTTAPIKey
             settingsStore.groqSTTModel = groqSTTModel
+        case .soniox:
+            settingsStore.sonioxAPIKey = sonioxAPIKey
+            settingsStore.sonioxModel = sonioxModel
         case .appleSpeech, .localSTT, .typefluxOfficial, .typefluxCloud:
             break
         }
@@ -2522,7 +2543,7 @@ final class StudioViewModel: ObservableObject {
                             if payload.done || collected.count >= 60 { break }
                         }
                     case .appleSpeech, .localSTT, .whisperAPI, .multimodalLLM, .aliCloud, .doubaoRealtime,
-                         .googleCloud, .groqSTT, .typefluxOfficial:
+                         .googleCloud, .groqSTT, .soniox, .typefluxOfficial:
                         return (firstTokenDate, collected)
                     }
 
@@ -2568,6 +2589,8 @@ final class StudioViewModel: ObservableObject {
         let capturedAppLanguage = appLanguage
         let capturedGroqSTTAPIKey = groqSTTAPIKey
         let capturedGroqSTTModel = groqSTTModel
+        let capturedSonioxAPIKey = sonioxAPIKey
+        let capturedSonioxModel = sonioxModel
 
         sttTestTask = Task {
             let startDate = Date()
@@ -2613,6 +2636,11 @@ final class StudioViewModel: ObservableObject {
                             model: capturedGroqSTTModel.isEmpty
                                 ? OpenAIAudioModelCatalog.groqWhisperModels[0] : capturedGroqSTTModel,
                             apiKey: capturedGroqSTTAPIKey
+                        )
+                    case .soniox:
+                        try await SonioxTranscriber.testConnection(
+                            apiKey: capturedSonioxAPIKey,
+                            model: capturedSonioxModel
                         )
                     case .typefluxOfficial:
                         try await TypefluxOfficialTranscriber.testConnection()
@@ -2754,6 +2782,8 @@ final class StudioViewModel: ObservableObject {
                 .googleCloud
             case .groq:
                 .groqSTT
+            case .soniox:
+                .soniox
             case .typefluxOfficial:
                 .typefluxOfficial
             }

--- a/Sources/Typeflux/Settings/StudioModels.swift
+++ b/Sources/Typeflux/Settings/StudioModels.swift
@@ -169,6 +169,7 @@ enum StudioModelProviderID: String, CaseIterable, Identifiable {
     case doubaoRealtime
     case googleCloud
     case groqSTT
+    case soniox
     case typefluxOfficial
     case typefluxCloud
     case ollama
@@ -196,7 +197,7 @@ enum StudioModelProviderID: String, CaseIterable, Identifiable {
     var domain: StudioModelDomain {
         switch self {
         case .appleSpeech, .localSTT, .freeSTT, .whisperAPI, .multimodalLLM, .aliCloud, .doubaoRealtime,
-             .googleCloud, .groqSTT, .typefluxOfficial:
+             .googleCloud, .groqSTT, .soniox, .typefluxOfficial:
             .stt
         case .typefluxCloud, .ollama, .freeModel, .customLLM, .openRouter, .openAI, .anthropic, .gemini, .deepSeek,
              .kimi, .qwen, .zhipu, .minimax, .grok, .xiaomi, .groq, .openCodeZen, .openCodeGo:

--- a/Sources/Typeflux/Workflow/WorkflowController+Processing.swift
+++ b/Sources/Typeflux/Workflow/WorkflowController+Processing.swift
@@ -24,7 +24,7 @@ extension WorkflowController {
 
     var shouldSuppressPostRecordingStreamingPreviewForCurrentSTTProvider: Bool {
         switch settingsStore.sttProvider {
-        case .aliCloud, .doubaoRealtime, .googleCloud, .typefluxOfficial:
+        case .aliCloud, .doubaoRealtime, .googleCloud, .soniox, .typefluxOfficial:
             true
         default:
             false

--- a/Tests/TypefluxTests/STTRouterTests.swift
+++ b/Tests/TypefluxTests/STTRouterTests.swift
@@ -189,6 +189,7 @@ final class STTRouterTests: XCTestCase {
             doubaoRealtime: doubaoRealtimeOverride ?? doubaoRealtime,
             googleCloud: googleCloud,
             groq: groq,
+            soniox: MockSTTTranscriber(),
             typefluxOfficial: typefluxOfficialOverride ?? typefluxOfficial,
             typefluxCloudLoginFallbackLocalModel: typefluxCloudLoginFallbackLocalModel,
             isTypefluxCloudLoggedIn: isTypefluxCloudLoggedIn,
@@ -638,6 +639,7 @@ final class STTRouterTests: XCTestCase {
             doubaoRealtime: doubaoRealtime,
             googleCloud: googleCloud,
             groq: groq,
+            soniox: MockSTTTranscriber(),
             typefluxOfficial: scenarioAware
         )
 

--- a/Tests/TypefluxTests/WorkflowControllerAutomaticVocabularyTests.swift
+++ b/Tests/TypefluxTests/WorkflowControllerAutomaticVocabularyTests.swift
@@ -353,6 +353,7 @@ final class WorkflowControllerAutomaticVocabularyTests: XCTestCase {
                 doubaoRealtime: MockWorkflowTranscriber(),
                 googleCloud: MockWorkflowTranscriber(),
                 groq: MockWorkflowTranscriber(),
+                soniox: MockWorkflowTranscriber(),
                 typefluxOfficial: MockWorkflowTranscriber()
             ),
             llmService: llmService,

--- a/Tests/TypefluxTests/WorkflowControllerProcessingTests.swift
+++ b/Tests/TypefluxTests/WorkflowControllerProcessingTests.swift
@@ -1344,6 +1344,7 @@ final class WorkflowControllerProcessingTests: XCTestCase {
                 doubaoRealtime: sttTranscriber,
                 googleCloud: sttTranscriber,
                 groq: sttTranscriber,
+                soniox: sttTranscriber,
                 typefluxOfficial: sttTranscriber
             ),
             llmService: llmService,


### PR DESCRIPTION
## 功能概述

接入 **Soniox V5**（`stt-rt-v5`）作为新的实时 STT provider，架构与现有的阿里云/豆包实时 provider 一致。

- 使用 WebSocket 流式传输（PCM16 16kHz mono）
- 录音过程中实时显示转录预览，松开按键后注入最终文本
- 批量转录与实时转录共用同一 Session 实现

## 改动说明

**核心实现**
- 新增 `SonioxTranscriber.swift`，实现 `Transcriber` + `RealtimeTranscriptionSessionFactory` 协议；`SonioxSession` actor 负责 WebSocket 生命周期管理、token 累积、完成超时（5 秒）和安全取消
- `STTProvider.soniox` 已接入所有路由、录音和穷举 switch

**设置 UI**
- Provider 卡片包含 API Key、Model 输入框和连接测试按钮，风格与现有 provider（阿里云/Groq）保持一致
- 本地化：en / zh-Hans / zh-Hant / ja / ko

**Review 发现的 Bug 修复**
- `WorkflowController+Processing`：将 `.soniox` 加入 `shouldSuppressPostRecordingStreamingPreviewForCurrentSTTProvider`，避免录音结束后残留 overlay 闪烁
- `SonioxSession.cancel()`：同时 resume `sessionReadyCont` 和 `sessionFinishedCont`，防止 continuation 泄漏
- `waitForSessionFinished()`：增加 5 秒超时竞争，避免服务端静默断连导致录音流程永久挂起
- 测试文件：补充新增的 `soniox:` 参数

## 测试方法

- [ ] 设置 → 模型 → STT → 选择 Soniox → 填入 API Key → 点击测试 → 预期返回成功
- [ ] 选择 Soniox 后录音，overlay 实时显示转录内容，松键后文本正确注入
- [ ] `swift test` 通过（STTRouterTests、WorkflowControllerProcessingTests、WorkflowControllerAutomaticVocabularyTests）
- [ ] 切换回其他 provider，Soniox 配置正常保留

## 备注

`SonioxSnapshotDispatcher` 和 `SonioxWSDelegate` 与阿里云对应类型结构相同，提取为共享类型留作后续重构，本 PR 不涉及。

🤖 Generated with [Claude Code](https://claude.com/claude-code)