### PR TITLE
GUL-10: open billing plans before checkout

### DIFF
--- a/Sources/Typeflux/Auth/AccountBillingFlow.swift
+++ b/Sources/Typeflux/Auth/AccountBillingFlow.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+enum AccountBillingFlow {
+    static let billingPlansBaseURL = URL(string: "https://typeflux.app/billing/plans")!
+
+    static func destination(
+        for action: AccountSubscriptionPresentation.BillingAction,
+        requestBillingPageToken: () async throws -> String,
+        createPortalSession: () async throws -> URL,
+        billingPlansBaseURL: URL = billingPlansBaseURL
+    ) async throws -> URL {
+        switch action {
+        case .subscribe:
+            let token = try await requestBillingPageToken()
+            return try billingPlansURL(token: token, baseURL: billingPlansBaseURL)
+        case .manageBilling:
+            return try await createPortalSession()
+        }
+    }
+
+    static func billingPlansURL(token: String, baseURL: URL = billingPlansBaseURL) throws -> URL {
+        guard !token.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+              var components = URLComponents(url: baseURL, resolvingAgainstBaseURL: false)
+        else {
+            throw AuthError.serverError(code: "BILLING_PAGE_UNAVAILABLE", message: nil)
+        }
+
+        var fragment = URLComponents()
+        fragment.queryItems = [URLQueryItem(name: "t", value: token)]
+        guard let encodedFragment = fragment.percentEncodedQuery else {
+            throw AuthError.serverError(code: "BILLING_PAGE_UNAVAILABLE", message: nil)
+        }
+        components.percentEncodedFragment = encodedFragment
+
+        guard let url = components.url else {
+            throw AuthError.serverError(code: "BILLING_PAGE_UNAVAILABLE", message: nil)
+        }
+        return url
+    }
+}

