### PR TITLE
GUL-40: preserve audio during realtime startup

### DIFF
--- a/Sources/Typeflux/Workflow/WorkflowController.swift
+++ b/Sources/Typeflux/Workflow/WorkflowController.swift
@@ -1021,9 +1021,28 @@ final class WorkflowController {
             let livePreviewer = liveTranscriptionPreviewer
             let canUseRealtimeTranscription = effectiveIntent != .askSelection
             let usesLivePreview = canUseRealtimeTranscription && shouldUseLiveTranscriptionPreview()
+            let startupAudioBufferRelay = canUseRealtimeTranscription
+                ? RecordingStartupAudioBufferRelay()
+                : nil
+
+            // Begin local capture before resolving credentials or constructing a
+            // realtime transcription session. Some providers perform asynchronous
+            // setup here, and waiting for it used to leave the first spoken words
+            // outside both the recorded file and the streaming transcript.
+            try await startAudioRecorderWithStartupRetry(
+                levelHandler: { [weak self] level in
+                    self?.overlayController.updateLevel(level)
+                },
+                audioBufferHandler: startupAudioBufferRelay.map { relay in
+                    { buffer in relay.append(buffer) }
+                }
+            )
+            RecordingStartupLatencyTrace.shared.mark("workflow.audio_start_return")
+
             if usesLivePreview {
                 await livePreviewer?.prepareForStart()
             }
+            RecordingStartupLatencyTrace.shared.mark("workflow.transcription_setup_enter")
             let realtimeSession: (any RealtimeTranscriptionSession)? = if canUseRealtimeTranscription {
                 await sttRouter.makeRealtimeTranscriptionSession(
                     scenario: .voiceInput,
@@ -1049,20 +1068,21 @@ final class WorkflowController {
             activeRealtimeTranscriptionSession = realtimeSession
             activeRealtimeAudioBufferPump = realtimeAudioBufferPump
             await realtimeSession?.start()
-            try await startAudioRecorderWithStartupRetry(
-                levelHandler: { [weak self] level in
-                    self?.overlayController.updateLevel(level)
-                },
-                audioBufferHandler: (usesLivePreview || realtimeSession != nil) ? { buffer in
+            RecordingStartupLatencyTrace.shared.mark("workflow.transcription_setup_return")
+
+            if usesLivePreview || realtimeSession != nil {
+                startupAudioBufferRelay?.activate { buffer in
                     realtimeAudioBufferPump?.append(buffer)
                     Task {
                         if usesLivePreview {
                             await livePreviewer?.append(buffer)
                         }
                     }
-                } : nil
-            )
-            RecordingStartupLatencyTrace.shared.mark("workflow.audio_start_return")
+                }
+            } else {
+                startupAudioBufferRelay?.cancel()
+            }
+
             isAudioRecorderStarting = false
             isAudioRecorderStarted = true
             pendingRecordingStartID = nil

--- a/Sources/Typeflux/Workflow/WorkflowController.swift
+++ b/Sources/Typeflux/Workflow/WorkflowController.swift
@@ -1038,6 +1038,11 @@ final class WorkflowController {
                 }
             )
             RecordingStartupLatencyTrace.shared.mark("workflow.audio_start_return")
+            // Capture is physically active now even though transcription setup is
+            // still pending. Publish that state so cancellation can stop the
+            // microphone immediately; isAudioRecorderStarting keeps a normal key
+            // release deferred until the streaming pipeline is ready.
+            isAudioRecorderStarted = true
 
             if usesLivePreview {
                 await livePreviewer?.prepareForStart()
@@ -1060,6 +1065,12 @@ final class WorkflowController {
             } else {
                 nil
             }
+            guard isRecording else {
+                startupAudioBufferRelay?.cancel()
+                await livePreviewer?.cancel()
+                await realtimeSession?.cancel()
+                return
+            }
             if effectiveIntent == .askSelection {
                 NetworkDebugLogger
                     .logMessage("[Ask Flow] realtime transcription disabled for isolated Ask Anything recording")
@@ -1069,6 +1080,16 @@ final class WorkflowController {
             activeRealtimeAudioBufferPump = realtimeAudioBufferPump
             await realtimeSession?.start()
             RecordingStartupLatencyTrace.shared.mark("workflow.transcription_setup_return")
+
+            guard isRecording else {
+                startupAudioBufferRelay?.cancel()
+                realtimeAudioBufferPump?.cancel()
+                await livePreviewer?.cancel()
+                await realtimeSession?.cancel()
+                activeRealtimeTranscriptionSession = nil
+                activeRealtimeAudioBufferPump = nil
+                return
+            }
 
             if usesLivePreview || realtimeSession != nil {
                 startupAudioBufferRelay?.activate { buffer in
@@ -1084,21 +1105,9 @@ final class WorkflowController {
             }
 
             isAudioRecorderStarting = false
-            isAudioRecorderStarted = true
             pendingRecordingStartID = nil
             if usesLivePreview {
                 startLiveTranscriptionPreviewIfNeeded(livePreviewer)
-            }
-
-            guard isRecording else {
-                isAudioRecorderStarted = false
-                _ = try? audioRecorder.stop()
-                Task { await livePreviewer?.cancel() }
-                realtimeAudioBufferPump?.cancel()
-                Task { await realtimeSession?.cancel() }
-                activeRealtimeTranscriptionSession = nil
-                activeRealtimeAudioBufferPump = nil
-                return
             }
 
             if shouldFinishRecordingAfterAudioStart {
@@ -1250,8 +1259,7 @@ final class WorkflowController {
     func finishRecordingFromCurrentMode() {
         guard isRecording else { return }
 
-        let shouldStopAudioRecorder = isAudioRecorderStarted
-        if !shouldStopAudioRecorder, isAudioRecorderStarting {
+        if isAudioRecorderStarting {
             shouldFinishRecordingAfterAudioStart = true
             recordingMode = .holdToTalk
             hotkeyPressedAt = nil
@@ -1260,6 +1268,7 @@ final class WorkflowController {
             return
         }
 
+        let shouldStopAudioRecorder = isAudioRecorderStarted
         let useQuickInput = shouldUseQuickInput(
             recordingMode: recordingMode,
             recordingIntent: recordingIntent

--- a/Tests/TypefluxTests/WorkflowControllerProcessingTests.swift
+++ b/Tests/TypefluxTests/WorkflowControllerProcessingTests.swift
@@ -858,6 +858,55 @@ final class WorkflowControllerProcessingTests: XCTestCase {
         }
     }
 
+    func testBeginRecordingCapturesAndReplaysAudioWhileRealtimeSessionIsPreparing() async throws {
+        let format = try XCTUnwrap(AVAudioFormat(
+            commonFormat: .pcmFormatFloat32,
+            sampleRate: 16000,
+            channels: 1,
+            interleaved: false
+        ))
+        let buffer = try XCTUnwrap(AVAudioPCMBuffer(pcmFormat: format, frameCapacity: 160))
+        buffer.frameLength = 160
+        buffer.floatChannelData?[0][0] = 0.25
+
+        let gate = AsyncTestGate()
+        let realtimeSession = PrefixCapturingRealtimeSession()
+        let transcriber = DelayedRealtimeFactoryTranscriber(
+            gate: gate,
+            session: realtimeSession
+        )
+        let audioRecorder = BufferEmittingAudioRecorder(buffer: buffer)
+        let controller = makeWorkflowController(
+            audioRecorder: audioRecorder,
+            sttTranscriber: transcriber,
+            sleep: { _ in },
+            configureSettings: { settingsStore in
+                settingsStore.sttProvider = .typefluxOfficial
+            }
+        )
+
+        let recordingTask = Task {
+            await controller.beginRecording(intent: .dictation, startLocked: false)
+        }
+        await gate.waitUntilBlocked()
+
+        XCTAssertEqual(audioRecorder.startCallCount, 1)
+        let appendCountWhilePreparing = await realtimeSession.appendCount
+        XCTAssertEqual(appendCountWhilePreparing, 0)
+
+        await gate.release()
+        await recordingTask.value
+        await realtimeSession.waitUntilAudioArrives()
+
+        let appendCountAfterSetup = await realtimeSession.appendCount
+        let firstSample = await realtimeSession.firstSample
+        XCTAssertEqual(appendCountAfterSetup, 1)
+        XCTAssertEqual(firstSample, 0.25, accuracy: 0.001)
+
+        controller.cancelRecording()
+        await waitForMainActorWork()
+    }
+
     func testReleasingAfterImmediateAudioStartStopsRecorder() async {
         let eventRecorder = ThreadSafeEventRecorder()
         let audioRecorder = MockProcessingAudioRecorder {
@@ -1953,6 +2002,118 @@ private final class FileReturningAudioRecorder: AudioRecorder {
         stops += 1
         lock.unlock()
         return AudioFile(fileURL: fileURL, duration: 1)
+    }
+}
+
+private final class BufferEmittingAudioRecorder: AudioRecorder {
+    private let buffer: AVAudioPCMBuffer
+    private let lock = NSLock()
+    private var starts = 0
+
+    init(buffer: AVAudioPCMBuffer) {
+        self.buffer = buffer
+    }
+
+    var startCallCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return starts
+    }
+
+    func start(
+        levelHandler _: @escaping (Float) -> Void,
+        audioBufferHandler: ((AVAudioPCMBuffer) -> Void)?
+    ) throws {
+        lock.lock()
+        starts += 1
+        lock.unlock()
+        audioBufferHandler?(buffer)
+    }
+
+    func stop() throws -> AudioFile {
+        AudioFile(fileURL: URL(fileURLWithPath: "/tmp/mock.wav"), duration: 1)
+    }
+}
+
+private actor AsyncTestGate {
+    private var blocked = false
+    private var released = false
+    private var blockContinuation: CheckedContinuation<Void, Never>?
+    private var releaseContinuation: CheckedContinuation<Void, Never>?
+
+    func wait() async {
+        blocked = true
+        blockContinuation?.resume()
+        blockContinuation = nil
+        guard !released else { return }
+        await withCheckedContinuation { continuation in
+            releaseContinuation = continuation
+        }
+    }
+
+    func waitUntilBlocked() async {
+        guard !blocked else { return }
+        await withCheckedContinuation { continuation in
+            blockContinuation = continuation
+        }
+    }
+
+    func release() {
+        released = true
+        releaseContinuation?.resume()
+        releaseContinuation = nil
+    }
+}
+
+private final class DelayedRealtimeFactoryTranscriber: RealtimeTranscriptionSessionFactory {
+    private let gate: AsyncTestGate
+    private let session: any RealtimeTranscriptionSession
+
+    init(gate: AsyncTestGate, session: any RealtimeTranscriptionSession) {
+        self.gate = gate
+        self.session = session
+    }
+
+    func transcribe(audioFile _: AudioFile) async throws -> String {
+        ""
+    }
+
+    func makeRealtimeTranscriptionSession(
+        scenario _: TypefluxCloudScenario,
+        onUpdate _: @escaping @Sendable (TranscriptionSnapshot) async -> Void
+    ) async throws -> any RealtimeTranscriptionSession {
+        await gate.wait()
+        return session
+    }
+}
+
+private actor PrefixCapturingRealtimeSession: RealtimeTranscriptionSession {
+    private(set) var appendCount = 0
+    private(set) var firstSample: Float = 0
+    private var audioContinuation: CheckedContinuation<Void, Never>?
+
+    func start() async {}
+
+    func append(_ buffer: AVAudioPCMBuffer) async {
+        appendCount += 1
+        if appendCount == 1 {
+            firstSample = buffer.floatChannelData?[0][0] ?? 0
+            audioContinuation?.resume()
+            audioContinuation = nil
+        }
+    }
+
+    func finish() async throws -> String {
+        ""
+    }
+
+    func cancel() async {}
+
+    func waitUntilAudioArrives() async {
+        guard appendCount == 0 else { return }
+        await withCheckedContinuation { continuation in
+            audioContinuation = continuation
+        }
     }
 }
 

--- a/Tests/TypefluxTests/WorkflowControllerProcessingTests.swift
+++ b/Tests/TypefluxTests/WorkflowControllerProcessingTests.swift
@@ -881,7 +881,7 @@ final class WorkflowControllerProcessingTests: XCTestCase {
             sttTranscriber: transcriber,
             sleep: { _ in },
             configureSettings: { settingsStore in
-                settingsStore.sttProvider = .typefluxOfficial
+                settingsStore.sttProvider = .googleCloud
             }
         )
 
@@ -905,6 +905,102 @@ final class WorkflowControllerProcessingTests: XCTestCase {
 
         controller.cancelRecording()
         await waitForMainActorWork()
+    }
+
+    func testCancelDuringRealtimeSessionPreparationStopsCaptureAndDropsBufferedAudio() async throws {
+        let format = try XCTUnwrap(AVAudioFormat(
+            commonFormat: .pcmFormatFloat32,
+            sampleRate: 16000,
+            channels: 1,
+            interleaved: false
+        ))
+        let buffer = try XCTUnwrap(AVAudioPCMBuffer(pcmFormat: format, frameCapacity: 160))
+        buffer.frameLength = 160
+        buffer.floatChannelData?[0][0] = 0.25
+
+        let gate = AsyncTestGate()
+        let realtimeSession = PrefixCapturingRealtimeSession()
+        let transcriber = DelayedRealtimeFactoryTranscriber(
+            gate: gate,
+            session: realtimeSession
+        )
+        let audioRecorder = BufferEmittingAudioRecorder(buffer: buffer)
+        let controller = makeWorkflowController(
+            audioRecorder: audioRecorder,
+            sttTranscriber: transcriber,
+            sleep: { _ in },
+            configureSettings: { settingsStore in
+                settingsStore.sttProvider = .googleCloud
+            }
+        )
+
+        let recordingTask = Task {
+            await controller.beginRecording(intent: .dictation, startLocked: false)
+        }
+        await gate.waitUntilBlocked()
+
+        XCTAssertEqual(audioRecorder.startCallCount, 1)
+        controller.cancelRecording()
+        XCTAssertEqual(audioRecorder.stopCallCount, 1)
+
+        await gate.release()
+        await recordingTask.value
+        await waitForMainActorWork()
+
+        let appendCount = await realtimeSession.appendCount
+        XCTAssertEqual(appendCount, 0)
+        XCTAssertFalse(controller.isRecording)
+        XCTAssertFalse(controller.isAudioRecorderStarted)
+        XCTAssertFalse(controller.isAudioRecorderStarting)
+    }
+
+    func testCancelDuringRealtimeSessionStartStopsCaptureAndDropsBufferedAudio() async throws {
+        let format = try XCTUnwrap(AVAudioFormat(
+            commonFormat: .pcmFormatFloat32,
+            sampleRate: 16000,
+            channels: 1,
+            interleaved: false
+        ))
+        let buffer = try XCTUnwrap(AVAudioPCMBuffer(pcmFormat: format, frameCapacity: 160))
+        buffer.frameLength = 160
+        buffer.floatChannelData?[0][0] = 0.25
+
+        let factoryGate = AsyncTestGate()
+        await factoryGate.release()
+        let startGate = AsyncTestGate()
+        let realtimeSession = PrefixCapturingRealtimeSession(startGate: startGate)
+        let transcriber = DelayedRealtimeFactoryTranscriber(
+            gate: factoryGate,
+            session: realtimeSession
+        )
+        let audioRecorder = BufferEmittingAudioRecorder(buffer: buffer)
+        let controller = makeWorkflowController(
+            audioRecorder: audioRecorder,
+            sttTranscriber: transcriber,
+            sleep: { _ in },
+            configureSettings: { settingsStore in
+                settingsStore.sttProvider = .googleCloud
+            }
+        )
+
+        let recordingTask = Task {
+            await controller.beginRecording(intent: .dictation, startLocked: false)
+        }
+        await startGate.waitUntilBlocked()
+
+        XCTAssertEqual(audioRecorder.startCallCount, 1)
+        controller.cancelRecording()
+        XCTAssertEqual(audioRecorder.stopCallCount, 1)
+
+        await startGate.release()
+        await recordingTask.value
+        await waitForMainActorWork()
+
+        let appendCount = await realtimeSession.appendCount
+        XCTAssertEqual(appendCount, 0)
+        XCTAssertFalse(controller.isRecording)
+        XCTAssertFalse(controller.isAudioRecorderStarted)
+        XCTAssertFalse(controller.isAudioRecorderStarting)
     }
 
     func testReleasingAfterImmediateAudioStartStopsRecorder() async {
@@ -2009,6 +2105,7 @@ private final class BufferEmittingAudioRecorder: AudioRecorder {
     private let buffer: AVAudioPCMBuffer
     private let lock = NSLock()
     private var starts = 0
+    private var stops = 0
 
     init(buffer: AVAudioPCMBuffer) {
         self.buffer = buffer
@@ -2018,6 +2115,12 @@ private final class BufferEmittingAudioRecorder: AudioRecorder {
         lock.lock()
         defer { lock.unlock() }
         return starts
+    }
+
+    var stopCallCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return stops
     }
 
     func start(
@@ -2031,7 +2134,10 @@ private final class BufferEmittingAudioRecorder: AudioRecorder {
     }
 
     func stop() throws -> AudioFile {
-        AudioFile(fileURL: URL(fileURLWithPath: "/tmp/mock.wav"), duration: 1)
+        lock.lock()
+        stops += 1
+        lock.unlock()
+        return AudioFile(fileURL: URL(fileURLWithPath: "/tmp/mock.wav"), duration: 1)
     }
 }
 
@@ -2088,11 +2194,18 @@ private final class DelayedRealtimeFactoryTranscriber: RealtimeTranscriptionSess
 }
 
 private actor PrefixCapturingRealtimeSession: RealtimeTranscriptionSession {
+    private let startGate: AsyncTestGate?
     private(set) var appendCount = 0
     private(set) var firstSample: Float = 0
     private var audioContinuation: CheckedContinuation<Void, Never>?
 
-    func start() async {}
+    init(startGate: AsyncTestGate? = nil) {
+        self.startGate = startGate
+    }
+
+    func start() async {
+        await startGate?.wait()
+    }
 
     func append(_ buffer: AVAudioPCMBuffer) async {
         appendCount += 1


### PR DESCRIPTION
## Summary

- start local audio capture before asynchronous realtime transcription setup
- buffer and replay startup PCM frames once the realtime session is ready
- publish physical capture state during setup so cancellation stops the microphone immediately
- guard both async setup boundaries so cancelled sessions never replay buffered audio or resurrect recorder state
- cover delayed Google session creation, delayed session start, prefix delivery, and cancellation

## Verification

- `swift test` (2,372 tests passed)
- `swift test --enable-code-coverage --filter WorkflowControllerProcessingTests` (75 tests passed; all newly added cancellation branches covered)
- `git diff --check`

`make format` could not run because `swiftformat` and `swiftlint` are not installed in this environment.

Stacked on #118 to coordinate the overlapping audio-startup changes.

Closes GUL-40
