### PR TITLE
GUL-35: rename persona prompt label

### DIFF
--- a/Sources/Typeflux/Resources/en.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/en.lproj/Localizable.strings
@@ -608,7 +608,7 @@
 "settings.personas.editTitle" = "Edit Persona";
 "settings.personas.name" = "Persona Name";
 "settings.personas.namePlaceholder" = "Enter persona name";
-"settings.personas.prompt" = "System Prompt";
+"settings.personas.prompt" = "Persona Definition";
 "settings.personas.saved" = "Persona saved.";
 "settings.personas.tag.system" = "System";
 "settings.personas.deleteDialog.title" = "Delete Persona?";

--- a/Sources/Typeflux/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/ja.lproj/Localizable.strings
@@ -599,7 +599,7 @@
 "settings.personas.editTitle" = "ペルソナを編集";
 "settings.personas.name" = "ペルソナ名";
 "settings.personas.namePlaceholder" = "ペルソナ名を入力してください";
-"settings.personas.prompt" = "システムプロンプト";
+"settings.personas.prompt" = "ペルソナ定義";
 "settings.personas.saved" = "ペルソナが保存されました。";
 "settings.personas.tag.system" = "システム";
 "settings.personas.deleteDialog.title" = "ペルソナを削除しますか?";

--- a/Sources/Typeflux/Resources/ko.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/ko.lproj/Localizable.strings
@@ -599,7 +599,7 @@
 "settings.personas.editTitle" = "페르소나 편집";
 "settings.personas.name" = "페르소나 이름";
 "settings.personas.namePlaceholder" = "페르소나 이름을 입력하세요";
-"settings.personas.prompt" = "시스템 프롬프트";
+"settings.personas.prompt" = "페르소나 정의";
 "settings.personas.saved" = "페르소나가 저장되었습니다.";
 "settings.personas.tag.system" = "시스템";
 "settings.personas.deleteDialog.title" = "페르소나를 삭제하시겠습니까?";

--- a/Sources/Typeflux/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/zh-Hans.lproj/Localizable.strings
@@ -608,7 +608,7 @@
 "settings.personas.editTitle" = "编辑人设";
 "settings.personas.name" = "人设名称";
 "settings.personas.namePlaceholder" = "输入人设名称";
-"settings.personas.prompt" = "系统提示词";
+"settings.personas.prompt" = "人设定义";
 "settings.personas.saved" = "人设已保存。";
 "settings.personas.tag.system" = "系统";
 "settings.personas.deleteDialog.title" = "删除人设？";

--- a/Sources/Typeflux/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/zh-Hant.lproj/Localizable.strings
@@ -606,7 +606,7 @@
 "settings.personas.editTitle" = "編輯人設";
 "settings.personas.name" = "人設名稱";
 "settings.personas.namePlaceholder" = "輸入人設名稱";
-"settings.personas.prompt" = "系統提示詞";
+"settings.personas.prompt" = "人設定義";
 "settings.personas.saved" = "人設已儲存。";
 "settings.personas.tag.system" = "系統";
 "settings.personas.deleteDialog.title" = "刪除人設？";

--- a/Tests/TypefluxTests/LocalizationResourceTests.swift
+++ b/Tests/TypefluxTests/LocalizationResourceTests.swift
@@ -49,6 +49,27 @@ final class LocalizationResourceTests: XCTestCase {
         }
     }
 
+    func testPersonaDefinitionUsesUserFriendlyCopyForAllSupportedLanguages() throws {
+        let expectedValues: [AppLanguage: String] = [
+            .english: "Persona Definition",
+            .simplifiedChinese: "人设定义",
+            .traditionalChinese: "人設定義",
+            .japanese: "ペルソナ定義",
+            .korean: "페르소나 정의"
+        ]
+
+        for language in AppLanguage.allCases {
+            let bundle = try localizationBundle(for: language)
+            let localized = bundle.localizedString(forKey: "settings.personas.prompt", value: nil, table: nil)
+
+            XCTAssertEqual(
+                localized,
+                expectedValues[language],
+                "Unexpected persona definition copy in \(language.rawValue)"
+            )
+        }
+    }
+
     func testOverlayProcessingPhaseKeysExistForAllSupportedLanguages() throws {
         let keys = [
             "overlay.processing.transcribing",


### PR DESCRIPTION
## Summary

- rename the persona editor label from technical “System Prompt” wording to user-facing “Persona Definition” wording
- update all five supported localizations
- add a regression test covering the exact localized copy

## Verification

- `swift test --filter LocalizationResourceTests` (11 tests passed)
- `swift test` (2,368 tests passed)
- `git diff --check`

## Screenshot

- [Original UI highlighting the label](https://multica.ai/api/attachments/01a032a2-0d90-7773-9be4-b854994d974d/download)

Closes GUL-35
