### PR TITLE
GUL-34: use white backgrounds for model icons

### DIFF
--- a/Sources/Typeflux/Onboarding/OnboardingProviderStyle.swift
+++ b/Sources/Typeflux/Onboarding/OnboardingProviderStyle.swift
@@ -1,20 +1,5 @@
 import Foundation
 
-enum OnboardingProviderIconPlateStyle: Equatable {
-    case neutral
-    case light
-}
-
 enum OnboardingProviderStyle {
     static let listColumnWidth: CGFloat = 408
-
-    static func iconPlateStyle(for providerID: StudioModelProviderID) -> OnboardingProviderIconPlateStyle {
-        switch providerID {
-        case .whisperAPI, .multimodalLLM, .googleCloud, .openAI, .openRouter, .grok, .groq, .groqSTT,
-             .ollama:
-            .light
-        default:
-            .neutral
-        }
-    }
 }

--- a/Sources/Typeflux/Onboarding/OnboardingView.swift
+++ b/Sources/Typeflux/Onboarding/OnboardingView.swift
@@ -1365,11 +1365,11 @@ struct OnboardingView: View {
 
     private func providerIconBadge(for providerID: StudioModelProviderID, isSelected: Bool) -> some View {
         RoundedRectangle(cornerRadius: 12, style: .continuous)
-            .fill(providerIconBadgeBackground(for: providerID, isSelected: isSelected))
+            .fill(StudioTheme.modelProviderIconPlate)
             .frame(width: 38, height: 38)
             .overlay(
                 RoundedRectangle(cornerRadius: 12, style: .continuous)
-                    .stroke(providerIconBadgeBorder(for: providerID, isSelected: isSelected), lineWidth: 1)
+                    .stroke(providerIconBadgeBorder(isSelected: isSelected), lineWidth: 1)
             )
             .overlay(
                 Group {
@@ -1389,43 +1389,16 @@ struct OnboardingView: View {
                     } else {
                         Image(systemName: providerSymbol(for: providerID))
                             .font(.system(size: 14, weight: .medium))
-                            .foregroundStyle(isSelected ? StudioTheme.accent : onboardingSecondaryText)
+                            .foregroundStyle(
+                                isSelected ? StudioTheme.accent : StudioTheme.modelProviderFallbackSymbol
+                            )
                     }
                 }
             )
     }
 
-    private func providerIconBadgeBackground(for providerID: StudioModelProviderID,
-                                             isSelected: Bool) -> LinearGradient {
-        switch OnboardingProviderStyle.iconPlateStyle(for: providerID) {
-        case .light:
-            let top = isSelected
-                ? StudioTheme.accent.opacity(0.18)
-                : Color.white.opacity(0.92)
-            let bottom = isSelected
-                ? StudioTheme.accent.opacity(0.34)
-                : Color(red: 0.84, green: 0.87, blue: 0.93).opacity(0.84)
-            return LinearGradient(colors: [top, bottom], startPoint: .topLeading, endPoint: .bottomTrailing)
-        case .neutral:
-            let top = isDarkMode
-                ? Color.white.opacity(isSelected ? 0.1 : 0.07)
-                : StudioTheme.surface.opacity(isSelected ? 0.96 : 0.92)
-            let bottom = isDarkMode
-                ? Color(red: 0.12, green: 0.13, blue: 0.17).opacity(isSelected ? 0.72 : 0.82)
-                : StudioTheme.surfaceMuted.opacity(isSelected ? 0.98 : 0.94)
-            return LinearGradient(colors: [top, bottom], startPoint: .topLeading, endPoint: .bottomTrailing)
-        }
-    }
-
-    private func providerIconBadgeBorder(for providerID: StudioModelProviderID, isSelected: Bool) -> Color {
-        switch OnboardingProviderStyle.iconPlateStyle(for: providerID) {
-        case .light:
-            isDarkMode ? Color.white.opacity(isSelected ? 0.28 : 0.18) : StudioTheme.border
-                .opacity(isSelected ? 0.9 : 0.72)
-        case .neutral:
-            isDarkMode ? Color.white.opacity(isSelected ? 0.12 : 0.08) : StudioTheme.border
-                .opacity(isSelected ? 0.85 : 0.72)
-        }
+    private func providerIconBadgeBorder(isSelected: Bool) -> Color {
+        isSelected ? StudioTheme.accent.opacity(0.55) : Color.black.opacity(0.12)
     }
 
     private func permissionsStep(contentHeight: CGFloat) -> some View {

--- a/Sources/Typeflux/Settings/SettingsView.swift
+++ b/Sources/Typeflux/Settings/SettingsView.swift
@@ -5702,7 +5702,7 @@ struct StudioView: View {
                         RoundedRectangle(
                             cornerRadius: StudioTheme.CornerRadius.large, style: .continuous
                         )
-                        .fill(providerBadgeBackground(for: providerID, isFocused: isFocused))
+                        .fill(StudioTheme.modelProviderIconPlate)
                         .frame(
                             width: StudioTheme.ControlSize.modelProviderBadge,
                             height: StudioTheme.ControlSize.modelProviderBadge
@@ -5778,19 +5778,6 @@ struct StudioView: View {
         return model.isEmpty ? L("settings.models.modelNotConfigured") : model
     }
 
-    private func providerBadgeBackground(for provider: StudioModelProviderID, isFocused: Bool)
-        -> Color {
-        if provider.usesTypefluxBranding {
-            return isFocused ? StudioTheme.controlSurface : Color.clear
-        }
-
-        if providerLogoResourceName(for: provider) != nil {
-            return isFocused ? StudioTheme.selectionSurfaceRaised : StudioTheme.iconTileSurface
-        }
-
-        return isFocused ? StudioTheme.selectionSurfaceRaised : StudioTheme.iconTileSurface
-    }
-
     @ViewBuilder
     private func providerIconView(for provider: StudioModelProviderID, isFocused: Bool) -> some View {
         if provider.usesTypefluxBranding {
@@ -5813,7 +5800,7 @@ struct StudioView: View {
                         size: StudioTheme.ControlSize.modelProviderBadgeSymbol, weight: .semibold
                     )
                 )
-                .foregroundStyle(isFocused ? StudioTheme.accent : StudioTheme.textSecondary)
+                .foregroundStyle(isFocused ? StudioTheme.accent : StudioTheme.modelProviderFallbackSymbol)
         }
     }
 

--- a/Sources/Typeflux/UI/StudioTheme.swift
+++ b/Sources/Typeflux/UI/StudioTheme.swift
@@ -339,6 +339,8 @@ enum StudioTheme {
         light: NSColor(calibratedRed: 0.90, green: 0.94, blue: 1.0, alpha: 0.74),
         dark: NSColor(calibratedWhite: 0.245, alpha: 0.62)
     )
+    static let modelProviderIconPlate = Color.white
+    static let modelProviderFallbackSymbol = Color.black.opacity(0.72)
     static let border = dynamic(
         light: NSColor(calibratedRed: 0.38, green: 0.45, blue: 0.56, alpha: 0.14),
         dark: NSColor(calibratedWhite: 1.0, alpha: 0.115)

--- a/Tests/TypefluxTests/OnboardingProviderStyleTests.swift
+++ b/Tests/TypefluxTests/OnboardingProviderStyleTests.swift
@@ -6,24 +6,4 @@ final class OnboardingProviderStyleTests: XCTestCase {
         XCTAssertEqual(OnboardingProviderStyle.listColumnWidth, 408)
         XCTAssertLessThan(OnboardingProviderStyle.listColumnWidth, 430)
     }
-
-    func testMonochromeProvidersUseLightIconPlate() {
-        let providers: [StudioModelProviderID] = [
-            .openAI, .whisperAPI, .multimodalLLM, .openRouter, .grok, .groq, .groqSTT, .ollama
-        ]
-
-        for provider in providers {
-            XCTAssertEqual(OnboardingProviderStyle.iconPlateStyle(for: provider), .light)
-        }
-    }
-
-    func testColorfulAndSymbolProvidersUseNeutralIconPlate() {
-        let providers: [StudioModelProviderID] = [
-            .aliCloud, .doubaoRealtime, .anthropic, .gemini, .freeSTT, .freeModel, .appleSpeech
-        ]
-
-        for provider in providers {
-            XCTAssertEqual(OnboardingProviderStyle.iconPlateStyle(for: provider), .neutral)
-        }
-    }
 }

--- a/Tests/TypefluxTests/StudioThemeTests.swift
+++ b/Tests/TypefluxTests/StudioThemeTests.swift
@@ -54,6 +54,14 @@ final class StudioThemeTests: XCTestCase {
         XCTAssertEqual(StudioTheme.contentInset, StudioTheme.Layout.contentInset)
     }
 
+    func testModelProviderIconPlateUsesWhiteBackground() {
+        XCTAssertEqual(StudioTheme.modelProviderIconPlate, .white)
+    }
+
+    func testModelProviderFallbackSymbolUsesDarkForeground() {
+        XCTAssertEqual(StudioTheme.modelProviderFallbackSymbol, .black.opacity(0.72))
+    }
+
     // MARK: - Overview Layout
 
     func testOverviewLayoutUsesStackedArrangementForNarrowContent() {


### PR DESCRIPTION
## Summary

- use one pure-white background for every STT and LLM provider icon in model settings
- apply the same background to onboarding provider icons in both appearance modes
- keep symbol-only provider icons readable with a dark fallback foreground
- remove the obsolete per-provider light/neutral icon-plate classification

## Tests

- `swift test --filter StudioThemeTests`
- `swift test` (2366 tests, 0 failures)
- `make coverage` (2366 tests, 0 failures; report generated successfully)

Closes GUL-34