--- a/Sources/Typeflux/Auth/AccountView.swift
+++ b/Sources/Typeflux/Auth/AccountView.swift
@@ -480,9 +480,11 @@ struct AccountView: View {
 
         Task {
             do {
-                let url = subscriptionPresentation.billingAction == .manageBilling
-                    ? try await authState.createBillingPortalSession()
-                    : try await authState.startCheckout()
+                let url = try await AccountBillingFlow.destination(
+                    for: subscriptionPresentation.billingAction,
+                    requestBillingPageToken: { try await authState.requestBillingPageToken() },
+                    createPortalSession: { try await authState.createBillingPortalSession() }
+                )
                 await MainActor.run {
                     NSWorkspace.shared.open(url)
                     isOpeningBilling = false

--- a/Sources/Typeflux/Auth/AuthState+Subscription.swift
+++ b/Sources/Typeflux/Auth/AuthState+Subscription.swift
@@ -97,6 +97,14 @@ extension AuthState {
         return session.url
     }
 
+    func requestBillingPageToken() async throws -> String {
+        guard let token = accessToken else {
+            throw AuthError.unauthorized
+        }
+        let response = try await issueBillingPageToken(token)
+        return response.token
+    }
+
     private func startCheckoutPolling() {
         checkoutPollingTask?.cancel()
         checkoutPollingTask = Task { @MainActor [weak self] in

--- a/Sources/Typeflux/Auth/AuthState.swift
+++ b/Sources/Typeflux/Auth/AuthState.swift
@@ -51,6 +51,7 @@ final class AuthState: ObservableObject {
     let fetchCurrentPeriodUsageStats: (String) async throws -> CloudUsageCurrentPeriodStats
     let createCheckoutSession: (String, String) async throws -> BillingCheckoutSession
     let createPortalSession: (String) async throws -> BillingPortalSession
+    let issueBillingPageToken: (String) async throws -> BillingPageTokenResponse
 
     @Published var isLoggedIn: Bool = false
     @Published var userProfile: UserProfile?
@@ -130,6 +131,9 @@ final class AuthState: ObservableObject {
         },
         createPortalSession: @escaping (String) async throws -> BillingPortalSession = { token in
             try await BillingAPIService.createPortalSession(token: token)
+        },
+        issueBillingPageToken: @escaping (String) async throws -> BillingPageTokenResponse = { token in
+            try await BillingAPIService.requestBillingPageToken(token: token)
         }
     ) {
         self.loadStoredToken = loadStoredToken
@@ -151,6 +155,7 @@ final class AuthState: ObservableObject {
         self.fetchCurrentPeriodUsageStats = fetchCurrentPeriodUsageStats
         self.createCheckoutSession = createCheckoutSession
         self.createPortalSession = createPortalSession
+        self.issueBillingPageToken = issueBillingPageToken
         restoreSession()
     }
 

--- a/Sources/Typeflux/Auth/BillingAPIService.swift
+++ b/Sources/Typeflux/Auth/BillingAPIService.swift
@@ -36,6 +36,10 @@ struct BillingAPIService: Sendable {
         try await execute(path: "/api/v1/billing/portal-session", method: "POST", token: token, body: Data("{}".utf8))
     }
 
+    func requestBillingPageToken(token: String) async throws -> BillingPageTokenResponse {
+        try await execute(path: "/api/v1/billing/page-token", method: "POST", token: token, body: Data("{}".utf8))
+    }
+
     static func fetchSubscription(token: String) async throws -> BillingSubscriptionSnapshot {
         try await BillingAPIService().fetchSubscription(token: token)
     }
@@ -46,6 +50,10 @@ struct BillingAPIService: Sendable {
 
     static func createPortalSession(token: String) async throws -> BillingPortalSession {
         try await BillingAPIService().createPortalSession(token: token)
+    }
+
+    static func requestBillingPageToken(token: String) async throws -> BillingPageTokenResponse {
+        try await BillingAPIService().requestBillingPageToken(token: token)
     }
 
     private func encode(_ body: some Encodable) throws -> Data {

--- a/Sources/Typeflux/Auth/BillingModels.swift
+++ b/Sources/Typeflux/Auth/BillingModels.swift
@@ -185,6 +185,10 @@ struct BillingPortalSession: Decodable, Equatable {
     let url: URL
 }
 
+struct BillingPageTokenResponse: Decodable, Equatable {
+    let token: String
+}
+
 struct BillingCheckoutSessionRequest: Encodable {
     let planCode: String
 

--- a/Sources/Typeflux/Networking/TypefluxCloudServerErrorMessage.swift
+++ b/Sources/Typeflux/Networking/TypefluxCloudServerErrorMessage.swift
@@ -52,6 +52,8 @@ enum TypefluxCloudServerErrorMessage {
             return "cloud.error.billingConnectionUnavailable"
         case "BILLING_SERVICE_UNAVAILABLE", "BILLING_NOT_CONFIGURED":
             return "cloud.error.billingServiceUnavailable"
+        case "BILLING_PAGE_UNAVAILABLE":
+            return "cloud.error.billingPageUnavailable"
         case "SERVER_ERROR", "INTERNAL", "INTERNAL_SERVER_ERROR":
             return "cloud.error.server"
         default:

--- a/Sources/Typeflux/Resources/en.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/en.lproj/Localizable.strings
@@ -1160,6 +1160,7 @@
 "cloud.error.subscriptionExists" = "You already have a subscription. Open billing management to change or resume it.";
 "cloud.error.billingConnectionUnavailable" = "We couldn't connect to Typeflux Cloud to load your subscription. Check your internet connection and try again. Your account has not been changed.";
 "cloud.error.billingServiceUnavailable" = "Typeflux Cloud couldn't load your subscription right now. Your account has not been changed. Please try again in a few minutes.";
+"cloud.error.billingPageUnavailable" = "We couldn't open the subscription plans right now. Please try again.";
 "cloud.error.server" = "Typeflux Cloud is temporarily unavailable. Please try again later.";
 "cloud.billing.subscriptionRequired.title" = "Typeflux Cloud needs a subscription";
 "cloud.billing.subscriptionRequired.body" = "This Cloud feature is not included in your current plan. Subscribe to keep using Typeflux Cloud.";

--- a/Sources/Typeflux/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/ja.lproj/Localizable.strings
@@ -1145,6 +1145,7 @@
 "cloud.error.subscriptionExists" = "すでにサブスクリプションがあります。請求管理を開いて変更または再開してください。";
 "cloud.error.billingConnectionUnavailable" = "Typeflux Cloud に接続できなかったため、サブスクリプション情報を読み込めませんでした。インターネット接続を確認して、もう一度お試しください。アカウント内容は変更されていません。";
 "cloud.error.billingServiceUnavailable" = "Typeflux Cloud は現在サブスクリプション情報を読み込めません。アカウント内容は変更されていません。数分後にもう一度お試しください。";
+"cloud.error.billingPageUnavailable" = "現在サブスクリプションプランのページを開けません。もう一度お試しください。";
 "cloud.error.server" = "Typeflux Cloud は一時的に利用できません。後でもう一度お試しください。";
 "cloud.billing.subscriptionRequired.title" = "Typeflux Cloud の購読が必要です";
 "cloud.billing.subscriptionRequired.body" = "このクラウド機能は現在のプランに含まれていません。購読すると Typeflux Cloud を引き続き利用できます。";

--- a/Sources/Typeflux/Resources/ko.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/ko.lproj/Localizable.strings
@@ -1145,6 +1145,7 @@
 "cloud.error.subscriptionExists" = "이미 구독 중입니다. 결제 관리에서 구독을 변경하거나 재개해 주세요.";
 "cloud.error.billingConnectionUnavailable" = "Typeflux Cloud에 연결할 수 없어 구독 정보를 불러오지 못했습니다. 인터넷 연결을 확인한 후 다시 시도하세요. 계정 내용은 변경되지 않았습니다.";
 "cloud.error.billingServiceUnavailable" = "현재 Typeflux Cloud에서 구독 정보를 불러올 수 없습니다. 계정 내용은 변경되지 않았습니다. 몇 분 후 다시 시도하세요.";
+"cloud.error.billingPageUnavailable" = "현재 구독 요금제 페이지를 열 수 없습니다. 다시 시도하세요.";
 "cloud.error.server" = "Typeflux Cloud를 일시적으로 사용할 수 없습니다. 나중에 다시 시도해 주세요.";
 "cloud.billing.subscriptionRequired.title" = "Typeflux Cloud 구독이 필요합니다";
 "cloud.billing.subscriptionRequired.body" = "현재 요금제에는 이 클라우드 기능이 포함되어 있지 않습니다. 구독하면 Typeflux Cloud를 계속 사용할 수 있습니다.";

--- a/Sources/Typeflux/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/zh-Hans.lproj/Localizable.strings
@@ -1160,6 +1160,7 @@
 "cloud.error.subscriptionExists" = "你已有订阅，请打开账单管理进行变更或恢复。";
 "cloud.error.billingConnectionUnavailable" = "暂时无法连接 Typeflux Cloud，因此未能加载订阅信息。请检查网络连接后重试；你的账号不会因此发生变化。";
 "cloud.error.billingServiceUnavailable" = "Typeflux Cloud 暂时无法加载订阅信息，你的账号不会因此发生变化。请过几分钟再试。";
+"cloud.error.billingPageUnavailable" = "暂时无法打开订阅套餐页面，请稍后重试。";
 "cloud.error.server" = "Typeflux Cloud 暂时不可用，请稍后再试。";
 "cloud.billing.subscriptionRequired.title" = "需要开通 Typeflux Cloud";
 "cloud.billing.subscriptionRequired.body" = "当前套餐暂不包含这项云端功能。开通会员后即可继续使用 Typeflux Cloud。";

--- a/Sources/Typeflux/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/zh-Hant.lproj/Localizable.strings
@@ -1156,6 +1156,7 @@
 "cloud.error.subscriptionExists" = "你已有訂閱，請開啟帳單管理進行變更或恢復。";
 "cloud.error.billingConnectionUnavailable" = "暫時無法連接 Typeflux Cloud，因此未能載入訂閱資訊。請檢查網路連線後再試一次；你的帳號不會因此發生變更。";
 "cloud.error.billingServiceUnavailable" = "Typeflux Cloud 暫時無法載入訂閱資訊，你的帳號不會因此發生變更。請過幾分鐘再試一次。";
+"cloud.error.billingPageUnavailable" = "暫時無法開啟訂閱方案頁面，請稍後再試一次。";
 "cloud.error.server" = "Typeflux Cloud 暫時無法使用，請稍後再試。";
 "cloud.billing.subscriptionRequired.title" = "需要開通 Typeflux Cloud";
 "cloud.billing.subscriptionRequired.body" = "目前方案暫不包含這項雲端功能。開通會員後即可繼續使用 Typeflux Cloud。";

--- a/Tests/TypefluxTests/AccountBillingFlowTests.swift
+++ b/Tests/TypefluxTests/AccountBillingFlowTests.swift
@@ -1,0 +1,91 @@
+@testable import Typeflux
+import XCTest
+
+@MainActor
+final class AccountBillingFlowTests: XCTestCase {
+    func testBillingPlansURLPlacesEncodedTokenInFragment() throws {
+        let url = try AccountBillingFlow.billingPlansURL(token: "header.payload+/signature=")
+
+        XCTAssertEqual(url.scheme, "https")
+        XCTAssertEqual(url.host, "typeflux.app")
+        XCTAssertEqual(url.path, "/billing/plans")
+
+        let fragment = try XCTUnwrap(url.fragment)
+        let fragmentComponents = try XCTUnwrap(URLComponents(string: "?\(fragment)"))
+        XCTAssertEqual(fragmentComponents.queryItems, [URLQueryItem(name: "t", value: "header.payload+/signature=")])
+        XCTAssertNil(url.query)
+    }
+
+    func testSubscribeDestinationRequestsPageTokenWithoutCreatingPortal() async throws {
+        var tokenRequests = 0
+        var portalRequests = 0
+
+        let url = try await AccountBillingFlow.destination(
+            for: .subscribe,
+            requestBillingPageToken: {
+                tokenRequests += 1
+                return "billing.jwt.token"
+            },
+            createPortalSession: {
+                portalRequests += 1
+                return URL(string: "https://billing.stripe.com/portal")!
+            }
+        )
+
+        XCTAssertEqual(url.absoluteString, "https://typeflux.app/billing/plans#t=billing.jwt.token")
+        XCTAssertEqual(tokenRequests, 1)
+        XCTAssertEqual(portalRequests, 0)
+    }
+
+    func testManageBillingDestinationCreatesPortalWithoutRequestingPageToken() async throws {
+        var tokenRequests = 0
+        var portalRequests = 0
+
+        let url = try await AccountBillingFlow.destination(
+            for: .manageBilling,
+            requestBillingPageToken: {
+                tokenRequests += 1
+                return "billing.jwt.token"
+            },
+            createPortalSession: {
+                portalRequests += 1
+                return URL(string: "https://billing.stripe.com/portal")!
+            }
+        )
+
+        XCTAssertEqual(url.absoluteString, "https://billing.stripe.com/portal")
+        XCTAssertEqual(tokenRequests, 0)
+        XCTAssertEqual(portalRequests, 1)
+    }
+
+    func testSubscribeDestinationPropagatesPageTokenFailure() async {
+        var portalRequests = 0
+
+        do {
+            _ = try await AccountBillingFlow.destination(
+                for: .subscribe,
+                requestBillingPageToken: {
+                    throw AuthError.serverError(code: "BILLING_NOT_CONFIGURED", message: nil)
+                },
+                createPortalSession: {
+                    portalRequests += 1
+                    return URL(string: "https://billing.stripe.com/portal")!
+                }
+            )
+            XCTFail("Expected page token request to fail")
+        } catch let error as AuthError {
+            XCTAssertEqual(error.authErrorCode, "BILLING_NOT_CONFIGURED")
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+
+        XCTAssertEqual(portalRequests, 0)
+    }
+
+    func testBillingPlansURLRejectsEmptyTokenWithLocalizedError() {
+        XCTAssertThrowsError(try AccountBillingFlow.billingPlansURL(token: "   \n")) { error in
+            XCTAssertFalse(error.localizedDescription.isEmpty)
+            XCTAssertNotEqual(error.localizedDescription, "cloud.error.billingPageUnavailable")
+        }
+    }
+}

--- a/Tests/TypefluxTests/AuthStateTests.swift
+++ b/Tests/TypefluxTests/AuthStateTests.swift
@@ -382,6 +382,55 @@ final class AuthStateTests: XCTestCase {
         XCTAssertEqual(state.subscription, activeSubscription)
     }
 
+    func testRequestBillingPageTokenForwardsAccessToken() async throws {
+        let storedToken = validStoredToken()
+        var requestedAccessToken: String?
+        let state = AuthState(
+            loadStoredToken: { storedToken },
+            loadStoredRefreshToken: { nil },
+            loadStoredUserProfile: { nil },
+            saveStoredToken: { _, _ in },
+            saveStoredUserProfile: { _ in },
+            clearStoredSession: {},
+            fetchProfile: { _ in self.makeProfile(email: "billing-page@test.com") },
+            fetchSubscription: { _ in .none },
+            issueBillingPageToken: { token in
+                requestedAccessToken = token
+                return BillingPageTokenResponse(token: "billing.jwt.token")
+            }
+        )
+
+        let pageToken = try await state.requestBillingPageToken()
+
+        XCTAssertEqual(pageToken, "billing.jwt.token")
+        XCTAssertEqual(requestedAccessToken, "valid-token")
+    }
+
+    func testRequestBillingPageTokenRequiresAuthenticatedSession() async {
+        let state = AuthState(
+            loadStoredToken: { nil },
+            loadStoredRefreshToken: { nil },
+            loadStoredUserProfile: { nil },
+            saveStoredToken: { _, _ in },
+            saveStoredUserProfile: { _ in },
+            clearStoredSession: {},
+            fetchProfile: { _ in self.makeProfile(email: "billing-page@test.com") },
+            fetchSubscription: { _ in .none },
+            issueBillingPageToken: { _ in
+                XCTFail("Page token API should not be called without a session")
+                return BillingPageTokenResponse(token: "unexpected")
+            }
+        )
+
+        do {
+            _ = try await state.requestBillingPageToken()
+            XCTFail("Expected unauthorized error")
+        } catch AuthError.unauthorized {
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
     func testStartCheckoutPostsEntitlementNotificationWhenSubscriptionBecomesActive() async throws {
         var storedToken: (token: String, expiresAt: Int)?
         var checkoutStarted = false

--- a/Tests/TypefluxTests/BillingAPIServiceTests.swift
+++ b/Tests/TypefluxTests/BillingAPIServiceTests.swift
@@ -161,6 +161,41 @@ final class BillingAPIServiceTests: XCTestCase {
         XCTAssertEqual(portal.url.absoluteString, "https://billing.stripe.com/session/test")
     }
 
+    func testRequestBillingPageTokenPostsAuthenticatedEmptyJSONAndDecodesToken() async throws {
+        let session = BillingStubSession()
+        await session.setHandler { request in
+            XCTAssertEqual(request.url?.absoluteString, "https://api.example/api/v1/billing/page-token")
+            XCTAssertEqual(request.httpMethod, "POST")
+            XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer token-1")
+            XCTAssertEqual(request.httpBody, Data("{}".utf8))
+            let body = #"{"code":"OK","data":{"token":"billing.jwt.token"}}"#
+            return (Data(body.utf8), Self.httpResponse(url: request.url!, status: 200))
+        }
+        let service = makeService(session: session)
+
+        let response = try await service.requestBillingPageToken(token: "token-1")
+
+        XCTAssertEqual(response, BillingPageTokenResponse(token: "billing.jwt.token"))
+    }
+
+    func testRequestBillingPageTokenSurfacesServerError() async {
+        let session = BillingStubSession()
+        await session.setHandler { request in
+            let body = #"{"code":"BILLING_NOT_CONFIGURED","message":"missing secret"}"#
+            return (Data(body.utf8), Self.httpResponse(url: request.url!, status: 400))
+        }
+        let service = makeService(session: session)
+
+        do {
+            _ = try await service.requestBillingPageToken(token: "token-1")
+            XCTFail("Expected billing configuration error")
+        } catch let error as AuthError {
+            XCTAssertEqual(error.authErrorCode, "BILLING_NOT_CONFIGURED")
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
     func testFetchSubscriptionRetriesTransientGatewayFailure() async throws {
         let session = BillingStubSession()
         await session.setHandler { request in

--- a/Tests/TypefluxTests/LocalizationResourceTests.swift
+++ b/Tests/TypefluxTests/LocalizationResourceTests.swift
@@ -29,6 +29,17 @@ final class LocalizationResourceTests: XCTestCase {
         }
     }
 
+    func testBillingPageUnavailableHasLocalizedValueForAllSupportedLanguages() throws {
+        for language in AppLanguage.allCases {
+            let bundle = try localizationBundle(for: language)
+            let key = "cloud.error.billingPageUnavailable"
+            let localized = bundle.localizedString(forKey: key, value: nil, table: nil)
+
+            XCTAssertNotEqual(localized, key, "Missing localized value for \(key) in \(language.rawValue)")
+            XCTAssertFalse(localized.isEmpty)
+        }
+    }
+
     func testChineseOllamaProviderNameUsesRequestedWordOrder() throws {
         for language in [AppLanguage.simplifiedChinese, .traditionalChinese] {
             let bundle = try localizationBundle(for: language)

--- a/Tests/TypefluxTests/TypefluxCloudServerErrorMessageTests.swift
+++ b/Tests/TypefluxTests/TypefluxCloudServerErrorMessageTests.swift
@@ -56,6 +56,10 @@ final class TypefluxCloudServerErrorMessageTests: XCTestCase {
             TypefluxCloudServerErrorMessage.localizationKey(for: "BILLING_NOT_CONFIGURED"),
             "cloud.error.billingServiceUnavailable"
         )
+        XCTAssertEqual(
+            TypefluxCloudServerErrorMessage.localizationKey(for: "BILLING_PAGE_UNAVAILABLE"),
+            "cloud.error.billingPageUnavailable"
+        )
     }
 
     func testBillingErrorParsesSubscriptionRequiredHTTPBody() {


### PR DESCRIPTION
## Summary

- request a short-lived billing page token before starting a new subscription
- open `https://typeflux.app/billing/plans#t=<token>` for subscribe actions while preserving Stripe portal management
- add localized errors and unit coverage for API, AuthState, URL construction, and billing-flow branches

## Verification

- `swift build`
- focused coverage run: 11 tests passed; `AccountBillingFlow.swift` line coverage 92.86%; new API/AuthState methods exercised on success and failure paths
- relevant suites: 39 tests passed across billing API, billing flow, AuthState page token, localization resources, and server-error mapping
- full `swift test` was attempted; the local runner stalled in pre-existing `AuthStateTests` while macOS AddressBook/CoreData XPC was unavailable. Tests completed before that point had no failures.

Closes GUL-10
