### PR TITLE
GUL-44: add subscription self-sync action

### DIFF
--- a/Sources/Typeflux/Auth/AccountView.swift
+++ b/Sources/Typeflux/Auth/AccountView.swift
@@ -69,10 +69,33 @@ struct AccountView: View {
                             AccountRefreshIconButton(
                                 helpText: L("auth.account.refreshSubscription"),
                                 isVisible: isHoveringSubscriptionCard,
-                                isDisabled: authState.isLoadingSubscription || isOpeningBilling,
+                                isDisabled: authState.isLoadingSubscription
+                                    || authState.isSyncingSubscription
+                                    || isOpeningBilling,
                                 isLoading: authState.isLoadingSubscription
                             ) {
                                 Task { await authState.refreshSubscription() }
+                            }
+
+                            if subscriptionPresentation.showsSubscriptionSyncAction {
+                                Button(action: syncBillingSubscription) {
+                                    Group {
+                                        if authState.isSyncingSubscription {
+                                            ProgressView()
+                                                .controlSize(.small)
+                                        } else {
+                                            Text(L("auth.account.subscriptionSyncAction"))
+                                        }
+                                    }
+                                    .font(.studioBody(StudioTheme.Typography.caption))
+                                    .foregroundStyle(StudioTheme.textSecondary)
+                                }
+                                .buttonStyle(.plain)
+                                .disabled(
+                                    authState.isSyncingSubscription
+                                        || authState.isLoadingSubscription
+                                        || isOpeningBilling
+                                )
                             }
 
                             StudioButton(
@@ -81,7 +104,7 @@ struct AccountView: View {
                                     : L("auth.account.subscribe"),
                                 systemImage: "arrow.up.forward.app",
                                 variant: .primary,
-                                isDisabled: isOpeningBilling,
+                                isDisabled: isOpeningBilling || authState.isSyncingSubscription,
                                 isLoading: isOpeningBilling
                             ) {
                                 openBillingFlow()
@@ -494,6 +517,17 @@ struct AccountView: View {
                     isOpeningBilling = false
                     billingActionError = error.localizedDescription
                 }
+            }
+        }
+    }
+
+    private func syncBillingSubscription() {
+        billingActionError = nil
+        Task {
+            do {
+                _ = try await authState.syncSubscription()
+            } catch {
+                billingActionError = error.localizedDescription
             }
         }
     }

--- a/Sources/Typeflux/Auth/AuthState+Subscription.swift
+++ b/Sources/Typeflux/Auth/AuthState+Subscription.swift
@@ -20,17 +20,8 @@ extension AuthState {
         defer { isLoadingSubscription = false }
 
         do {
-            let wasEntitled = subscription.entitled
-            let hadPaidSubscription = subscription.hasPaidSubscription
             let snapshot = try await fetchSubscription(token)
-            subscription = snapshot
-            subscriptionError = nil
-            let becameEntitled = !wasEntitled && snapshot.entitled
-            let becamePaid = !hadPaidSubscription && snapshot.hasPaidSubscription
-            if pendingCheckoutSubscriptionEntitlement, becameEntitled || becamePaid {
-                pendingCheckoutSubscriptionEntitlement = false
-                NotificationCenter.default.post(name: .authCheckoutSubscriptionDidBecomeEntitled, object: self)
-            }
+            applySubscriptionSnapshot(snapshot)
             return snapshot
         } catch let error as AuthError {
             subscriptionError = error.localizedDescription
@@ -39,6 +30,21 @@ extension AuthState {
             subscriptionError = error.localizedDescription
             return nil
         }
+    }
+
+    @discardableResult
+    func syncSubscription() async throws -> BillingSubscriptionSnapshot {
+        guard let token = accessToken else {
+            throw AuthError.unauthorized
+        }
+        guard !isSyncingSubscription else { return subscription }
+
+        isSyncingSubscription = true
+        defer { isSyncingSubscription = false }
+
+        let snapshot = try await syncBillingSubscription(token)
+        applySubscriptionSnapshot(snapshot)
+        return snapshot
     }
 
     @discardableResult
@@ -120,6 +126,19 @@ extension AuthState {
                 }
             }
             pendingCheckoutSubscriptionEntitlement = false
