### PR TITLE
GUL-24: move diagnostics into timing card

### DIFF
--- a/Sources/Typeflux/UI/HistoryPipelineTimelineView.swift
+++ b/Sources/Typeflux/UI/HistoryPipelineTimelineView.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-struct HistoryPipelineSummaryBadgesView: View {
+private struct HistoryPipelineSummaryBadgesView: View {
     let items: [HistoryPipelineBadgePresentationItem]
 
     var body: some View {
@@ -57,6 +57,7 @@ struct HistoryPipelineTimelineView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: StudioTheme.Spacing.smallMedium) {
             header
+            summaryBadges
             slowestStage
             lanes
             requestDetails
@@ -68,6 +69,13 @@ struct HistoryPipelineTimelineView: View {
             RoundedRectangle(cornerRadius: StudioTheme.CornerRadius.large, style: .continuous)
                 .fill(StudioTheme.controlSurface)
         )
+    }
+
+    @ViewBuilder
+    private var summaryBadges: some View {
+        if !timeline.summaryBadges.isEmpty {
+            HistoryPipelineSummaryBadgesView(items: timeline.summaryBadges)
+        }
     }
 
     @ViewBuilder

--- a/Sources/Typeflux/UI/StudioComponents.swift
+++ b/Sources/Typeflux/UI/StudioComponents.swift
@@ -1587,10 +1587,6 @@ struct StudioHistoryRow: View {
                                 .studioTooltip(record.failureMessage ?? L("workflow.processing.failed"), yOffset: 28)
                         }
                     }
-
-                    if let timeline = record.pipelineTimeline, !timeline.summaryBadges.isEmpty {
-                        HistoryPipelineSummaryBadgesView(items: timeline.summaryBadges)
-                    }
                 }
 
                 Spacer(minLength: StudioTheme.Spacing.small)


### PR DESCRIPTION
## Summary

- hide transcription timing badges from collapsed history rows
- show the same diagnostic badges inside the expanded processing timing card
- keep the history list focused on user-facing transcription content

## Verification

- `swift test --filter 'SettingsViewModelHistoryAudioTests|StudioModelsTests|LocalizationResourceTests'` (57 passed)
- `swift test` (2367 passed)
- `git diff --check`

Follow-up to #113 for GUL-24.
