### PR TITLE
GUL-42: fall back to local speech recognition when offline

### DIFF
--- a/Sources/Typeflux/Networking/ServerConnectivityFailure.swift
+++ b/Sources/Typeflux/Networking/ServerConnectivityFailure.swift
@@ -1,0 +1,79 @@
+import Darwin
+import Foundation
+
+enum ServerConnectivityFailure {
+    static func matches(_ error: Error) -> Bool {
+        matches(error, depth: 0)
+    }
+
+    private static func matches(_ error: Error, depth: Int) -> Bool {
+        guard depth < 8 else { return false }
+
+        if let executorError = error as? CloudRequestExecutorError,
+           case let .allEndpointsFailed(lastError) = executorError {
+            return matches(lastError, depth: depth + 1)
+        }
+
+        if let raceError = error as? CloudLocalTranscriptionRaceError {
+            return raceError.cloudError.map { matches($0, depth: depth + 1) } ?? false
+        }
+
+        if let integratedError = error as? TypefluxCloudIntegratedRewriteError {
+            return matches(integratedError.underlyingError, depth: depth + 1)
+        }
+
+        let nsError = error as NSError
+        if nsError.domain == NSURLErrorDomain,
+           connectivityURLCodes.contains(nsError.code) {
+            return true
+        }
+        if nsError.domain == NSPOSIXErrorDomain,
+           connectivityPOSIXCodes.contains(nsError.code) {
+            return true
+        }
+        if let underlyingError = nsError.userInfo[NSUnderlyingErrorKey] as? Error,
+           matches(underlyingError, depth: depth + 1) {
+            return true
+        }
+
+        let message = nsError.localizedDescription.lowercased()
+        return connectivityMessageFragments.contains { message.contains($0) }
+    }
+
+    private static let connectivityURLCodes: Set<Int> = [
+        URLError.timedOut.rawValue,
+        URLError.cannotFindHost.rawValue,
+        URLError.cannotConnectToHost.rawValue,
+        URLError.networkConnectionLost.rawValue,
+        URLError.dnsLookupFailed.rawValue,
+        URLError.notConnectedToInternet.rawValue,
+        URLError.internationalRoamingOff.rawValue,
+        URLError.callIsActive.rawValue,
+        URLError.dataNotAllowed.rawValue,
+        URLError.cannotLoadFromNetwork.rawValue,
+        URLError.secureConnectionFailed.rawValue
+    ]
+
+    private static let connectivityPOSIXCodes: Set<Int> = [
+        Int(ECONNREFUSED),
+        Int(ECONNRESET),
+        Int(ENETDOWN),
+        Int(ENETUNREACH),
+        Int(EHOSTDOWN),
+        Int(EHOSTUNREACH),
+        Int(ETIMEDOUT)
+    ]
+
+    private static let connectivityMessageFragments = [
+        "could not connect to the server",
+        "couldn't connect to the server",
+        "couldn’t connect to the server",
+        "cannot connect to the server",
+        "server is unreachable",
+        "network is unreachable",
+        "network connection was lost",
+        "socket is not connected",
+        "socket was not connected",
+        "not connected to the internet"
+    ]
+}