+        }
+    }
+
+    private func applySubscriptionSnapshot(_ snapshot: BillingSubscriptionSnapshot) {
+        let wasEntitled = subscription.entitled
+        let hadPaidSubscription = subscription.hasPaidSubscription
+        subscription = snapshot
+        subscriptionError = nil
+        let becameEntitled = !wasEntitled && snapshot.entitled
+        let becamePaid = !hadPaidSubscription && snapshot.hasPaidSubscription
+        if pendingCheckoutSubscriptionEntitlement, becameEntitled || becamePaid {
+            pendingCheckoutSubscriptionEntitlement = false
+            NotificationCenter.default.post(name: .authCheckoutSubscriptionDidBecomeEntitled, object: self)
         }
     }
 }

--- a/Sources/Typeflux/Auth/AuthState.swift
+++ b/Sources/Typeflux/Auth/AuthState.swift
@@ -48,6 +48,7 @@ final class AuthState: ObservableObject {
     let fetchProfile: (String) async throws -> UserProfile
     let refreshAccessToken: (String) async throws -> LoginResponse
     let fetchSubscription: (String) async throws -> BillingSubscriptionSnapshot
+    let syncBillingSubscription: (String) async throws -> BillingSubscriptionSnapshot
     let fetchCurrentPeriodUsageStats: (String) async throws -> CloudUsageCurrentPeriodStats
     let createCheckoutSession: (String, String) async throws -> BillingCheckoutSession
     let createPortalSession: (String) async throws -> BillingPortalSession
@@ -58,6 +59,7 @@ final class AuthState: ObservableObject {
     @Published var isLoading: Bool = false
     @Published var subscription: BillingSubscriptionSnapshot = .none
     @Published var isLoadingSubscription: Bool = false
+    @Published var isSyncingSubscription: Bool = false
     @Published var subscriptionError: String?
     @Published var usageStats: CloudUsageStats = .empty
     @Published var usageCredits: CloudCreditSummary?
@@ -123,6 +125,9 @@ final class AuthState: ObservableObject {
         fetchSubscription: @escaping (String) async throws -> BillingSubscriptionSnapshot = { token in
             try await BillingAPIService.fetchSubscription(token: token)
         },
+        syncSubscription: @escaping (String) async throws -> BillingSubscriptionSnapshot = { token in
+            try await BillingAPIService.syncSubscription(token: token)
+        },
         fetchCurrentPeriodUsageStats: @escaping (String) async throws -> CloudUsageCurrentPeriodStats = { token in
             try await CloudUsageAPIService.fetchCurrentPeriodStats(token: token)
         },
@@ -152,6 +157,7 @@ final class AuthState: ObservableObject {
         self.fetchProfile = fetchProfile
         self.refreshAccessToken = refreshAccessToken
         self.fetchSubscription = fetchSubscription
+        syncBillingSubscription = syncSubscription
         self.fetchCurrentPeriodUsageStats = fetchCurrentPeriodUsageStats
         self.createCheckoutSession = createCheckoutSession
         self.createPortalSession = createPortalSession
@@ -191,6 +197,7 @@ final class AuthState: ObservableObject {
         userProfile = nil
         subscription = .none
         subscriptionError = nil
+        isSyncingSubscription = false
         usageStats = .empty
         usageCredits = nil
         usagePeriodStart = nil

--- a/Sources/Typeflux/Auth/BillingAPIService.swift
+++ b/Sources/Typeflux/Auth/BillingAPIService.swift
@@ -1,6 +1,19 @@
 import Foundation
 import os
 
+enum BillingSubscriptionSyncError: LocalizedError, Equatable {
+    case rateLimited(retryAfterSeconds: Int?)
+
+    var errorDescription: String? {
+        switch self {
+        case let .rateLimited(.some(seconds)):
+            String(format: L("auth.account.subscriptionSyncRateLimitedWait"), String(seconds))
+        case .rateLimited(.none):
+            L("auth.account.subscriptionSyncRateLimited")
+        }
+    }
+}
+
 struct BillingAPIService: Sendable {
     private static let logger = Logger(subsystem: "ai.gulu.app.typeflux", category: "BillingAPIService")
 
@@ -27,6 +40,16 @@ struct BillingAPIService: Sendable {
         }
     }
 
+    func syncSubscription(token: String) async throws -> BillingSubscriptionSnapshot {
+        try await execute(
+            path: "/api/v1/billing/subscription/sync",
+            method: "POST",
+            token: token,
+            body: Data("{}".utf8),
+            handlesRateLimit: true
+        )
+    }
+
     func createCheckoutSession(token: String, planCode: String) async throws -> BillingCheckoutSession {
         let body = try encode(BillingCheckoutSessionRequest(planCode: planCode))
         return try await execute(path: "/api/v1/billing/checkout-session", method: "POST", token: token, body: body)
@@ -42,6 +65,10 @@ struct BillingAPIService: Sendable {
 
     static func fetchSubscription(token: String) async throws -> BillingSubscriptionSnapshot {
         try await BillingAPIService().fetchSubscription(token: token)
+    }
+
+    static func syncSubscription(token: String) async throws -> BillingSubscriptionSnapshot {
+        try await BillingAPIService().syncSubscription(token: token)
     }
 
     static func createCheckoutSession(token: String, planCode: String) async throws -> BillingCheckoutSession {
@@ -68,7 +95,8 @@ struct BillingAPIService: Sendable {
         path: String,
         method: String,
         token: String,
-        body: Data?
+        body: Data?,
+        handlesRateLimit: Bool = false
     ) async throws -> Response {
         let data: Data
         let httpResponse: HTTPURLResponse
@@ -91,6 +119,12 @@ struct BillingAPIService: Sendable {
         } catch {
             Self.logger.error("Billing network error: \(error.localizedDescription)")
             throw Self.availabilityError(for: error)
+        }
+
+        if handlesRateLimit, httpResponse.statusCode == 429 {
+            throw BillingSubscriptionSyncError.rateLimited(
+                retryAfterSeconds: Self.retryAfterSeconds(from: httpResponse)
+            )
         }
 
         let envelope: APIResponse<Response>
@@ -127,5 +161,24 @@ struct BillingAPIService: Sendable {
         guard let authError = error as? AuthError else { return false }
         return authError.authErrorCode == "BILLING_CONNECTION_UNAVAILABLE"
             || authError.authErrorCode == "BILLING_SERVICE_UNAVAILABLE"
+    }
+
+    static func retryAfterSeconds(from response: HTTPURLResponse, now: Date = Date()) -> Int? {
+        guard let value = response.value(forHTTPHeaderField: "Retry-After")?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+            !value.isEmpty
+        else {
+            return nil
+        }
+        if let seconds = Int(value) {
+            return max(0, seconds)
+        }
+
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        formatter.dateFormat = "EEE',' dd MMM yyyy HH':'mm':'ss z"
+        guard let retryDate = formatter.date(from: value) else { return nil }
+        return max(0, Int(ceil(retryDate.timeIntervalSince(now))))
     }
 }

--- a/Sources/Typeflux/Auth/BillingModels.swift
+++ b/Sources/Typeflux/Auth/BillingModels.swift
@@ -231,6 +231,7 @@ struct AccountSubscriptionPresentation: Equatable {
     let periodLabelKey: String
     let period: PeriodValue
     let billingAction: BillingAction
+    let showsSubscriptionSyncAction: Bool
 
     static func make(from snapshot: BillingSubscriptionSnapshot) -> AccountSubscriptionPresentation {
         AccountSubscriptionPresentation(
@@ -239,7 +240,8 @@ struct AccountSubscriptionPresentation: Equatable {
             status: statusValue(for: snapshot),
             periodLabelKey: periodLabelKey(for: snapshot),
             period: periodValue(for: snapshot),
-            billingAction: snapshot.hasPaidSubscription ? .manageBilling : .subscribe
+            billingAction: snapshot.hasPaidSubscription ? .manageBilling : .subscribe,
+            showsSubscriptionSyncAction: snapshot.billingEnabled && !snapshot.hasPaidSubscription
         )
     }
 

--- a/Sources/Typeflux/Resources/en.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/en.lproj/Localizable.strings
@@ -1245,6 +1245,9 @@
 "auth.account.subscriptionPeriodRange" = "%@ to %@";
 "auth.account.subscriptionPeriodUntil" = "Until %@";
 "auth.account.refreshSubscription" = "Refresh";
+"auth.account.subscriptionSyncAction" = "Paid but not active?";
+"auth.account.subscriptionSyncRateLimited" = "Too many attempts. Please wait a moment and try again.";
+"auth.account.subscriptionSyncRateLimitedWait" = "Too many attempts. Please try again in %@ seconds.";
 "auth.account.subscribe" = "Subscribe";
 "auth.account.manageBilling" = "Manage Billing";
 "auth.account.usage" = "Usage Details";

--- a/Sources/Typeflux/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/ja.lproj/Localizable.strings
@@ -1230,6 +1230,9 @@
 "auth.account.subscriptionPeriodRange" = "%@ から %@";
 "auth.account.subscriptionPeriodUntil" = "%@ まで";
 "auth.account.refreshSubscription" = "更新";
+"auth.account.subscriptionSyncAction" = "支払い済みなのに未反映ですか？";
+"auth.account.subscriptionSyncRateLimited" = "操作が多すぎます。しばらく待ってからもう一度お試しください。";
+"auth.account.subscriptionSyncRateLimitedWait" = "操作が多すぎます。%@ 秒後にもう一度お試しください。";
 "auth.account.subscribe" = "購読";
 "auth.account.manageBilling" = "請求管理";
 "auth.account.usage" = "使用明細";

--- a/Sources/Typeflux/Resources/ko.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/ko.lproj/Localizable.strings
@@ -1230,6 +1230,9 @@
 "auth.account.subscriptionPeriodRange" = "%@ ~ %@";
 "auth.account.subscriptionPeriodUntil" = "%@까지";
 "auth.account.refreshSubscription" = "새로고침";
+"auth.account.subscriptionSyncAction" = "결제했지만 반영되지 않았나요?";
+"auth.account.subscriptionSyncRateLimited" = "요청이 너무 잦습니다. 잠시 후 다시 시도해 주세요.";
+"auth.account.subscriptionSyncRateLimitedWait" = "요청이 너무 잦습니다. %@초 후 다시 시도해 주세요.";
 "auth.account.subscribe" = "구독";
 "auth.account.manageBilling" = "결제 관리";
 "auth.account.usage" = "사용 상세";

--- a/Sources/Typeflux/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/zh-Hans.lproj/Localizable.strings
@@ -1245,6 +1245,9 @@
 "auth.account.subscriptionPeriodRange" = "%@ 至 %@";
 "auth.account.subscriptionPeriodUntil" = "至 %@";
 "auth.account.refreshSubscription" = "刷新";
+"auth.account.subscriptionSyncAction" = "已支付但未生效？";
+"auth.account.subscriptionSyncRateLimited" = "操作太频繁，请稍后再试。";
+"auth.account.subscriptionSyncRateLimitedWait" = "操作太频繁，请在 %@ 秒后再试。";
 "auth.account.subscribe" = "订阅";
 "auth.account.manageBilling" = "管理账单";
 "auth.account.usage" = "使用明细";

--- a/Sources/Typeflux/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/zh-Hant.lproj/Localizable.strings
@@ -1241,6 +1241,9 @@
 "auth.account.subscriptionPeriodRange" = "%@ 至 %@";
 "auth.account.subscriptionPeriodUntil" = "至 %@";
 "auth.account.refreshSubscription" = "重新整理";
+"auth.account.subscriptionSyncAction" = "已付款但尚未生效？";
+"auth.account.subscriptionSyncRateLimited" = "操作過於頻繁，請稍後再試。";
+"auth.account.subscriptionSyncRateLimitedWait" = "操作過於頻繁，請在 %@ 秒後再試。";
 "auth.account.subscribe" = "訂閱";
 "auth.account.manageBilling" = "管理帳單";
 "auth.account.usage" = "使用明細";

--- a/Tests/TypefluxTests/AccountSubscriptionPresentationTests.swift
+++ b/Tests/TypefluxTests/AccountSubscriptionPresentationTests.swift
@@ -11,6 +11,7 @@ final class AccountSubscriptionPresentationTests: XCTestCase {
         XCTAssertEqual(presentation.status, .localized("auth.account.subscriptionStatusNone"))
         XCTAssertEqual(presentation.periodLabelKey, "auth.account.subscriptionPeriod")
         XCTAssertEqual(presentation.period, .unavailable)
+        XCTAssertFalse(presentation.showsSubscriptionSyncAction)
     }
 
     func testActiveDefaultPlanSelectsManageBillingAndRenewalPeriod() {
@@ -31,6 +32,41 @@ final class AccountSubscriptionPresentationTests: XCTestCase {
         XCTAssertEqual(presentation.status, .localized("auth.account.subscriptionStatusActive"))
         XCTAssertEqual(presentation.periodLabelKey, "auth.account.subscriptionPeriod")
         XCTAssertEqual(presentation.period, .renewsOn("2026-06-01T00:00:00Z"))
+        XCTAssertFalse(presentation.showsSubscriptionSyncAction)
+    }
+
+    func testBillingEnabledFreePlanShowsSubscriptionSyncAction() {
+        let snapshot = BillingSubscriptionSnapshot(
+            planCode: "free",
+            status: "free",
+            currentPeriodStart: nil,
+            currentPeriodEnd: nil,
+            cancelAtPeriodEnd: false,
+            entitled: true,
+            active: true,
+            paid: false,
+            periodSource: "free",
+            billingEnabled: true
+        )
+
+        XCTAssertTrue(AccountSubscriptionPresentation.make(from: snapshot).showsSubscriptionSyncAction)
+    }
+
+    func testBillingDisabledUnpaidPlanHidesSubscriptionSyncAction() {
+        let snapshot = BillingSubscriptionSnapshot(
+            planCode: "free",
+            status: "free",
+            currentPeriodStart: nil,
+            currentPeriodEnd: nil,
+            cancelAtPeriodEnd: false,
+            entitled: true,
+            active: true,
+            paid: false,
+            periodSource: "free",
+            billingEnabled: false
+        )
+
+        XCTAssertFalse(AccountSubscriptionPresentation.make(from: snapshot).showsSubscriptionSyncAction)
     }
 
     func testFreePlanIsActiveButSelectsSubscribeAction() {

--- a/Tests/TypefluxTests/AuthStateTests.swift
+++ b/Tests/TypefluxTests/AuthStateTests.swift
@@ -238,6 +238,154 @@ final class AuthStateTests: XCTestCase {
         XCTAssertNotNil(state.subscriptionError)
     }
 
+    func testSyncSubscriptionUsesAccessTokenAndAppliesReturnedSnapshot() async throws {
+        let storedToken = validStoredToken()
+        var requestedToken: String?
+        let paidSubscription = BillingSubscriptionSnapshot(
+            planCode: "pro",
+            status: "active",
+            currentPeriodStart: nil,
+            currentPeriodEnd: "2999-06-01T00:00:00Z",
+            cancelAtPeriodEnd: false,
+            entitled: true,
+            active: true,
+            paid: true,
+            billingEnabled: true
+        )
+        let state = AuthState(
+            loadStoredToken: { storedToken },
+            loadStoredUserProfile: { nil },
+            saveStoredToken: { _, _ in },
+            saveStoredUserProfile: { _ in },
+            clearStoredSession: {},
+            fetchProfile: { _ in self.makeProfile(email: "subscription-sync@test.com") },
+            fetchSubscription: { _ in .none },
+            syncSubscription: { token in
+                requestedToken = token
+                return paidSubscription
+            }
+        )
+        state.subscriptionError = "stale error"
+
+        let result = try await state.syncSubscription()
+
+        XCTAssertEqual(requestedToken, "valid-token")
+        XCTAssertEqual(result, paidSubscription)
+        XCTAssertEqual(state.subscription, paidSubscription)
+        XCTAssertNil(state.subscriptionError)
+        XCTAssertFalse(state.isSyncingSubscription)
+    }
+
+    func testSyncSubscriptionFailurePreservesStateAndResetsLoading() async {
+        let storedToken = validStoredToken()
+        let freeSubscription = BillingSubscriptionSnapshot(
+            planCode: "free",
+            status: "free",
+            currentPeriodStart: nil,
+            currentPeriodEnd: nil,
+            cancelAtPeriodEnd: false,
+            entitled: true,
+            active: true,
+            paid: false,
+            periodSource: "free",
+            billingEnabled: true
+        )
+        let state = AuthState(
+            loadStoredToken: { storedToken },
+            loadStoredUserProfile: { nil },
+            saveStoredToken: { _, _ in },
+            saveStoredUserProfile: { _ in },
+            clearStoredSession: {},
+            fetchProfile: { _ in self.makeProfile(email: "subscription-sync-error@test.com") },
+            fetchSubscription: { _ in .none },
+            syncSubscription: { _ in
+                throw BillingSubscriptionSyncError.rateLimited(retryAfterSeconds: 42)
+            }
+        )
+        state.subscription = freeSubscription
+
+        do {
+            _ = try await state.syncSubscription()
+            XCTFail("Expected rate limit error")
+        } catch let error as BillingSubscriptionSyncError {
+            XCTAssertEqual(error, .rateLimited(retryAfterSeconds: 42))
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+
+        XCTAssertEqual(state.subscription, freeSubscription)
+        XCTAssertFalse(state.isSyncingSubscription)
+    }
+
+    func testSyncSubscriptionLoadingStatePreventsDuplicateRequests() async throws {
+        let storedToken = validStoredToken()
+        let started = expectation(description: "subscription sync started")
+        let gate = SubscriptionSyncGate()
+        var requestCount = 0
+        let paidSubscription = BillingSubscriptionSnapshot(
+            planCode: "pro",
+            status: "active",
+            currentPeriodStart: nil,
+            currentPeriodEnd: "2999-06-01T00:00:00Z",
+            cancelAtPeriodEnd: false,
+            entitled: true,
+            active: true,
+            paid: true,
+            billingEnabled: true
+        )
+        let state = AuthState(
+            loadStoredToken: { storedToken },
+            loadStoredUserProfile: { nil },
+            saveStoredToken: { _, _ in },
+            saveStoredUserProfile: { _ in },
+            clearStoredSession: {},
+            fetchProfile: { _ in self.makeProfile(email: "subscription-sync-loading@test.com") },
+            fetchSubscription: { _ in .none },
+            syncSubscription: { _ in
+                requestCount += 1
+                started.fulfill()
+                await gate.wait()
+                return paidSubscription
+            }
+        )
+
+        let firstRequest = Task { try await state.syncSubscription() }
+        await fulfillment(of: [started], timeout: 1)
+
+        XCTAssertTrue(state.isSyncingSubscription)
+        let duplicateResult = try await state.syncSubscription()
+        XCTAssertEqual(duplicateResult, state.subscription)
+        XCTAssertEqual(requestCount, 1)
+
+        await gate.release()
+        let result = try await firstRequest.value
+        XCTAssertEqual(result, paidSubscription)
+        XCTAssertFalse(state.isSyncingSubscription)
+    }
+
+    func testSyncSubscriptionRequiresAuthenticatedSession() async {
+        let state = AuthState(
+            loadStoredToken: { nil },
+            loadStoredUserProfile: { nil },
+            saveStoredToken: { _, _ in },
+            saveStoredUserProfile: { _ in },
+            clearStoredSession: {},
+            fetchProfile: { _ in self.makeProfile(email: "subscription-sync-auth@test.com") },
+            syncSubscription: { _ in
+                XCTFail("Sync API should not be called without a session")
+                return .none
+            }
+        )
+
+        do {
+            _ = try await state.syncSubscription()
+            XCTFail("Expected unauthorized error")
+        } catch AuthError.unauthorized {
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
     func testLoginSuccessUsesInMemoryTokenWhenPersistenceDoesNotImmediatelyLoad() async {
         var savedProfile: UserProfile?
         var fetchedProfileToken: String?
@@ -734,5 +882,20 @@ final class AuthStateTests: XCTestCase {
         for _ in 0 ..< 100 where count() == 0 {
             await Task.yield()
         }
+    }
+}
+
+private actor SubscriptionSyncGate {
+    private var continuation: CheckedContinuation<Void, Never>?
+
+    func wait() async {
+        await withCheckedContinuation { continuation in
+            self.continuation = continuation
+        }
+    }
+
+    func release() {
+        continuation?.resume()
+        continuation = nil
     }
 }

--- a/Tests/TypefluxTests/BillingAPIServiceTests.swift
+++ b/Tests/TypefluxTests/BillingAPIServiceTests.swift
@@ -120,6 +120,117 @@ final class BillingAPIServiceTests: XCTestCase {
         XCTAssertFalse(snapshot.hasPaidSubscription)
         XCTAssertTrue(snapshot.isFreePlan)
     }
+}
+
+extension BillingAPIServiceTests {
+    func testSyncSubscriptionPostsAuthenticatedEmptyJSONAndUpdatesSnapshot() async throws {
+        let session = BillingStubSession()
+        await session.setHandler { request in
+            XCTAssertEqual(request.url?.absoluteString, "https://api.example/api/v1/billing/subscription/sync")
+            XCTAssertEqual(request.httpMethod, "POST")
+            XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer token-1")
+            XCTAssertEqual(request.httpBody, Data("{}".utf8))
+            let body = """
+            {
+              "code": "OK",
+              "data": {
+                "billing_enabled": true,
+                "plan_code": "pro",
+                "status": "active",
+                "active": true,
+                "paid": true,
+                "entitled": true
+              }
+            }
+            """
+            return (Data(body.utf8), Self.httpResponse(url: request.url!, status: 200))
+        }
+        let service = makeService(session: session)
+
+        let snapshot = try await service.syncSubscription(token: "token-1")
+
+        XCTAssertEqual(snapshot.planCode, "pro")
+        XCTAssertTrue(snapshot.hasPaidSubscription)
+    }
+
+    func testSyncSubscriptionSurfacesRateLimitWithRetryAfterSeconds() async {
+        let session = BillingStubSession()
+        await session.setHandler { request in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 429,
+                httpVersion: nil,
+                headerFields: ["Retry-After": "37"]
+            )!
+            return (Data("not required for rate limits".utf8), response)
+        }
+        let service = makeService(session: session)
+
+        do {
+            _ = try await service.syncSubscription(token: "token-1")
+            XCTFail("Expected rate limit error")
+        } catch let error as BillingSubscriptionSyncError {
+            XCTAssertEqual(error, .rateLimited(retryAfterSeconds: 37))
+            XCTAssertTrue(error.localizedDescription.contains("37"))
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func testSyncSubscriptionUsesGenericRateLimitMessageWithoutRetryAfter() async {
+        let session = BillingStubSession()
+        await session.setHandler { request in
+            (Data(), Self.httpResponse(url: request.url!, status: 429))
+        }
+        let service = makeService(session: session)
+
+        do {
+            _ = try await service.syncSubscription(token: "token-1")
+            XCTFail("Expected rate limit error")
+        } catch let error as BillingSubscriptionSyncError {
+            XCTAssertEqual(error, .rateLimited(retryAfterSeconds: nil))
+            XCTAssertFalse(error.localizedDescription.isEmpty)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func testRetryAfterParsesHTTPDateAndClampsExpiredValues() {
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let futureResponse = HTTPURLResponse(
+            url: baseURL,
+            statusCode: 429,
+            httpVersion: nil,
+            headerFields: ["Retry-After": "Fri, 15 Jan 2027 08:01:00 GMT"]
+        )!
+        let expiredResponse = HTTPURLResponse(
+            url: baseURL,
+            statusCode: 429,
+            httpVersion: nil,
+            headerFields: ["Retry-After": "Fri, 15 Jan 2021 08:00:00 GMT"]
+        )!
+
+        XCTAssertEqual(BillingAPIService.retryAfterSeconds(from: futureResponse, now: now), 60)
+        XCTAssertEqual(BillingAPIService.retryAfterSeconds(from: expiredResponse, now: now), 0)
+    }
+
+    func testSyncSubscriptionPreservesStandardServerErrors() async {
+        let session = BillingStubSession()
+        await session.setHandler { request in
+            let body = #"{"code":"BILLING_NOT_CONFIGURED","message":"billing unavailable"}"#
+            return (Data(body.utf8), Self.httpResponse(url: request.url!, status: 400))
+        }
+        let service = makeService(session: session)
+
+        do {
+            _ = try await service.syncSubscription(token: "token-1")
+            XCTFail("Expected server error")
+        } catch let error as AuthError {
+            XCTAssertEqual(error.authErrorCode, "BILLING_NOT_CONFIGURED")
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
 
     func testCreateCheckoutSessionPostsPlanCodeAndDecodesURL() async throws {
         let session = BillingStubSession()


### PR DESCRIPTION
## Summary

- add a localized self-service subscription sync action for free accounts when billing is enabled
- refresh account subscription state immediately and prevent duplicate billing actions while syncing
- surface friendly `429 Retry-After` guidance and preserve existing billing error handling
- cover visibility, request/response handling, state updates, duplicate prevention, and error cases

## Tests

- `swift test --enable-code-coverage` (2,379 tests passed)
- `swift test --filter BillingAPIServiceTests` (16 tests passed)
- `git diff --check`
- `plutil -lint` for all updated localization files

Closes GUL-44
