### PR TITLE
GUL-39: extend Bluetooth audio recovery window

### DIFF
--- a/Sources/Typeflux/Workflow/WorkflowController+AudioRecorder.swift
+++ b/Sources/Typeflux/Workflow/WorkflowController+AudioRecorder.swift
@@ -26,15 +26,17 @@ extension WorkflowController {
         levelHandler: @escaping (Float) -> Void,
         audioBufferHandler: ((AVAudioPCMBuffer) -> Void)?
     ) async throws {
-        for attempt in 1 ... Self.audioStartupMaxAttemptCount {
+        var attempt = 1
+        while true {
             do {
                 try audioRecorder.start(levelHandler: levelHandler, audioBufferHandler: audioBufferHandler)
                 return
             } catch {
+                let maxAttemptCount = Self.audioStartupMaxAttemptCount(for: error)
                 guard
                     AVFoundationAudioRecorder.isRecoverableInputReconfigurationError(error),
                     isRecording,
-                    attempt < Self.audioStartupMaxAttemptCount
+                    attempt < maxAttemptCount
                 else {
                     throw error
                 }
@@ -43,7 +45,7 @@ extension WorkflowController {
                     """
                     [Audio Recorder] Microphone input is reconfiguring; retrying with a fresh audio engine.
                     attempt: \(attempt)
-                    maxAttempts: \(Self.audioStartupMaxAttemptCount)
+                    maxAttempts: \(maxAttemptCount)
                     retryDelayMilliseconds: 250
                     """
                 )
@@ -51,7 +53,20 @@ extension WorkflowController {
                 guard isRecording else {
                     throw error
                 }
+                attempt += 1
             }
         }
+    }
+
+    static func audioStartupMaxAttemptCount(for error: Error) -> Int {
+        if let recorderError = error as? AVFoundationAudioRecorder.RecorderError,
+           recorderError == .inputStartupTimedOut
+        {
+            return audioStartupMaxAttemptCount
+        }
+
+        return AVFoundationAudioRecorder.isRecoverableInputReconfigurationError(error)
+            ? audioReconfigurationStartupMaxAttemptCount
+            : audioStartupMaxAttemptCount
     }
 }

--- a/Sources/Typeflux/Workflow/WorkflowController.swift
+++ b/Sources/Typeflux/Workflow/WorkflowController.swift
@@ -31,6 +31,9 @@ final class WorkflowController {
     static let localModelPreheatDebounce: Duration = .milliseconds(180)
     static let recordingHintAutoHideDelay: TimeInterval = 3.0
     static let audioStartupMaxAttemptCount = 3
+    // Bluetooth routes can need several seconds to publish a stable input format.
+    // At the 250ms retry interval this allows about 2.75 seconds to settle.
+    static let audioReconfigurationStartupMaxAttemptCount = 12
     static let audioStartupRetryDelay: Duration = .milliseconds(250)
     static let llmTimeoutAfterTranscriptionSeconds: TimeInterval = 3
     static let paidCreditExhaustedPromptSuppressionInterval: TimeInterval = 60 * 60

--- a/Tests/TypefluxTests/WorkflowControllerProcessingTests.swift
+++ b/Tests/TypefluxTests/WorkflowControllerProcessingTests.swift
@@ -811,7 +811,7 @@ final class WorkflowControllerProcessingTests: XCTestCase {
 
     func testBeginRecordingRetriesFormatChangeUntilAudioStartupSucceeds() async {
         let audioRecorder = TransientAudioStartupFailureRecorder(
-            failureCount: 2,
+            failureCount: 5,
             error: NSError(
                 domain: "com.apple.coreaudio.avfaudio",
                 code: Int(kAudioUnitErr_FormatNotSupported)
@@ -828,10 +828,34 @@ final class WorkflowControllerProcessingTests: XCTestCase {
         XCTAssertTrue(controller.isRecording)
         XCTAssertTrue(controller.isAudioRecorderStarted)
         XCTAssertFalse(controller.isAudioRecorderStarting)
-        XCTAssertEqual(audioRecorder.startCallCount, 3)
+        XCTAssertEqual(audioRecorder.startCallCount, 6)
 
         controller.cancelRecording()
         await waitForMainActorWork()
+    }
+
+    func testBeginRecordingBoundsPersistentFormatChangeRetries() async {
+        let audioRecorder = ThrowingStartAudioRecorder(
+            error: NSError(
+                domain: "com.apple.coreaudio.avfaudio",
+                code: Int(kAudioUnitErr_FormatNotSupported)
+            )
+        )
+        let controller = makeWorkflowController(
+            audioRecorder: audioRecorder,
+            sleep: { _ in }
+        )
+
+        await controller.beginRecording(intent: .dictation, startLocked: false)
+        await waitForMainActorWork()
+
+        XCTAssertFalse(controller.isRecording)
+        XCTAssertFalse(controller.isAudioRecorderStarted)
+        XCTAssertFalse(controller.isAudioRecorderStarting)
+        XCTAssertEqual(audioRecorder.startCallCount, 12)
+        await MainActor.run {
+            controller.overlayController.dismissImmediately()
+        }
     }
 
     func testReleasingAfterImmediateAudioStartStopsRecorder() async {


### PR DESCRIPTION
## Summary

- extend recoverable Core Audio route-change startup retries from about 0.5 seconds to about 2.75 seconds
- keep the existing three-attempt cap for slow startup timeouts
- cover delayed Bluetooth format stabilization and the bounded failure path

## Verification

- `swift test --filter WorkflowControllerProcessingTests` (72 tests passed)
- `swift test` (2,369 tests passed)
- `make coverage` (changed retry file: 96.72% line coverage)
- `git diff --check`

`make format` could not run because the repository's `swiftformat`/`swiftlint` executables are not installed in this environment.

Closes GUL-39