--- a/Sources/Typeflux/Overlay/OverlayController.swift
+++ b/Sources/Typeflux/Overlay/OverlayController.swift
@@ -257,6 +257,14 @@ final class OverlayController {
     private static let shadowGutter: CGFloat = 32
     private static let processingStatusLocalizationKey = "overlay.processing.thinking"
 
+    static func noticeIsInteractive(dismissible: Bool) -> Bool {
+        dismissible
+    }
+
+    var isShowingPassiveNotice: Bool {
+        model.presentation == .notice && !model.noticeDismissible
+    }
+
     struct PersonaPickerItem: Identifiable, Equatable {
         let id: String
         let title: String
@@ -735,6 +743,22 @@ final class OverlayController {
         }
         cancelPendingPresentationTransition()
         dismissWorkItem?.cancel()
+        model.noticeDismissible = true
+        model.presentation = .notice
+        model.statusText = L("overlay.notice.title")
+        model.detailText = message
+        refreshWindow()
+        dismiss(after: Self.autoDismissDelay)
+    }
+
+    func showPassiveNotice(message: String) {
+        if !Thread.isMainThread {
+            DispatchQueue.main.async { [weak self] in self?.showPassiveNotice(message: message) }
+            return
+        }
+        cancelPendingPresentationTransition()
+        dismissWorkItem?.cancel()
+        model.noticeDismissible = false
         model.presentation = .notice
         model.statusText = L("overlay.notice.title")
         model.detailText = message
@@ -1079,7 +1103,7 @@ final class OverlayController {
         case .notice:
             return OverlayMetrics(
                 size: NSSize(width: 344, height: 108), anchor: .bottom, offset: 80,
-                interactive: true
+                interactive: Self.noticeIsInteractive(dismissible: model.noticeDismissible)
             )
         case .failure:
             let actionHeight = model.failureActions.reduce(CGFloat(0)) { height, action in
@@ -1423,6 +1447,7 @@ final class OverlayViewModel: ObservableObject {
     @Published var pickerStyle: OverlayController.PickerStyle = .persona
     @Published var failureActions: [OverlayFailureAction] = []
     @Published var failureTone: OverlayFailureTone = .error
+    @Published var noticeDismissible = true
     @Published var overlayStyle: OverlayStyle = .liquidGlass
     var onDismissRequested: (() -> Void)?
     var onCancelRequested: (() -> Void)?
@@ -1796,7 +1821,7 @@ private struct OverlayView: View {
                     icon: "info.circle",
                     accent: StudioTheme.accent,
                     title: model.statusText,
-                    dismissible: true,
+                    dismissible: model.noticeDismissible,
                     titleSize: 13.5
                 )
 

--- a/Sources/Typeflux/Resources/en.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/en.lproj/Localizable.strings
@@ -366,6 +366,7 @@
 "workflow.recording.tooShort" = "Speech was too short. Transcription cancelled.";
 "workflow.transcription.emptySkipped" = "Skipped because transcription was empty.";
 "workflow.transcription.noSpeech" = "No clear speech detected. Transcription cancelled.";
+"workflow.transcription.serverUnavailableNotice" = "The server and local speech recognition are temporarily unavailable. Your recording was saved in History for retry.";
 "workflow.result.copyTitle" = "Copy Result";
 "workflow.ask.answerTitle" = "Ask Anything";
 "workflow.ask.questionSectionTitle" = "Your Question";

--- a/Sources/Typeflux/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/ja.lproj/Localizable.strings
@@ -362,6 +362,7 @@
 "workflow.recording.tooShort" = "スピーチが短すぎました。転写はキャンセルされました。";
 "workflow.transcription.emptySkipped" = "転写が空だったのでスキップされました。";
 "workflow.transcription.noSpeech" = "明瞭な音声が検出されませんでした。転写はキャンセルされました。";
+"workflow.transcription.serverUnavailableNotice" = "サーバーとローカル音声認識を一時的に利用できません。録音は履歴に保存され、後で再試行できます。";
 "workflow.result.copyTitle" = "コピー結果";
 "workflow.ask.answerTitle" = "何でも聞いてください";
 "workflow.ask.questionSectionTitle" = "あなたの質問";

--- a/Sources/Typeflux/Resources/ko.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/ko.lproj/Localizable.strings
@@ -362,6 +362,7 @@
 "workflow.recording.tooShort" = "말이 너무 짧았습니다. 스크립트 작성이 취소되었습니다.";
 "workflow.transcription.emptySkipped" = "텍스트 변환이 비어 있으므로 건너뛰었습니다.";
 "workflow.transcription.noSpeech" = "명확한 음성이 감지되지 않았습니다. 스크립트 작성이 취소되었습니다.";
+"workflow.transcription.serverUnavailableNotice" = "서버와 로컬 음성 인식을 일시적으로 사용할 수 없습니다. 녹음은 기록에 저장되어 나중에 다시 시도할 수 있습니다.";
 "workflow.result.copyTitle" = "결과 복사";
 "workflow.ask.answerTitle" = "무엇이든 물어보세요";
 "workflow.ask.questionSectionTitle" = "질문";

--- a/Sources/Typeflux/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/zh-Hans.lproj/Localizable.strings
@@ -366,6 +366,7 @@
 "workflow.recording.tooShort" = "说话时间太短，本次转写已取消。";
 "workflow.transcription.emptySkipped" = "由于转写结果为空，已跳过后续处理。";
 "workflow.transcription.noSpeech" = "未检测到清晰语音，本次转写已取消。";
+"workflow.transcription.serverUnavailableNotice" = "服务器和本地语音识别暂时不可用，录音已保存在历史记录中，可稍后重试。";
 "workflow.result.copyTitle" = "复制结果";
 "workflow.ask.answerTitle" = "随便问";
 "workflow.ask.questionSectionTitle" = "你的问题";

--- a/Sources/Typeflux/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/zh-Hant.lproj/Localizable.strings
@@ -364,6 +364,7 @@
 "workflow.recording.tooShort" = "說話時間太短，本次轉寫已取消。";
 "workflow.transcription.emptySkipped" = "因轉寫結果為空，已略過後續處理。";
 "workflow.transcription.noSpeech" = "未偵測到清晰語音，本次轉寫已取消。";
+"workflow.transcription.serverUnavailableNotice" = "伺服器和本地語音辨識暫時無法使用，錄音已儲存在歷史記錄中，可稍後重試。";
 "workflow.result.copyTitle" = "複製結果";
 "workflow.ask.answerTitle" = "隨便問";
 "workflow.ask.questionSectionTitle" = "你的問題";

--- a/Sources/Typeflux/STT/DefaultSenseVoiceFallbackTranscriber.swift
+++ b/Sources/Typeflux/STT/DefaultSenseVoiceFallbackTranscriber.swift
@@ -25,7 +25,10 @@ final class DefaultSenseVoiceFallbackTranscriber: Transcriber {
         settingsStore.localSTTModel = .senseVoiceSmall
         settingsStore.localSTTModelIdentifier = LocalSTTModel.senseVoiceSmall.defaultModelIdentifier
         settingsStore.localSTTDownloadSource = LocalSTTModel.senseVoiceSmall.recommendedDownloadSource
-        settingsStore.localSTTAutoSetup = true
+        // A connectivity fallback must never turn into a blocking network download.
+        // The full app links its bundled SenseVoice model during startup; lightweight
+        // installs fail fast here and keep the saved recording available for retry.
+        settingsStore.localSTTAutoSetup = false
 
         return try await LocalModelTranscriber(
             settingsStore: settingsStore,

--- a/Sources/Typeflux/STT/STTRouter+Fallbacks.swift
+++ b/Sources/Typeflux/STT/STTRouter+Fallbacks.swift
@@ -168,6 +168,28 @@ extension STTRouter {
         return try? await transcriber.transcribeStream(audioFile: audioFile, onUpdate: onUpdate)
     }
 
+    func transcribeWithConnectivityFallbackIfAvailable(
+        error: Error,
+        audioFile: AudioFile,
+        onUpdate: @escaping @Sendable (TranscriptionSnapshot) async -> Void
+    ) async -> String? {
+        guard ServerConnectivityFailure.matches(error),
+              let fallback = typefluxCloudLoginFallbackLocalModel
+        else {
+            return nil
+        }
+
+        do {
+            NetworkDebugLogger.logMessage(
+                "Server unavailable; falling back to the default local speech model"
+            )
+            return try await fallback.transcribeStream(audioFile: audioFile, onUpdate: onUpdate)
+        } catch {
+            NetworkDebugLogger.logError(context: "Default local connectivity fallback failed", error: error)
+            return nil
+        }
+    }
+
     func transcribeWithAppleSpeechFallbackIfEnabled(
         message: String,
         audioFile: AudioFile,

--- a/Sources/Typeflux/STT/STTRouter+Transcription.swift
+++ b/Sources/Typeflux/STT/STTRouter+Transcription.swift
@@ -33,9 +33,11 @@ extension STTRouter {
                 onUpdate: onUpdate
             )
         case .multimodalLLM:
-            try await RequestRetry.perform(operationName: "Multimodal STT request") { [self] in
-                try await multimodal.transcribeStream(audioFile: audioFile, onUpdate: onUpdate)
-            }
+            try await transcribeWithRemoteProvider(
+                route: remoteSTTRoute(for: .multimodalLLM),
+                audioFile: audioFile,
+                onUpdate: onUpdate
+            )
         case .groq:
             try await transcribeWithGroq(audioFile: audioFile, onUpdate: onUpdate)
         case .typefluxOfficial:
@@ -87,13 +89,26 @@ extension STTRouter {
         onUpdate: @escaping @Sendable (TranscriptionSnapshot) async -> Void
     ) async throws -> String {
         do {
-            return try await RequestRetry.perform(operationName: route.operationName) {
+            return try await RequestRetry.perform(
+                operationName: route.operationName,
+                shouldRetry: { !ServerConnectivityFailure.matches($0) }
+            ) {
                 try await route.provider.transcribeStream(audioFile: audioFile, onUpdate: onUpdate)
             }
         } catch {
             NetworkDebugLogger.logError(context: route.failureContext, error: error)
             if let localResult = await transcribeWithAutoModelIfReady(audioFile: audioFile, onUpdate: onUpdate) {
                 NetworkDebugLogger.logMessage(route.autoModelSuccessMessage)
+                return localResult
+            }
+            if let localResult = await transcribeWithConnectivityFallbackIfAvailable(
+                error: error,
+                audioFile: audioFile,
+                onUpdate: onUpdate
+            ) {
+                NetworkDebugLogger.logMessage(
+                    "Default local model succeeded after a server connectivity failure"
+                )
                 return localResult
             }
             if let appleResult = try await transcribeWithAppleSpeechFallbackIfEnabled(
@@ -218,6 +233,14 @@ extension STTRouter {
                 failureContext: "Soniox ASR failed",
                 autoModelSuccessMessage: "Auto local model succeeded after Soniox ASR failure",
                 appleFallbackMessage: "Falling back to Apple Speech after Soniox ASR failure"
+            )
+        case .multimodalLLM:
+            return RemoteSTTRoute(
+                provider: multimodal,
+                operationName: "Multimodal STT request",
+                failureContext: "Multimodal STT failed",
+                autoModelSuccessMessage: "Auto local model succeeded after multimodal STT failure",
+                appleFallbackMessage: "Falling back to Apple Speech after multimodal STT failure"
             )
         default:
             assertionFailure("Unexpected non-remote STT provider")

--- a/Sources/Typeflux/Workflow/WorkflowController+Processing.swift
+++ b/Sources/Typeflux/Workflow/WorkflowController+Processing.swift
@@ -1062,13 +1062,21 @@ extension WorkflowController {
             await MainActor.run {
                 if self.processingSessionID == sessionID {
                     self.lastRetryableFailureRecord = retryableFailureRecord
-                    self.soundEffectPlayer.play(.error)
-                    self.appState.setStatus(.failed(message: L("workflow.processing.failed")))
-                    if retryableFailureRecord == nil {
-                        self.overlayController.showFailure(message: msg)
-                        self.overlayController.dismiss(after: 3.0)
+                    if ServerConnectivityFailure.matches(error) {
+                        self.soundEffectPlayer.play(.tip)
+                        self.appState.setStatus(.idle)
+                        self.overlayController.showPassiveNotice(
+                            message: L("workflow.transcription.serverUnavailableNotice")
+                        )
                     } else {
-                        self.overlayController.showRetryableFailure(message: msg)
+                        self.soundEffectPlayer.play(.error)
+                        self.appState.setStatus(.failed(message: L("workflow.processing.failed")))
+                        if retryableFailureRecord == nil {
+                            self.overlayController.showFailure(message: msg)
+                            self.overlayController.dismiss(after: 3.0)
+                        } else {
+                            self.overlayController.showRetryableFailure(message: msg)
+                        }
                     }
                 }
             }

--- a/Tests/TypefluxTests/DefaultSenseVoiceFallbackTranscriberTests.swift
+++ b/Tests/TypefluxTests/DefaultSenseVoiceFallbackTranscriberTests.swift
@@ -1,0 +1,45 @@
+@testable import Typeflux
+import XCTest
+
+final class DefaultSenseVoiceFallbackTranscriberTests: XCTestCase {
+    func testMissingBundledModelFailsWithoutStartingDownload() async {
+        let modelManager = MissingFallbackModelManager()
+        let transcriber = DefaultSenseVoiceFallbackTranscriber(modelManager: modelManager)
+
+        do {
+            _ = try await transcriber.transcribe(
+                audioFile: AudioFile(fileURL: URL(fileURLWithPath: "/dev/null"), duration: 1)
+            )
+            XCTFail("Expected the bundled model to be unavailable")
+        } catch {
+            XCTAssertEqual((error as NSError).domain, LocalModelTranscriber.notPreparedErrorDomain)
+        }
+
+        XCTAssertEqual(modelManager.prepareCallCount, 0)
+    }
+}
+
+private final class MissingFallbackModelManager: LocalSTTModelManaging {
+    private(set) var prepareCallCount = 0
+
+    func prepareModel(
+        settingsStore _: SettingsStore,
+        onUpdate _: (@Sendable (LocalSTTPreparationUpdate) -> Void)?
+    ) async throws {
+        prepareCallCount += 1
+    }
+
+    func preparedModelInfo(settingsStore _: SettingsStore) -> LocalSTTPreparedModelInfo? {
+        nil
+    }
+
+    func isModelAvailable(_: LocalSTTModel) -> Bool {
+        false
+    }
+
+    func deleteModelFiles(_: LocalSTTModel) throws {}
+
+    func storagePath(for _: LocalSTTConfiguration) -> String {
+        ""
+    }
+}

--- a/Tests/TypefluxTests/OverlayControllerTests.swift
+++ b/Tests/TypefluxTests/OverlayControllerTests.swift
@@ -74,4 +74,9 @@ final class OverlayControllerTests: XCTestCase {
         XCTAssertEqual(wrapped[0].style, .text)
         XCTAssertEqual(wrapped[0].trailingSystemImage, "gearshape")
     }
+
+    func testPassiveNoticeDoesNotAcceptMouseInteraction() {
+        XCTAssertFalse(OverlayController.noticeIsInteractive(dismissible: false))
+        XCTAssertTrue(OverlayController.noticeIsInteractive(dismissible: true))
+    }
 }

--- a/Tests/TypefluxTests/STTRouterTests.swift
+++ b/Tests/TypefluxTests/STTRouterTests.swift
@@ -711,6 +711,42 @@ final class STTRouterTests: XCTestCase {
         }
     }
 
+    func testConnectivityFailureUsesBundledLocalFallbackWhenOptimizationIsDisabled() async throws {
+        settings.sttProvider = .whisperAPI
+        settings.localOptimizationEnabled = false
+        settings.useAppleSpeechFallback = false
+        whisper.errorToThrow = URLError(.cannotConnectToHost)
+        let bundledLocalFallback = MockTranscriber()
+        bundledLocalFallback.resultToReturn = "offline transcript"
+        let router = makeRouter(typefluxCloudLoginFallbackLocalModel: bundledLocalFallback)
+
+        let result = try await router.transcribe(audioFile: dummyAudioFile())
+
+        XCTAssertEqual(result, "offline transcript")
+        XCTAssertEqual(whisper.transcribeCallCount, 1)
+        XCTAssertEqual(bundledLocalFallback.transcribeCallCount, 1)
+        XCTAssertEqual(appleSpeech.transcribeCallCount, 0)
+    }
+
+    func testNonConnectivityFailureDoesNotUseBundledLocalFallback() async {
+        settings.sttProvider = .whisperAPI
+        settings.localOptimizationEnabled = false
+        settings.useAppleSpeechFallback = false
+        whisper.errorToThrow = NSError(domain: "RemoteSTT", code: 401)
+        let bundledLocalFallback = MockTranscriber()
+        bundledLocalFallback.resultToReturn = "must not be used"
+        let router = makeRouter(typefluxCloudLoginFallbackLocalModel: bundledLocalFallback)
+
+        do {
+            _ = try await router.transcribe(audioFile: dummyAudioFile())
+            XCTFail("Expected remote provider error")
+        } catch {
+            XCTAssertEqual((error as NSError).domain, "RemoteSTT")
+        }
+
+        XCTAssertEqual(bundledLocalFallback.transcribeCallCount, 0)
+    }
+
     // MARK: - WhisperAPI default OpenAI endpoint
 
     func testWhisperAPIWithEmptyBaseURLStillRoutesToWhisperTranscriber() async throws {

--- a/Tests/TypefluxTests/ServerConnectivityFailureTests.swift
+++ b/Tests/TypefluxTests/ServerConnectivityFailureTests.swift
@@ -1,0 +1,40 @@
+@testable import Typeflux
+import XCTest
+
+final class ServerConnectivityFailureTests: XCTestCase {
+    func testMatchesURLAndNestedCloudExecutorConnectivityFailures() {
+        XCTAssertTrue(ServerConnectivityFailure.matches(URLError(.notConnectedToInternet)))
+        XCTAssertTrue(ServerConnectivityFailure.matches(
+            CloudRequestExecutorError.allEndpointsFailed(
+                lastError: URLError(.cannotConnectToHost)
+            )
+        ))
+    }
+
+    func testMatchesUnderlyingAndUserFacingConnectionErrors() {
+        let wrapped = NSError(
+            domain: "Wrapper",
+            code: 1,
+            userInfo: [NSUnderlyingErrorKey: URLError(.networkConnectionLost)]
+        )
+        let userFacing = NSError(
+            domain: "WebSocket",
+            code: 1,
+            userInfo: [NSLocalizedDescriptionKey: "Could not connect to the server."]
+        )
+
+        XCTAssertTrue(ServerConnectivityFailure.matches(wrapped))
+        XCTAssertTrue(ServerConnectivityFailure.matches(userFacing))
+    }
+
+    func testRejectsCancellationAndApplicationErrors() {
+        XCTAssertFalse(ServerConnectivityFailure.matches(URLError(.cancelled)))
+        XCTAssertFalse(ServerConnectivityFailure.matches(
+            NSError(
+                domain: "RemoteSTT",
+                code: 401,
+                userInfo: [NSLocalizedDescriptionKey: "Unauthorized"]
+            )
+        ))
+    }
+}

--- a/Tests/TypefluxTests/WorkflowControllerProcessingTests.swift
+++ b/Tests/TypefluxTests/WorkflowControllerProcessingTests.swift
@@ -669,6 +669,38 @@ final class WorkflowControllerProcessingTests: XCTestCase {
         XCTAssertEqual(savedRecord?.pipelineTiming?.llmOutcome?.usedTranscriptFallback, true)
     }
 
+    func testConnectivityFailureKeepsRecordingRetryableAndShowsPassiveNotice() async {
+        let historyStore = MockProcessingHistoryStore()
+        let audioPath = "/tmp/connectivity-fallback.wav"
+        let controller = makeWorkflowController(
+            sttTranscriber: MockProcessingTranscriber(error: URLError(.cannotConnectToHost)),
+            historyStore: historyStore,
+            configureSettings: { $0.sttProvider = .whisperAPI }
+        )
+
+        await controller.process(
+            audioFile: AudioFile(fileURL: URL(fileURLWithPath: audioPath), duration: 1),
+            record: HistoryRecord(
+                date: Date(),
+                audioFilePath: audioPath,
+                recordingStatus: .succeeded,
+                transcriptionStatus: .running
+            ),
+            selectionSnapshot: TextSelectionSnapshot(),
+            selectedText: nil,
+            askContextText: nil,
+            inputContext: nil,
+            personaPrompt: nil,
+            recordingIntent: .dictation,
+            sessionID: controller.processingSessionID
+        )
+
+        XCTAssertEqual(controller.appState.status, .idle)
+        XCTAssertEqual(controller.lastRetryableFailureRecord?.audioFilePath, audioPath)
+        XCTAssertTrue(controller.overlayController.isShowingPassiveNotice)
+        XCTAssertEqual(historyStore.list().last?.transcriptionStatus, .failed)
+    }
+
     func testDecideAskSelectionThrowsConfigurationErrorWhenLLMIsNotConfigured() async {
         let controller = makeWorkflowController()
 


### PR DESCRIPTION
## Summary
- detect transport-level server connectivity failures and immediately fall back to the bundled SenseVoice model
- avoid retries and model downloads that would block voice input while offline
- replace the focus-stealing retry error with a passive, non-interactive notice when both server and local recognition are unavailable
- preserve the recording in History for retry and add localized copy plus regression coverage

## Validation
- `swift test` (2376 tests, 0 failures)
- targeted coverage tests (8 tests, 0 failures; 88.24% line coverage for new core files)
- `git diff --check`
- `make format` could not run because swiftformat/swiftlint are not installed in the environment

Closes GUL-42