### PR TITLE
Adapt account UI to billing availability

### DIFF
--- a/Sources/Typeflux/Auth/AccountUsageCreditProgressView.swift
+++ b/Sources/Typeflux/Auth/AccountUsageCreditProgressView.swift
@@ -1,13 +1,19 @@
 import SwiftUI
 
 struct AccountUsageCreditProgressView: View {
-    let credits: CloudCreditSummary
+    let credits: CloudCreditSummary?
+    let isFreeAllowance: Bool
+
+    init(credits: CloudCreditSummary?, isFreeAllowance: Bool = false) {
+        self.credits = credits
+        self.isFreeAllowance = isFreeAllowance
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: StudioTheme.Spacing.small) {
             HStack(alignment: .firstTextBaseline, spacing: StudioTheme.Spacing.medium) {
                 Label {
-                    Text(L("auth.account.usageQuota"))
+                    Text(L(isFreeAllowance ? "auth.account.usageFreeQuota" : "auth.account.usageQuota"))
                         .font(.studioBody(StudioTheme.Typography.body, weight: .semibold))
                 } icon: {
                     Image(systemName: "gauge")
@@ -19,7 +25,7 @@ struct AccountUsageCreditProgressView: View {
 
                 Text(remainingText)
                     .font(.studioBody(StudioTheme.Typography.bodySmall, weight: .semibold))
-                    .foregroundStyle(credits.unlimited ? StudioTheme.success : StudioTheme.textSecondary)
+                    .foregroundStyle(credits?.unlimited == true ? StudioTheme.success : StudioTheme.textSecondary)
                     .lineLimit(1)
                     .minimumScaleFactor(0.85)
             }
@@ -60,11 +66,12 @@ struct AccountUsageCreditProgressView: View {
     }
 
     private var hasFiniteLimit: Bool {
-        !credits.unlimited && credits.limit > 0
+        guard let credits else { return false }
+        return !credits.unlimited && credits.limit > 0
     }
 
     private var usagePercentage: Double {
-        guard hasFiniteLimit else { return 0 }
+        guard hasFiniteLimit, let credits else { return 0 }
         return Double(credits.used) / Double(credits.limit) * 100
     }
 
@@ -77,6 +84,9 @@ struct AccountUsageCreditProgressView: View {
     }
 
     private var remainingText: String {
+        guard let credits else {
+            return L("auth.account.usageQuotaUnavailable")
+        }
         if credits.unlimited {
             return L("auth.account.usageQuotaUnlimited")
         }
@@ -87,6 +97,9 @@ struct AccountUsageCreditProgressView: View {
     }
 
     private var progressDescription: String {
+        guard let credits else {
+            return L("auth.account.usageQuotaUnavailable")
+        }
         if credits.unlimited {
             return String(
                 format: L("auth.account.usageQuotaUsedUnlimited"),

--- a/Sources/Typeflux/Auth/AccountView.swift
+++ b/Sources/Typeflux/Auth/AccountView.swift
@@ -15,7 +15,9 @@ struct AccountView: View {
         VStack(alignment: .leading, spacing: StudioTheme.Spacing.pageGroup) {
             if let profile = authState.userProfile {
                 profileCard(profile: profile)
-                subscriptionCard
+                if authState.subscription.shouldShowSubscriptionDetails {
+                    subscriptionCard
+                }
                 usageCard
             } else if authState.isLoading {
                 loadingCard
@@ -115,10 +117,6 @@ struct AccountView: View {
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
 
-                if let credits = authState.usageCredits {
-                    AccountUsageCreditProgressView(credits: credits)
-                }
-
                 if let error = billingActionError ?? authState.subscriptionError {
                     Text(error)
                         .font(.studioBody(StudioTheme.Typography.caption))
@@ -161,6 +159,11 @@ struct AccountView: View {
                         .fixedSize(horizontal: false, vertical: true)
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
+
+                AccountUsageCreditProgressView(
+                    credits: authState.usageCredits,
+                    isFreeAllowance: authState.subscription.treatsCreditsAsFreeAllowance
+                )
 
                 HStack(alignment: .top, spacing: StudioTheme.Spacing.medium) {
                     accountSummaryItem(

--- a/Sources/Typeflux/Auth/AuthState+Subscription.swift
+++ b/Sources/Typeflux/Auth/AuthState+Subscription.swift
@@ -33,9 +33,11 @@ extension AuthState {
             }
             return snapshot
         } catch let error as AuthError {
+            subscription = subscription.disablingBilling()
             subscriptionError = error.localizedDescription
             return nil
         } catch {
+            subscription = subscription.disablingBilling()
             subscriptionError = error.localizedDescription
             return nil
         }

--- a/Sources/Typeflux/Auth/BillingModels.swift
+++ b/Sources/Typeflux/Auth/BillingModels.swift
@@ -1,6 +1,7 @@
 import Foundation
 
 struct BillingSubscriptionSnapshot: Decodable, Equatable {
+    let billingEnabled: Bool
     let planCode: String?
     let planName: String?
     let status: String?
@@ -15,6 +16,7 @@ struct BillingSubscriptionSnapshot: Decodable, Equatable {
     enum CodingKeys: String, CodingKey {
         case active
         case paid
+        case billingEnabled = "billing_enabled"
         case planCode = "plan_code"
         case planName = "plan_name"
         case status
@@ -41,8 +43,10 @@ struct BillingSubscriptionSnapshot: Decodable, Equatable {
         planName: String? = nil,
         active: Bool? = nil,
         paid: Bool? = nil,
-        periodSource: String? = nil
+        periodSource: String? = nil,
+        billingEnabled: Bool = false
     ) {
+        self.billingEnabled = billingEnabled
         self.planCode = planCode
         self.planName = planName
         self.status = status
@@ -82,7 +86,10 @@ struct BillingSubscriptionSnapshot: Decodable, Equatable {
             planName: source.decodeIfPresent(String.self, forKey: .planName),
             active: active,
             paid: source.decodeIfPresent(Bool.self, forKey: .paid),
-            periodSource: source.decodeIfPresent(String.self, forKey: .periodSource)
+            periodSource: source.decodeIfPresent(String.self, forKey: .periodSource),
+            billingEnabled: root.decodeIfPresent(Bool.self, forKey: .billingEnabled)
+                ?? source.decodeIfPresent(Bool.self, forKey: .billingEnabled)
+                ?? false
         )
     }
 
@@ -91,6 +98,30 @@ struct BillingSubscriptionSnapshot: Decodable, Equatable {
             return false
         }
         return true
+    }
+
+    var shouldShowSubscriptionDetails: Bool {
+        billingEnabled
+    }
+
+    var treatsCreditsAsFreeAllowance: Bool {
+        !billingEnabled
+    }
+
+    func disablingBilling() -> BillingSubscriptionSnapshot {
+        BillingSubscriptionSnapshot(
+            planCode: planCode,
+            status: status,
+            currentPeriodStart: currentPeriodStart,
+            currentPeriodEnd: currentPeriodEnd,
+            cancelAtPeriodEnd: cancelAtPeriodEnd,
+            entitled: entitled,
+            planName: planName,
+            active: active,
+            paid: paid,
+            periodSource: periodSource,
+            billingEnabled: false
+        )
     }
 
     var hasPaidSubscription: Bool {
@@ -113,7 +144,8 @@ struct BillingSubscriptionSnapshot: Decodable, Equatable {
             cancelAtPeriodEnd: false,
             entitled: false,
             active: false,
-            paid: false
+            paid: false,
+            billingEnabled: false
         )
     }
 

--- a/Sources/Typeflux/Networking/TypefluxCloudBillingError.swift
+++ b/Sources/Typeflux/Networking/TypefluxCloudBillingError.swift
@@ -27,23 +27,29 @@ struct TypefluxCloudBillingError: LocalizedError, Equatable {
         }
     }
 
-    func title(hasPaidSubscription: Bool) -> String {
+    func title(hasPaidSubscription: Bool, billingEnabled: Bool = true) -> String {
+        if !billingEnabled {
+            return L("cloud.billing.freeQuotaExceeded.title")
+        }
         switch reason {
         case .subscriptionRequired:
-            L("cloud.billing.subscriptionRequired.title")
+            return L("cloud.billing.subscriptionRequired.title")
         case .quotaExceeded:
-            hasPaidSubscription
+            return hasPaidSubscription
                 ? L("cloud.billing.quotaExceeded.title")
                 : L("cloud.billing.subscriptionRequired.title")
         }
     }
 
-    func message(hasPaidSubscription: Bool) -> String {
+    func message(hasPaidSubscription: Bool, billingEnabled: Bool = true) -> String {
+        if !billingEnabled {
+            return L("cloud.billing.freeQuotaExceeded.body")
+        }
         switch reason {
         case .subscriptionRequired:
-            L("cloud.billing.subscriptionRequired.body")
+            return L("cloud.billing.subscriptionRequired.body")
         case .quotaExceeded:
-            hasPaidSubscription
+            return hasPaidSubscription
                 ? L("cloud.billing.quotaExceeded.body")
                 : L("cloud.billing.subscriptionRequired.body")
         }
@@ -53,12 +59,15 @@ struct TypefluxCloudBillingError: LocalizedError, Equatable {
         primaryActionTitle(hasPaidSubscription: false)
     }
 
-    func primaryActionTitle(hasPaidSubscription: Bool) -> String {
+    func primaryActionTitle(hasPaidSubscription: Bool, billingEnabled: Bool = true) -> String {
+        if !billingEnabled {
+            return L("cloud.billing.action.openAccount")
+        }
         switch reason {
         case .subscriptionRequired:
-            L("cloud.billing.action.subscribe")
+            return L("cloud.billing.action.subscribe")
         case .quotaExceeded:
-            hasPaidSubscription
+            return hasPaidSubscription
                 ? L("cloud.billing.action.openAccount")
                 : L("cloud.billing.action.subscribe")
         }

--- a/Sources/Typeflux/Resources/en.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/en.lproj/Localizable.strings
@@ -1080,6 +1080,8 @@
 "cloud.billing.subscriptionRequired.body" = "This Cloud feature is not included in your current plan. Subscribe to keep using Typeflux Cloud.";
 "cloud.billing.quotaExceeded.title" = "Typeflux Cloud credits used up";
 "cloud.billing.quotaExceeded.body" = "Your Cloud quota or credits are currently unavailable. Open Account to review your subscription or billing.";
+"cloud.billing.freeQuotaExceeded.title" = "Free Cloud credits used up";
+"cloud.billing.freeQuotaExceeded.body" = "Your free Cloud credits have been used up for this period. Open Account to review usage or switch to another model.";
 "cloud.billing.action.openAccount" = "Open Account";
 "cloud.billing.action.subscribe" = "Subscribe";
 "cloud.billing.action.switchModel" = "Switch Model";
@@ -1139,7 +1141,8 @@
 "auth.account.usageTranscripts" = "Transcript Chars";
 "auth.account.usageAnswers" = "Answer Chars";
 "auth.account.refreshUsage" = "Refresh Usage";
-"auth.account.usageQuota" = "Subscription Credits";
+"auth.account.usageQuota" = "Cloud Credits";
+"auth.account.usageFreeQuota" = "Monthly Free Credits";
 "auth.account.usageQuotaRemaining" = "%@ remaining";
 "auth.account.usageQuotaUnlimited" = "Unlimited allowance";
 "auth.account.usageQuotaUsedOfLimit" = "%@ / %@ used (%@)";

--- a/Sources/Typeflux/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/ja.lproj/Localizable.strings
@@ -1065,6 +1065,8 @@
 "cloud.billing.subscriptionRequired.body" = "このクラウド機能は現在のプランに含まれていません。購読すると Typeflux Cloud を引き続き利用できます。";
 "cloud.billing.quotaExceeded.title" = "Typeflux Cloud の利用枠が不足しています";
 "cloud.billing.quotaExceeded.body" = "クラウドの利用枠またはクレジットが現在利用できません。アカウント画面で購読または請求を確認してください。";
+"cloud.billing.freeQuotaExceeded.title" = "無料のクラウドクレジットを使い切りました";
+"cloud.billing.freeQuotaExceeded.body" = "この期間の無料クラウドクレジットを使い切りました。アカウントで使用量を確認するか、別のモデルに切り替えてください。";
 "cloud.billing.action.openAccount" = "アカウントを開く";
 "cloud.billing.action.subscribe" = "購読する";
 "cloud.billing.action.switchModel" = "別のモデルに切り替え";
@@ -1124,7 +1126,8 @@
 "auth.account.usageTranscripts" = "文字起こし文字数";
 "auth.account.usageAnswers" = "回答文字数";
 "auth.account.refreshUsage" = "使用量を更新";
-"auth.account.usageQuota" = "サブスクリプションクレジット";
+"auth.account.usageQuota" = "クラウドクレジット";
+"auth.account.usageFreeQuota" = "毎月の無料クレジット";
 "auth.account.usageQuotaRemaining" = "残り %@";
 "auth.account.usageQuotaUnlimited" = "無制限";
 "auth.account.usageQuotaUsedOfLimit" = "%@ / %@ 使用済み（%@）";

--- a/Sources/Typeflux/Resources/ko.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/ko.lproj/Localizable.strings
@@ -1065,6 +1065,8 @@
 "cloud.billing.subscriptionRequired.body" = "현재 요금제에는 이 클라우드 기능이 포함되어 있지 않습니다. 구독하면 Typeflux Cloud를 계속 사용할 수 있습니다.";
 "cloud.billing.quotaExceeded.title" = "Typeflux Cloud 한도를 사용할 수 없습니다";
 "cloud.billing.quotaExceeded.body" = "현재 클라우드 한도 또는 크레딧을 사용할 수 없습니다. 계정 화면에서 구독 또는 결제를 확인해 주세요.";
+"cloud.billing.freeQuotaExceeded.title" = "무료 클라우드 크레딧을 모두 사용했습니다";
+"cloud.billing.freeQuotaExceeded.body" = "이번 기간의 무료 클라우드 크레딧을 모두 사용했습니다. 계정에서 사용량을 확인하거나 다른 모델로 전환하세요.";
 "cloud.billing.action.openAccount" = "계정 열기";
 "cloud.billing.action.subscribe" = "구독하기";
 "cloud.billing.action.switchModel" = "다른 모델로 전환";
@@ -1124,7 +1126,8 @@
 "auth.account.usageTranscripts" = "전사 문자";
 "auth.account.usageAnswers" = "답변 문자";
 "auth.account.refreshUsage" = "사용량 새로고침";
-"auth.account.usageQuota" = "구독 크레딧";
+"auth.account.usageQuota" = "클라우드 크레딧";
+"auth.account.usageFreeQuota" = "월간 무료 크레딧";
 "auth.account.usageQuotaRemaining" = "%@ 남음";
 "auth.account.usageQuotaUnlimited" = "무제한";
 "auth.account.usageQuotaUsedOfLimit" = "%@ / %@ 사용됨(%@)";

--- a/Sources/Typeflux/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/zh-Hans.lproj/Localizable.strings
@@ -1080,6 +1080,8 @@
 "cloud.billing.subscriptionRequired.body" = "当前套餐暂不包含这项云端功能。开通会员后即可继续使用 Typeflux Cloud。";
 "cloud.billing.quotaExceeded.title" = "Typeflux Cloud 额度暂不可用";
 "cloud.billing.quotaExceeded.body" = "当前云端额度或余额不足。请前往账号页处理订阅或账单。";
+"cloud.billing.freeQuotaExceeded.title" = "免费云端额度已用完";
+"cloud.billing.freeQuotaExceeded.body" = "当前周期的免费云端额度已用完。你可以前往账号页查看用量，或切换其他模型。";
 "cloud.billing.action.openAccount" = "打开账号";
 "cloud.billing.action.subscribe" = "订阅会员";
 "cloud.billing.action.switchModel" = "切换其他模型";
@@ -1139,7 +1141,8 @@
 "auth.account.usageTranscripts" = "转写字符";
 "auth.account.usageAnswers" = "回复字符";
 "auth.account.refreshUsage" = "刷新用量";
-"auth.account.usageQuota" = "订阅额度";
+"auth.account.usageQuota" = "云端额度";
+"auth.account.usageFreeQuota" = "每月免费额度";
 "auth.account.usageQuotaRemaining" = "剩余 %@";
 "auth.account.usageQuotaUnlimited" = "不限额度";
 "auth.account.usageQuotaUsedOfLimit" = "已用 %@ / %@（%@）";

--- a/Sources/Typeflux/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/zh-Hant.lproj/Localizable.strings
@@ -1076,6 +1076,8 @@
 "cloud.billing.subscriptionRequired.body" = "目前方案暫不包含這項雲端功能。開通會員後即可繼續使用 Typeflux Cloud。";
 "cloud.billing.quotaExceeded.title" = "Typeflux Cloud 額度暫不可用";
 "cloud.billing.quotaExceeded.body" = "目前雲端額度或餘額不足。請前往帳號頁處理訂閱或帳單。";
+"cloud.billing.freeQuotaExceeded.title" = "免費雲端額度已用完";
+"cloud.billing.freeQuotaExceeded.body" = "目前週期的免費雲端額度已用完。你可以前往帳號頁查看用量，或切換其他模型。";
 "cloud.billing.action.openAccount" = "開啟帳號";
 "cloud.billing.action.subscribe" = "訂閱會員";
 "cloud.billing.action.switchModel" = "切換其他模型";
@@ -1135,7 +1137,8 @@
 "auth.account.usageTranscripts" = "轉寫字元";
 "auth.account.usageAnswers" = "回覆字元";
 "auth.account.refreshUsage" = "重新整理用量";
-"auth.account.usageQuota" = "訂閱額度";
+"auth.account.usageQuota" = "雲端額度";
+"auth.account.usageFreeQuota" = "每月免費額度";
 "auth.account.usageQuotaRemaining" = "剩餘 %@";
 "auth.account.usageQuotaUnlimited" = "不限額度";
 "auth.account.usageQuotaUsedOfLimit" = "已用 %@ / %@（%@）";

--- a/Sources/Typeflux/Workflow/WorkflowController+Persona.swift
+++ b/Sources/Typeflux/Workflow/WorkflowController+Persona.swift
@@ -279,7 +279,11 @@ extension WorkflowController {
                             self.activeProcessingRecordID = nil
                         }
                         if self.processingSessionID == sessionID {
-                            self.appState.setStatus(.failed(message: billingError.title))
+                            let subscription = AuthState.shared.subscription
+                            self.appState.setStatus(.failed(message: billingError.title(
+                                hasPaidSubscription: subscription.hasPaidSubscription,
+                                billingEnabled: subscription.billingEnabled
+                            )))
                             return true
                         }
                         return false

--- a/Sources/Typeflux/Workflow/WorkflowController+Processing.swift
+++ b/Sources/Typeflux/Workflow/WorkflowController+Processing.swift
@@ -970,7 +970,11 @@ extension WorkflowController {
                 let shouldPresentBilling = await MainActor.run {
                     guard self.processingSessionID == sessionID else { return false }
                     self.lastRetryableFailureRecord = nil
-                    self.appState.setStatus(.failed(message: billingError.title))
+                    let subscription = AuthState.shared.subscription
+                    self.appState.setStatus(.failed(message: billingError.title(
+                        hasPaidSubscription: subscription.hasPaidSubscription,
+                        billingEnabled: subscription.billingEnabled
+                    )))
                     return true
                 }
                 if shouldPresentBilling {

--- a/Sources/Typeflux/Workflow/WorkflowController.swift
+++ b/Sources/Typeflux/Workflow/WorkflowController.swift
@@ -1371,6 +1371,7 @@ final class WorkflowController {
     func presentCloudBillingError(_ error: TypefluxCloudBillingError) async {
         await MainActor.run {
             let hasPaidSubscription = AuthState.shared.subscription.hasPaidSubscription
+            let billingEnabled = AuthState.shared.subscription.billingEnabled
             guard self.shouldPresentCloudBillingError(
                 error,
                 hasPaidSubscription: hasPaidSubscription
@@ -1383,7 +1384,10 @@ final class WorkflowController {
 
             let actions: [OverlayFailureAction] = [
                 OverlayFailureAction(
-                    title: error.primaryActionTitle(hasPaidSubscription: hasPaidSubscription),
+                    title: error.primaryActionTitle(
+                        hasPaidSubscription: hasPaidSubscription,
+                        billingEnabled: billingEnabled
+                    ),
                     isRetry: false,
                     trailingSystemImage: "arrow.up.right",
                     handler: { [weak self] in
@@ -1411,8 +1415,8 @@ final class WorkflowController {
             ]
 
             self.overlayController.showFailureWithActions(
-                title: error.title(hasPaidSubscription: hasPaidSubscription),
-                message: error.message(hasPaidSubscription: hasPaidSubscription),
+                title: error.title(hasPaidSubscription: hasPaidSubscription, billingEnabled: billingEnabled),
+                message: error.message(hasPaidSubscription: hasPaidSubscription, billingEnabled: billingEnabled),
                 tone: .billing,
                 actions: actions
             )

--- a/Tests/TypefluxTests/AppPreferencesTests.swift
+++ b/Tests/TypefluxTests/AppPreferencesTests.swift
@@ -29,6 +29,7 @@ final class AppPreferencesTests: XCTestCase {
                 .typefluxOfficial,
                 .freeModel,
                 .localModel,
+                .soniox,
                 .aliCloud,
                 .doubaoRealtime,
                 .googleCloud,

--- a/Tests/TypefluxTests/AuthStateTests.swift
+++ b/Tests/TypefluxTests/AuthStateTests.swift
@@ -189,6 +189,44 @@ final class AuthStateTests: XCTestCase {
         XCTAssertNotNil(state.subscriptionError)
     }
 
+    func testSubscriptionRefreshFailureFailsBillingVisibilityClosed() async {
+        var storedToken: (token: String, expiresAt: Int)?
+        var shouldFail = false
+        let activeSubscription = BillingSubscriptionSnapshot(
+            planCode: BillingPlan.defaultPlanCode,
+            status: "active",
+            currentPeriodStart: nil,
+            currentPeriodEnd: "2999-06-01T00:00:00Z",
+            cancelAtPeriodEnd: false,
+            entitled: true,
+            active: true,
+            paid: true,
+            billingEnabled: true
+        )
+        let state = AuthState(
+            loadStoredToken: { storedToken },
+            loadStoredUserProfile: { nil },
+            saveStoredToken: { token, expiresAt in storedToken = (token, expiresAt) },
+            saveStoredUserProfile: { _ in },
+            clearStoredSession: { storedToken = nil },
+            fetchProfile: { _ in self.makeProfile(email: "billing-fail-closed@test.com") },
+            fetchSubscription: { _ in
+                if shouldFail { throw AuthError.networkError(URLError(.notConnectedToInternet)) }
+                return activeSubscription
+            }
+        )
+
+        await state.handleLoginSuccess(token: "token-1", expiresAt: Int(Date().timeIntervalSince1970) + 3600)
+        XCTAssertTrue(state.subscription.billingEnabled)
+
+        shouldFail = true
+        await state.refreshSubscription()
+
+        XCTAssertFalse(state.subscription.billingEnabled)
+        XCTAssertEqual(state.subscription.planCode, BillingPlan.defaultPlanCode)
+        XCTAssertNotNil(state.subscriptionError)
+    }
+
     func testLoginSuccessUsesInMemoryTokenWhenPersistenceDoesNotImmediatelyLoad() async {
         var savedProfile: UserProfile?
         var fetchedProfileToken: String?

--- a/Tests/TypefluxTests/BillingAPIServiceTests.swift
+++ b/Tests/TypefluxTests/BillingAPIServiceTests.swift
@@ -14,6 +14,7 @@ final class BillingAPIServiceTests: XCTestCase {
             {
               "code": "OK",
               "data": {
+                "billing_enabled": true,
                 "plan_code": "typeflux_cloud_monthly",
                 "status": "active",
                 "current_period_start": "2026-05-01T00:00:00Z",
@@ -32,6 +33,9 @@ final class BillingAPIServiceTests: XCTestCase {
         XCTAssertEqual(snapshot.planCode, "typeflux_cloud_monthly")
         XCTAssertEqual(snapshot.status, "active")
         XCTAssertEqual(snapshot.currentPeriodStart, "2026-05-01T00:00:00Z")
+        XCTAssertTrue(snapshot.billingEnabled)
+        XCTAssertTrue(snapshot.shouldShowSubscriptionDetails)
+        XCTAssertFalse(snapshot.treatsCreditsAsFreeAllowance)
         XCTAssertTrue(snapshot.entitled)
         XCTAssertTrue(snapshot.hasSubscription)
     }
@@ -62,6 +66,9 @@ final class BillingAPIServiceTests: XCTestCase {
         XCTAssertEqual(snapshot.status, "canceled")
         XCTAssertTrue(snapshot.cancelAtPeriodEnd)
         XCTAssertFalse(snapshot.entitled)
+        XCTAssertFalse(snapshot.billingEnabled)
+        XCTAssertFalse(snapshot.shouldShowSubscriptionDetails)
+        XCTAssertTrue(snapshot.treatsCreditsAsFreeAllowance)
     }
 
     func testSubscriptionDecodingInfersEntitlementFromActiveNonFractionalPeriodEnd() throws {

--- a/Tests/TypefluxTests/STTRouterTests.swift
+++ b/Tests/TypefluxTests/STTRouterTests.swift
@@ -189,7 +189,7 @@ final class STTRouterTests: XCTestCase {
             doubaoRealtime: doubaoRealtimeOverride ?? doubaoRealtime,
             googleCloud: googleCloud,
             groq: groq,
-            soniox: MockSTTTranscriber(),
+            soniox: MockTranscriber(),
             typefluxOfficial: typefluxOfficialOverride ?? typefluxOfficial,
             typefluxCloudLoginFallbackLocalModel: typefluxCloudLoginFallbackLocalModel,
             isTypefluxCloudLoggedIn: isTypefluxCloudLoggedIn,
@@ -639,7 +639,7 @@ final class STTRouterTests: XCTestCase {
             doubaoRealtime: doubaoRealtime,
             googleCloud: googleCloud,
             groq: groq,
-            soniox: MockSTTTranscriber(),
+            soniox: MockTranscriber(),
             typefluxOfficial: scenarioAware
         )
 

--- a/Tests/TypefluxTests/TypefluxCloudServerErrorMessageTests.swift
+++ b/Tests/TypefluxTests/TypefluxCloudServerErrorMessageTests.swift
@@ -88,6 +88,26 @@ final class TypefluxCloudServerErrorMessageTests: XCTestCase {
         }
     }
 
+    func testBillingErrorDoesNotSuggestSubscriptionWhenBillingIsDisabled() {
+        withEnglishLocalization {
+            let error = TypefluxCloudBillingError(reason: .quotaExceeded, serverMessage: nil)
+
+            XCTAssertEqual(
+                error.title(hasPaidSubscription: false, billingEnabled: false),
+                "Free Cloud credits used up"
+            )
+            XCTAssertEqual(
+                error.primaryActionTitle(hasPaidSubscription: false, billingEnabled: false),
+                "Open Account"
+            )
+            XCTAssertFalse(
+                error.message(hasPaidSubscription: false, billingEnabled: false).localizedCaseInsensitiveContains(
+                    "subscribe"
+                )
+            )
+        }
+    }
+
     func testBillingErrorParsesCreditBalanceExhaustedMessage() {
         let message = "request failed: credit_balance_exhausted"
 


### PR DESCRIPTION
## What changed

- decode the server-provided `billing_enabled` value
- hide subscription controls and subscription details when billing is disabled
- keep usage and free allowance information visible
- fail closed when subscription refresh fails
- adapt billing error messaging across all workflow paths and supported localizations
- add coverage for disabled-state decoding, presentation, and refresh failure behavior

## Why

The client must ship while Stripe payment is unavailable without showing non-functional subscription entry points.

## Impact

Users see usage and free allowance information only when server-side billing is disabled. Existing subscription UI remains unchanged when billing is enabled.

## Validation

- `swift test` — 2268 tests passed
- focused billing/auth tests — 24 tests passed
- `swiftformat --lint` on changed Swift files
- `git diff --check`