### PR TITLE
GUL-8 / GUL-26: Use server-provided billing plans URL

### DIFF
--- a/Sources/Typeflux/Auth/AccountBillingFlow.swift
+++ b/Sources/Typeflux/Auth/AccountBillingFlow.swift
@@ -1,40 +1,16 @@
 import Foundation
 
 enum AccountBillingFlow {
-    static let billingPlansBaseURL = URL(string: "https://typeflux.app/billing/plans")!
-
     static func destination(
         for action: AccountSubscriptionPresentation.BillingAction,
-        requestBillingPageToken: () async throws -> String,
-        createPortalSession: () async throws -> URL,
-        billingPlansBaseURL: URL = billingPlansBaseURL
+        requestBillingPageToken: () async throws -> URL,
+        createPortalSession: () async throws -> URL
     ) async throws -> URL {
         switch action {
         case .subscribe:
-            let token = try await requestBillingPageToken()
-            return try billingPlansURL(token: token, baseURL: billingPlansBaseURL)
+            return try await requestBillingPageToken()
         case .manageBilling:
             return try await createPortalSession()
         }
-    }
-
-    static func billingPlansURL(token: String, baseURL: URL = billingPlansBaseURL) throws -> URL {
-        guard !token.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
-              var components = URLComponents(url: baseURL, resolvingAgainstBaseURL: false)
-        else {
-            throw AuthError.serverError(code: "BILLING_PAGE_UNAVAILABLE", message: nil)
-        }
-
-        var fragment = URLComponents()
-        fragment.queryItems = [URLQueryItem(name: "t", value: token)]
-        guard let encodedFragment = fragment.percentEncodedQuery else {
-            throw AuthError.serverError(code: "BILLING_PAGE_UNAVAILABLE", message: nil)
-        }
-        components.percentEncodedFragment = encodedFragment
-
-        guard let url = components.url else {
-            throw AuthError.serverError(code: "BILLING_PAGE_UNAVAILABLE", message: nil)
-        }
-        return url
     }
 }

--- a/Sources/Typeflux/Auth/AuthState+Subscription.swift
+++ b/Sources/Typeflux/Auth/AuthState+Subscription.swift
@@ -97,12 +97,12 @@ extension AuthState {
         return session.url
     }
 
-    func requestBillingPageToken() async throws -> String {
+    func requestBillingPageToken() async throws -> URL {
         guard let token = accessToken else {
             throw AuthError.unauthorized
         }
         let response = try await issueBillingPageToken(token)
-        return response.token
+        return response.plansURL
     }
 
     private func startCheckoutPolling() {

--- a/Sources/Typeflux/Auth/BillingModels.swift
+++ b/Sources/Typeflux/Auth/BillingModels.swift
@@ -187,6 +187,12 @@ struct BillingPortalSession: Decodable, Equatable {
 
 struct BillingPageTokenResponse: Decodable, Equatable {
     let token: String
+    let plansURL: URL
+
+    enum CodingKeys: String, CodingKey {
+        case token
+        case plansURL = "plans_url"
+    }
 }
 
 struct BillingCheckoutSessionRequest: Encodable {

--- a/Tests/TypefluxTests/AccountBillingFlowTests.swift
+++ b/Tests/TypefluxTests/AccountBillingFlowTests.swift
@@ -3,20 +3,7 @@ import XCTest
 
 @MainActor
 final class AccountBillingFlowTests: XCTestCase {
-    func testBillingPlansURLPlacesEncodedTokenInFragment() throws {
-        let url = try AccountBillingFlow.billingPlansURL(token: "header.payload+/signature=")
-
-        XCTAssertEqual(url.scheme, "https")
-        XCTAssertEqual(url.host, "typeflux.app")
-        XCTAssertEqual(url.path, "/billing/plans")
-
-        let fragment = try XCTUnwrap(url.fragment)
-        let fragmentComponents = try XCTUnwrap(URLComponents(string: "?\(fragment)"))
-        XCTAssertEqual(fragmentComponents.queryItems, [URLQueryItem(name: "t", value: "header.payload+/signature=")])
-        XCTAssertNil(url.query)
-    }
-
-    func testSubscribeDestinationRequestsPageTokenWithoutCreatingPortal() async throws {
+    func testSubscribeDestinationUsesServerPlansURLWithoutCreatingPortal() async throws {
         var tokenRequests = 0
         var portalRequests = 0
 
@@ -24,7 +11,7 @@ final class AccountBillingFlowTests: XCTestCase {
             for: .subscribe,
             requestBillingPageToken: {
                 tokenRequests += 1
-                return "billing.jwt.token"
+                return URL(string: "https://billing.example/custom/plans#t=billing.jwt.token")!
             },
             createPortalSession: {
                 portalRequests += 1
@@ -32,7 +19,7 @@ final class AccountBillingFlowTests: XCTestCase {
             }
         )
 
-        XCTAssertEqual(url.absoluteString, "https://typeflux.app/billing/plans#t=billing.jwt.token")
+        XCTAssertEqual(url.absoluteString, "https://billing.example/custom/plans#t=billing.jwt.token")
         XCTAssertEqual(tokenRequests, 1)
         XCTAssertEqual(portalRequests, 0)
     }
@@ -45,7 +32,7 @@ final class AccountBillingFlowTests: XCTestCase {
             for: .manageBilling,
             requestBillingPageToken: {
                 tokenRequests += 1
-                return "billing.jwt.token"
+                return URL(string: "https://billing.example/custom/plans#t=billing.jwt.token")!
             },
             createPortalSession: {
                 portalRequests += 1
@@ -80,12 +67,5 @@ final class AccountBillingFlowTests: XCTestCase {
         }
 
         XCTAssertEqual(portalRequests, 0)
-    }
-
-    func testBillingPlansURLRejectsEmptyTokenWithLocalizedError() {
-        XCTAssertThrowsError(try AccountBillingFlow.billingPlansURL(token: "   \n")) { error in
-            XCTAssertFalse(error.localizedDescription.isEmpty)
-            XCTAssertNotEqual(error.localizedDescription, "cloud.error.billingPageUnavailable")
-        }
     }
 }

--- a/Tests/TypefluxTests/AuthStateTests.swift
+++ b/Tests/TypefluxTests/AuthStateTests.swift
@@ -396,13 +396,16 @@ final class AuthStateTests: XCTestCase {
             fetchSubscription: { _ in .none },
             issueBillingPageToken: { token in
                 requestedAccessToken = token
-                return BillingPageTokenResponse(token: "billing.jwt.token")
+                return BillingPageTokenResponse(
+                    token: "billing.jwt.token",
+                    plansURL: URL(string: "https://billing.example/plans#t=billing.jwt.token")!
+                )
             }
         )
 
-        let pageToken = try await state.requestBillingPageToken()
+        let plansURL = try await state.requestBillingPageToken()
 
-        XCTAssertEqual(pageToken, "billing.jwt.token")
+        XCTAssertEqual(plansURL.absoluteString, "https://billing.example/plans#t=billing.jwt.token")
         XCTAssertEqual(requestedAccessToken, "valid-token")
     }
 
@@ -418,7 +421,10 @@ final class AuthStateTests: XCTestCase {
             fetchSubscription: { _ in .none },
             issueBillingPageToken: { _ in
                 XCTFail("Page token API should not be called without a session")
-                return BillingPageTokenResponse(token: "unexpected")
+                return BillingPageTokenResponse(
+                    token: "unexpected",
+                    plansURL: URL(string: "https://billing.example/plans#t=unexpected")!
+                )
             }
         )
 

--- a/Tests/TypefluxTests/BillingAPIServiceTests.swift
+++ b/Tests/TypefluxTests/BillingAPIServiceTests.swift
@@ -168,14 +168,15 @@ final class BillingAPIServiceTests: XCTestCase {
             XCTAssertEqual(request.httpMethod, "POST")
             XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer token-1")
             XCTAssertEqual(request.httpBody, Data("{}".utf8))
-            let body = #"{"code":"OK","data":{"token":"billing.jwt.token"}}"#
+            let body = #"{"code":"OK","data":{"token":"billing.jwt.token","plans_url":"https://billing.example/plans#t=billing.jwt.token"}}"#
             return (Data(body.utf8), Self.httpResponse(url: request.url!, status: 200))
         }
         let service = makeService(session: session)
 
         let response = try await service.requestBillingPageToken(token: "token-1")
 
-        XCTAssertEqual(response, BillingPageTokenResponse(token: "billing.jwt.token"))
+        XCTAssertEqual(response.token, "billing.jwt.token")
+        XCTAssertEqual(response.plansURL.absoluteString, "https://billing.example/plans#t=billing.jwt.token")
     }
 
     func testRequestBillingPageTokenSurfacesServerError() async {


### PR DESCRIPTION
## Summary

- decode the API-provided `plans_url`
- pass the complete URL through the account billing flow
- remove the client-side billing URL constant and token-fragment construction

## Testing

- `swift test --disable-index-store` (2,340 tests passed)
- `swift test --disable-index-store --enable-code-coverage --filter 'AccountBillingFlowTests|BillingAPIServiceTests|AuthStateTests'` (34 tests passed; `AccountBillingFlow.swift` line coverage: 100%)

Related: GUL-8, GUL-26
