### PR TITLE
GUL-57: Add opt-in cloud data sync

### DIFF
--- a/Sources/Typeflux/App/DIContainer.swift
+++ b/Sources/Typeflux/App/DIContainer.swift
@@ -31,6 +31,7 @@ final class DIContainer {
     let agentJobsWindowController: AgentJobsWindowController
     let mcpRegistry: MCPRegistry
     let cloudLoginSyncCoordinator: CloudLoginSyncCoordinator
+    let cloudDataSyncCoordinator: CloudDataSyncCoordinator
     let outputPostProcessor: OutputPostProcessing
 
     // swiftlint:disable:next function_body_length
@@ -71,6 +72,7 @@ final class DIContainer {
         )
         notificationService = SystemLocalNotificationService.shared
         cloudLoginSyncCoordinator = CloudLoginSyncCoordinator(settingsStore: settingsStore)
+        cloudDataSyncCoordinator = CloudDataSyncCoordinator.shared
         localModelManager = LocalModelManager(analyticsReporter: analyticsReporter)
         bundledModelAutoSetup = BundledModelAutoSetup(linker: localModelManager)
         autoModelDownloadService = AutoModelDownloadService(

--- a/Sources/Typeflux/Auth/AccountView.swift
+++ b/Sources/Typeflux/Auth/AccountView.swift
@@ -10,11 +10,14 @@ struct AccountView: View {
     @State private var billingActionError: String?
     @State private var isHoveringSubscriptionCard = false
     @State private var isHoveringUsageCard = false
+    @ObservedObject private var cloudDataSync = CloudDataSyncCoordinator.shared
+    @State private var isConfirmingCloudSync = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: StudioTheme.Spacing.pageGroup) {
             if let profile = authState.userProfile {
                 profileCard(profile: profile)
+                cloudDataSyncCard
                 if authState.subscription.shouldShowSubscriptionDetails || authState.subscriptionError != nil {
                     subscriptionCard
                 }
@@ -52,6 +55,59 @@ struct AccountView: View {
                 }
             }
         }
+        .alert(L("cloudDataSync.consent.title"), isPresented: $isConfirmingCloudSync) {
+            Button(L("common.cancel"), role: .cancel) {}
+            Button(L("cloudDataSync.consent.confirm")) { cloudDataSync.setEnabled(true) }
+        } message: {
+            Text(L("cloudDataSync.consent.message"))
+        }
+    }
+
+    private var cloudDataSyncCard: some View {
+        StudioCard {
+            VStack(alignment: .leading, spacing: StudioTheme.Spacing.medium) {
+                StudioSettingRow(
+                    title: L("cloudDataSync.title"),
+                    subtitle: L("cloudDataSync.subtitle")
+                ) {
+                    Toggle("", isOn: Binding(
+                        get: { cloudDataSync.isEnabled },
+                        set: { enabled in
+                            if enabled { isConfirmingCloudSync = true }
+                            else { cloudDataSync.setEnabled(false) }
+                        }
+                    ))
+                    .labelsHidden()
+                    .toggleStyle(.switch)
+                }
+
+                if cloudDataSync.isEnabled {
+                    Divider().overlay(StudioTheme.border.opacity(StudioTheme.Opacity.divider))
+                    HStack {
+                        Text(cloudDataSyncStatus)
+                            .font(.studioBody(StudioTheme.Typography.caption))
+                            .foregroundStyle(
+                                cloudDataSync.lastError == nil ? StudioTheme.textSecondary : StudioTheme.danger
+                            )
+                        Spacer()
+                        StudioButton(
+                            title: L("cloudDataSync.syncNow"), systemImage: "arrow.triangle.2.circlepath",
+                            variant: .secondary, isDisabled: cloudDataSync.isSyncing,
+                            isLoading: cloudDataSync.isSyncing
+                        ) { cloudDataSync.synchronizeNow() }
+                    }
+                }
+            }
+        }
+    }
+
+    private var cloudDataSyncStatus: String {
+        if cloudDataSync.isSyncing { return L("cloudDataSync.status.syncing") }
+        if let error = cloudDataSync.lastError { return L("cloudDataSync.status.failed", error) }
+        if let date = cloudDataSync.lastSyncAt {
+            return L("cloudDataSync.status.lastSync", date.formatted(date: .omitted, time: .shortened))
+        }
+        return L("cloudDataSync.status.waiting")
     }
 
     private var subscriptionCard: some View {

--- a/Sources/Typeflux/Auth/AccountView.swift
+++ b/Sources/Typeflux/Auth/AccountView.swift
@@ -57,7 +57,12 @@ struct AccountView: View {
         }
         .alert(L("cloudDataSync.consent.title"), isPresented: $isConfirmingCloudSync) {
             Button(L("common.cancel"), role: .cancel) {}
-            Button(L("cloudDataSync.consent.confirm")) { cloudDataSync.setEnabled(true) }
+            Button(L("cloudDataSync.consent.merge")) {
+                cloudDataSync.setEnabled(true, mergeGuestData: true)
+            }
+            Button(L("cloudDataSync.consent.cloudOnly")) {
+                cloudDataSync.setEnabled(true, mergeGuestData: false)
+            }
         } message: {
             Text(L("cloudDataSync.consent.message"))
         }
@@ -73,8 +78,13 @@ struct AccountView: View {
                     Toggle("", isOn: Binding(
                         get: { cloudDataSync.isEnabled },
                         set: { enabled in
-                            if enabled { isConfirmingCloudSync = true }
-                            else { cloudDataSync.setEnabled(false) }
+                            if enabled && cloudDataSync.requiresInitialChoice {
+                                isConfirmingCloudSync = true
+                            } else if enabled {
+                                cloudDataSync.setEnabled(true)
+                            } else {
+                                cloudDataSync.setEnabled(false)
+                            }
                         }
                     ))
                     .labelsHidden()

--- a/Sources/Typeflux/Auth/AccountView.swift
+++ b/Sources/Typeflux/Auth/AccountView.swift
@@ -12,6 +12,7 @@ struct AccountView: View {
     @State private var isHoveringUsageCard = false
     @ObservedObject private var cloudDataSync = CloudDataSyncCoordinator.shared
     @State private var isConfirmingCloudSync = false
+    @State private var isConfirmingCloudDataDeletion = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: StudioTheme.Spacing.pageGroup) {
@@ -66,6 +67,14 @@ struct AccountView: View {
         } message: {
             Text(L("cloudDataSync.consent.message"))
         }
+        .alert(L("cloudDataSync.delete.title"), isPresented: $isConfirmingCloudDataDeletion) {
+            Button(L("common.cancel"), role: .cancel) {}
+            Button(L("cloudDataSync.delete.confirm"), role: .destructive) {
+                cloudDataSync.deleteCloudData()
+            }
+        } message: {
+            Text(L("cloudDataSync.delete.message"))
+        }
     }
 
     private var cloudDataSyncCard: some View {
@@ -91,7 +100,7 @@ struct AccountView: View {
                     .toggleStyle(.switch)
                 }
 
-                if cloudDataSync.isEnabled {
+                if cloudDataSync.isEnabled || cloudDataSync.lastError != nil {
                     Divider().overlay(StudioTheme.border.opacity(StudioTheme.Opacity.divider))
                     HStack {
                         Text(cloudDataSyncStatus)
@@ -100,12 +109,30 @@ struct AccountView: View {
                                 cloudDataSync.lastError == nil ? StudioTheme.textSecondary : StudioTheme.danger
                             )
                         Spacer()
-                        StudioButton(
-                            title: L("cloudDataSync.syncNow"), systemImage: "arrow.triangle.2.circlepath",
-                            variant: .secondary, isDisabled: cloudDataSync.isSyncing,
-                            isLoading: cloudDataSync.isSyncing
-                        ) { cloudDataSync.synchronizeNow() }
+                        if cloudDataSync.isEnabled {
+                            StudioButton(
+                                title: L("cloudDataSync.syncNow"), systemImage: "arrow.triangle.2.circlepath",
+                                variant: .secondary, isDisabled: cloudDataSync.isSyncing,
+                                isLoading: cloudDataSync.isSyncing
+                            ) { cloudDataSync.synchronizeNow() }
+                        }
                     }
+                }
+
+                if cloudDataSync.canDeleteCloudData {
+                    Divider().overlay(StudioTheme.border.opacity(StudioTheme.Opacity.divider))
+                    Button {
+                        isConfirmingCloudDataDeletion = true
+                    } label: {
+                        HStack(spacing: StudioTheme.Spacing.small) {
+                            if cloudDataSync.isDeletingCloudData { ProgressView().controlSize(.small) }
+                            Text(L("cloudDataSync.delete.action"))
+                        }
+                        .font(.studioBody(StudioTheme.Typography.caption))
+                        .foregroundStyle(StudioTheme.danger)
+                    }
+                    .buttonStyle(.plain)
+                    .disabled(cloudDataSync.isDeletingCloudData || cloudDataSync.isSyncing)
                 }
             }
         }

--- a/Sources/Typeflux/Auth/AuthState+Session.swift
+++ b/Sources/Typeflux/Auth/AuthState+Session.swift
@@ -89,6 +89,7 @@ extension AuthState {
             cachedStoredToken = (response.accessToken, normalizedExpiresAt)
             cachedRefreshToken = response.refreshToken ?? refreshToken
             logger.info("Token refreshed successfully")
+            NotificationCenter.default.post(name: .authTokenDidRefresh, object: self)
             return .refreshed
         } catch let error as AuthError {
             logger.error("Token refresh failed: \(error.localizedDescription)")

--- a/Sources/Typeflux/Auth/AuthState.swift
+++ b/Sources/Typeflux/Auth/AuthState.swift
@@ -11,6 +11,10 @@ extension Notification.Name {
     /// presence heartbeats can immediately drop the previous user association.
     static let authDidLogout = Notification.Name("AuthState.authDidLogout")
 
+    /// Posted after an access token is refreshed, including silent session
+    /// restoration where `authDidLogin` is intentionally not emitted.
+    static let authTokenDidRefresh = Notification.Name("AuthState.authTokenDidRefresh")
+
     /// Posted on the main actor when a checkout-started subscription refresh
     /// observes that the account has become entitled to Typeflux Cloud or has
     /// upgraded from a free/non-paid plan to a paid Cloud subscription.

--- a/Sources/Typeflux/Resources/en.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/en.lproj/Localizable.strings
@@ -1277,3 +1277,13 @@
 "agent.clarification.hotkeyHint" = "Press and hold your hotkey to record a reply";
 "agent.clarification.recordingHint" = "Recording... release hotkey when done";
 "agent.clarification.transcribingHint" = "Thinking...";
+"cloudDataSync.title" = "Cloud sync for vocabulary and personas";
+"cloudDataSync.subtitle" = "Off by default. When enabled, only custom vocabulary and custom personas are synced across your signed-in devices.";
+"cloudDataSync.consent.title" = "Enable cloud sync?";
+"cloudDataSync.consent.message" = "Your local vocabulary and custom personas will be uploaded to Typeflux Cloud and merged with existing cloud data. System personas, API keys, history, app bindings, and other settings are never uploaded.";
+"cloudDataSync.consent.confirm" = "Enable and merge";
+"cloudDataSync.syncNow" = "Sync now";
+"cloudDataSync.status.syncing" = "Syncing…";
+"cloudDataSync.status.failed" = "Sync failed: %@";
+"cloudDataSync.status.lastSync" = "Last synced at %@";
+"cloudDataSync.status.waiting" = "Waiting for first sync";

--- a/Sources/Typeflux/Resources/en.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/en.lproj/Localizable.strings
@@ -1289,3 +1289,8 @@
 "cloudDataSync.status.failed" = "Sync failed: %@";
 "cloudDataSync.status.lastSync" = "Last synced at %@";
 "cloudDataSync.status.waiting" = "Waiting for first sync";
+"cloudDataSync.resetRequired" = "Cloud data changed significantly. Review and enable sync again to choose whether to merge local data or use the cloud copy.";
+"cloudDataSync.delete.action" = "Delete all cloud sync data";
+"cloudDataSync.delete.title" = "Delete cloud sync data?";
+"cloudDataSync.delete.message" = "This permanently deletes cloud copies of your vocabulary and custom personas. Local data stays on this device. Other devices will stop syncing until you approve a new merge.";
+"cloudDataSync.delete.confirm" = "Delete cloud data";

--- a/Sources/Typeflux/Resources/en.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/en.lproj/Localizable.strings
@@ -1280,8 +1280,10 @@
 "cloudDataSync.title" = "Cloud sync for vocabulary and personas";
 "cloudDataSync.subtitle" = "Off by default. When enabled, only custom vocabulary and custom personas are synced across your signed-in devices.";
 "cloudDataSync.consent.title" = "Enable cloud sync?";
-"cloudDataSync.consent.message" = "Your local vocabulary and custom personas will be uploaded to Typeflux Cloud and merged with existing cloud data. System personas, API keys, history, app bindings, and other settings are never uploaded.";
+"cloudDataSync.consent.message" = "Choose whether to merge local and cloud data or use cloud data only. Once enabled, vocabulary and custom personas are encrypted in transit to Typeflux Cloud; other settings are not uploaded.";
 "cloudDataSync.consent.confirm" = "Enable and merge";
+"cloudDataSync.consent.merge" = "Merge local and cloud";
+"cloudDataSync.consent.cloudOnly" = "Use cloud data";
 "cloudDataSync.syncNow" = "Sync now";
 "cloudDataSync.status.syncing" = "Syncing…";
 "cloudDataSync.status.failed" = "Sync failed: %@";

--- a/Sources/Typeflux/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/ja.lproj/Localizable.strings
@@ -1274,3 +1274,8 @@
 "cloudDataSync.status.failed" = "同期に失敗しました：%@";
 "cloudDataSync.status.lastSync" = "最終同期：%@";
 "cloudDataSync.status.waiting" = "初回同期を待機中";
+"cloudDataSync.resetRequired" = "クラウドデータが大きく変更されました。同期を再度有効にし、ローカルデータを統合するかクラウド版を使用するか選択してください。";
+"cloudDataSync.delete.action" = "クラウド同期データをすべて削除";
+"cloudDataSync.delete.title" = "クラウド同期データを削除しますか？";
+"cloudDataSync.delete.message" = "クラウド上の単語帳とカスタムペルソナを完全に削除します。この端末のデータは残り、他の端末は再承認するまで同期を停止します。";
+"cloudDataSync.delete.confirm" = "クラウドデータを削除";

--- a/Sources/Typeflux/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/ja.lproj/Localizable.strings
@@ -1265,8 +1265,10 @@
 "cloudDataSync.title" = "単語帳とペルソナのクラウド同期";
 "cloudDataSync.subtitle" = "初期設定ではオフです。有効にすると、カスタム単語帳とカスタムペルソナのみを同じアカウントの端末間で同期します。";
 "cloudDataSync.consent.title" = "クラウド同期を有効にしますか？";
-"cloudDataSync.consent.message" = "ローカルの単語帳とカスタムペルソナを Typeflux Cloud にアップロードし、既存データと統合します。システムペルソナ、API キー、履歴、アプリ連携、その他の設定はアップロードされません。";
+"cloudDataSync.consent.message" = "ローカルとクラウドを統合するか、クラウドデータのみを使用するか選択してください。有効化後、単語帳とカスタムペルソナは暗号化通信で送信され、その他の設定はアップロードされません。";
 "cloudDataSync.consent.confirm" = "有効にして統合";
+"cloudDataSync.consent.merge" = "ローカルとクラウドを統合";
+"cloudDataSync.consent.cloudOnly" = "クラウドデータを使用";
 "cloudDataSync.syncNow" = "今すぐ同期";
 "cloudDataSync.status.syncing" = "同期中…";
 "cloudDataSync.status.failed" = "同期に失敗しました：%@";

--- a/Sources/Typeflux/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/ja.lproj/Localizable.strings
@@ -1262,3 +1262,13 @@
 "agent.clarification.hotkeyHint" = "ホットキーを押し続けて返答を録音";
 "agent.clarification.recordingHint" = "録音中... 完了したらホットキーを離してください";
 "agent.clarification.transcribingHint" = "思考中...";
+"cloudDataSync.title" = "単語帳とペルソナのクラウド同期";
+"cloudDataSync.subtitle" = "初期設定ではオフです。有効にすると、カスタム単語帳とカスタムペルソナのみを同じアカウントの端末間で同期します。";
+"cloudDataSync.consent.title" = "クラウド同期を有効にしますか？";
+"cloudDataSync.consent.message" = "ローカルの単語帳とカスタムペルソナを Typeflux Cloud にアップロードし、既存データと統合します。システムペルソナ、API キー、履歴、アプリ連携、その他の設定はアップロードされません。";
+"cloudDataSync.consent.confirm" = "有効にして統合";
+"cloudDataSync.syncNow" = "今すぐ同期";
+"cloudDataSync.status.syncing" = "同期中…";
+"cloudDataSync.status.failed" = "同期に失敗しました：%@";
+"cloudDataSync.status.lastSync" = "最終同期：%@";
+"cloudDataSync.status.waiting" = "初回同期を待機中";

--- a/Sources/Typeflux/Resources/ko.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/ko.lproj/Localizable.strings
@@ -1262,3 +1262,13 @@
 "agent.clarification.hotkeyHint" = "핫키를 누르고 있으면 답변을 녹음합니다";
 "agent.clarification.recordingHint" = "녹음 중... 완료되면 핫키를 놓으세요";
 "agent.clarification.transcribingHint" = "생각 중...";
+"cloudDataSync.title" = "단어장 및 페르소나 클라우드 동기화";
+"cloudDataSync.subtitle" = "기본값은 꺼짐입니다. 활성화하면 사용자 단어장과 사용자 페르소나만 같은 계정의 기기 간에 동기화됩니다.";
+"cloudDataSync.consent.title" = "클라우드 동기화를 켤까요?";
+"cloudDataSync.consent.message" = "로컬 단어장과 사용자 페르소나를 Typeflux Cloud에 업로드하고 기존 클라우드 데이터와 병합합니다. 시스템 페르소나, API 키, 기록, 앱 연결 및 기타 설정은 업로드하지 않습니다.";
+"cloudDataSync.consent.confirm" = "켜고 병합";
+"cloudDataSync.syncNow" = "지금 동기화";
+"cloudDataSync.status.syncing" = "동기화 중…";
+"cloudDataSync.status.failed" = "동기화 실패: %@";
+"cloudDataSync.status.lastSync" = "마지막 동기화: %@";
+"cloudDataSync.status.waiting" = "첫 동기화 대기 중";

--- a/Sources/Typeflux/Resources/ko.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/ko.lproj/Localizable.strings
@@ -1265,8 +1265,10 @@
 "cloudDataSync.title" = "단어장 및 페르소나 클라우드 동기화";
 "cloudDataSync.subtitle" = "기본값은 꺼짐입니다. 활성화하면 사용자 단어장과 사용자 페르소나만 같은 계정의 기기 간에 동기화됩니다.";
 "cloudDataSync.consent.title" = "클라우드 동기화를 켤까요?";
-"cloudDataSync.consent.message" = "로컬 단어장과 사용자 페르소나를 Typeflux Cloud에 업로드하고 기존 클라우드 데이터와 병합합니다. 시스템 페르소나, API 키, 기록, 앱 연결 및 기타 설정은 업로드하지 않습니다.";
+"cloudDataSync.consent.message" = "로컬과 클라우드 데이터를 병합하거나 클라우드 데이터만 사용할지 선택하세요. 활성화하면 단어장과 사용자 페르소나는 암호화된 연결로 전송되며 다른 설정은 업로드되지 않습니다.";
 "cloudDataSync.consent.confirm" = "켜고 병합";
+"cloudDataSync.consent.merge" = "로컬 및 클라우드 병합";
+"cloudDataSync.consent.cloudOnly" = "클라우드 데이터 사용";
 "cloudDataSync.syncNow" = "지금 동기화";
 "cloudDataSync.status.syncing" = "동기화 중…";
 "cloudDataSync.status.failed" = "동기화 실패: %@";

--- a/Sources/Typeflux/Resources/ko.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/ko.lproj/Localizable.strings
@@ -1274,3 +1274,8 @@
 "cloudDataSync.status.failed" = "동기화 실패: %@";
 "cloudDataSync.status.lastSync" = "마지막 동기화: %@";
 "cloudDataSync.status.waiting" = "첫 동기화 대기 중";
+"cloudDataSync.resetRequired" = "클라우드 데이터가 크게 변경되었습니다. 동기화를 다시 켜고 로컬 데이터를 병합할지 클라우드 데이터를 사용할지 선택하세요.";
+"cloudDataSync.delete.action" = "모든 클라우드 동기화 데이터 삭제";
+"cloudDataSync.delete.title" = "클라우드 동기화 데이터를 삭제할까요?";
+"cloudDataSync.delete.message" = "클라우드의 어휘와 사용자 지정 페르소나가 영구 삭제됩니다. 이 기기의 로컬 데이터는 유지되며 다른 기기는 다시 승인할 때까지 동기화를 중지합니다.";
+"cloudDataSync.delete.confirm" = "클라우드 데이터 삭제";

--- a/Sources/Typeflux/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/zh-Hans.lproj/Localizable.strings
@@ -1289,3 +1289,8 @@
 "cloudDataSync.status.failed" = "同步失败：%@";
 "cloudDataSync.status.lastSync" = "上次同步于 %@";
 "cloudDataSync.status.waiting" = "等待首次同步";
+"cloudDataSync.resetRequired" = "云端数据已发生重大变化。请重新开启同步，并选择合并本地数据或使用云端数据。";
+"cloudDataSync.delete.action" = "删除全部云同步数据";
+"cloudDataSync.delete.title" = "删除云同步数据？";
+"cloudDataSync.delete.message" = "这会永久删除云端保存的词库和自定义人设。本机数据会保留，其他设备将停止同步，直到你重新确认是否合并。";
+"cloudDataSync.delete.confirm" = "删除云端数据";

--- a/Sources/Typeflux/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/zh-Hans.lproj/Localizable.strings
@@ -1280,8 +1280,10 @@
 "cloudDataSync.title" = "词库与人设云同步";
 "cloudDataSync.subtitle" = "默认关闭。开启后，仅同步自定义词库和自定义人设到当前账号的其他设备。";
 "cloudDataSync.consent.title" = "开启云同步？";
-"cloudDataSync.consent.message" = "本地词库和自定义人设将上传至 Typeflux 云端，并与已有云端数据合并。系统人设、API 密钥、历史记录、应用绑定和其他设置不会上传。";
+"cloudDataSync.consent.message" = "请选择合并本机与云端数据，或仅使用云端数据。开启后，词库和自定义人设会加密传输至 Typeflux 云端；其他设置不会上传。";
 "cloudDataSync.consent.confirm" = "开启并合并";
+"cloudDataSync.consent.merge" = "合并本机与云端";
+"cloudDataSync.consent.cloudOnly" = "使用云端数据";
 "cloudDataSync.syncNow" = "立即同步";
 "cloudDataSync.status.syncing" = "正在同步…";
 "cloudDataSync.status.failed" = "同步失败：%@";

--- a/Sources/Typeflux/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/zh-Hans.lproj/Localizable.strings
@@ -1277,3 +1277,13 @@
 "agent.clarification.hotkeyHint" = "按住快捷键录制回复";
 "agent.clarification.recordingHint" = "录音中... 说完后松开快捷键";
 "agent.clarification.transcribingHint" = "思考中...";
+"cloudDataSync.title" = "词库与人设云同步";
+"cloudDataSync.subtitle" = "默认关闭。开启后，仅同步自定义词库和自定义人设到当前账号的其他设备。";
+"cloudDataSync.consent.title" = "开启云同步？";
+"cloudDataSync.consent.message" = "本地词库和自定义人设将上传至 Typeflux 云端，并与已有云端数据合并。系统人设、API 密钥、历史记录、应用绑定和其他设置不会上传。";
+"cloudDataSync.consent.confirm" = "开启并合并";
+"cloudDataSync.syncNow" = "立即同步";
+"cloudDataSync.status.syncing" = "正在同步…";
+"cloudDataSync.status.failed" = "同步失败：%@";
+"cloudDataSync.status.lastSync" = "上次同步于 %@";
+"cloudDataSync.status.waiting" = "等待首次同步";

--- a/Sources/Typeflux/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/zh-Hant.lproj/Localizable.strings
@@ -1273,3 +1273,13 @@
 "agent.clarification.hotkeyHint" = "按住快捷鍵錄製回覆";
 "agent.clarification.recordingHint" = "錄音中... 說完後鬆開快捷鍵";
 "agent.clarification.transcribingHint" = "思考中...";
+"cloudDataSync.title" = "詞庫與人設雲端同步";
+"cloudDataSync.subtitle" = "預設關閉。開啟後，僅同步自訂詞庫和自訂人設到目前帳號的其他裝置。";
+"cloudDataSync.consent.title" = "開啟雲端同步？";
+"cloudDataSync.consent.message" = "本機詞庫和自訂人設將上傳至 Typeflux 雲端，並與既有雲端資料合併。系統人設、API 金鑰、歷史記錄、應用程式綁定和其他設定不會上傳。";
+"cloudDataSync.consent.confirm" = "開啟並合併";
+"cloudDataSync.syncNow" = "立即同步";
+"cloudDataSync.status.syncing" = "正在同步…";
+"cloudDataSync.status.failed" = "同步失敗：%@";
+"cloudDataSync.status.lastSync" = "上次同步於 %@";
+"cloudDataSync.status.waiting" = "等待首次同步";

--- a/Sources/Typeflux/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/zh-Hant.lproj/Localizable.strings
@@ -1285,3 +1285,8 @@
 "cloudDataSync.status.failed" = "同步失敗：%@";
 "cloudDataSync.status.lastSync" = "上次同步於 %@";
 "cloudDataSync.status.waiting" = "等待首次同步";
+"cloudDataSync.resetRequired" = "雲端資料已發生重大變化。請重新開啟同步，並選擇合併本機資料或使用雲端資料。";
+"cloudDataSync.delete.action" = "刪除全部雲端同步資料";
+"cloudDataSync.delete.title" = "刪除雲端同步資料？";
+"cloudDataSync.delete.message" = "這會永久刪除雲端儲存的詞庫和自訂人設。本機資料會保留，其他裝置將停止同步，直到你重新確認是否合併。";
+"cloudDataSync.delete.confirm" = "刪除雲端資料";

--- a/Sources/Typeflux/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/zh-Hant.lproj/Localizable.strings
@@ -1276,8 +1276,10 @@
 "cloudDataSync.title" = "詞庫與人設雲端同步";
 "cloudDataSync.subtitle" = "預設關閉。開啟後，僅同步自訂詞庫和自訂人設到目前帳號的其他裝置。";
 "cloudDataSync.consent.title" = "開啟雲端同步？";
-"cloudDataSync.consent.message" = "本機詞庫和自訂人設將上傳至 Typeflux 雲端，並與既有雲端資料合併。系統人設、API 金鑰、歷史記錄、應用程式綁定和其他設定不會上傳。";
+"cloudDataSync.consent.message" = "請選擇合併本機與雲端資料，或只使用雲端資料。開啟後，詞庫和自訂人設會加密傳輸至 Typeflux 雲端；其他設定不會上傳。";
 "cloudDataSync.consent.confirm" = "開啟並合併";
+"cloudDataSync.consent.merge" = "合併本機與雲端";
+"cloudDataSync.consent.cloudOnly" = "使用雲端資料";
 "cloudDataSync.syncNow" = "立即同步";
 "cloudDataSync.status.syncing" = "正在同步…";
 "cloudDataSync.status.failed" = "同步失敗：%@";

--- a/Sources/Typeflux/Settings/SettingsStore.swift
+++ b/Sources/Typeflux/Settings/SettingsStore.swift
@@ -415,22 +415,24 @@ final class SettingsStore {
 
     var personasJSON: String {
         get {
-            migrateLegacyGuestPersonasIfNeeded()
-            return defaults.string(forKey: scopedPersonasKey) ?? ""
+            let storageKey = scopedPersonasKey
+            migrateLegacyGuestPersonasIfNeeded(storageKey: storageKey)
+            return defaults.string(forKey: storageKey) ?? ""
         }
         set {
-            migrateLegacyGuestPersonasIfNeeded()
-            defaults.set(newValue, forKey: scopedPersonasKey)
+            let storageKey = scopedPersonasKey
+            migrateLegacyGuestPersonasIfNeeded(storageKey: storageKey)
+            defaults.set(newValue, forKey: storageKey)
         }
     }
 
     private var scopedPersonasKey: String { "persona.items.\(CloudDataLocalScope.key)" }
 
-    private func migrateLegacyGuestPersonasIfNeeded() {
-        guard CloudDataLocalScope.key == "guest", defaults.object(forKey: scopedPersonasKey) == nil,
+    private func migrateLegacyGuestPersonasIfNeeded(storageKey: String) {
+        guard storageKey == "persona.items.guest", defaults.object(forKey: storageKey) == nil,
               let legacy = defaults.string(forKey: "persona.items")
         else { return }
-        defaults.set(legacy, forKey: scopedPersonasKey)
+        defaults.set(legacy, forKey: storageKey)
     }
 
     var personaAppBindings: [PersonaAppBinding] {

--- a/Sources/Typeflux/Settings/SettingsStore.swift
+++ b/Sources/Typeflux/Settings/SettingsStore.swift
@@ -414,8 +414,23 @@ final class SettingsStore {
     }
 
     var personasJSON: String {
-        get { defaults.string(forKey: "persona.items") ?? "" }
-        set { defaults.set(newValue, forKey: "persona.items") }
+        get {
+            migrateLegacyGuestPersonasIfNeeded()
+            return defaults.string(forKey: scopedPersonasKey) ?? ""
+        }
+        set {
+            migrateLegacyGuestPersonasIfNeeded()
+            defaults.set(newValue, forKey: scopedPersonasKey)
+        }
+    }
+
+    private var scopedPersonasKey: String { "persona.items.\(CloudDataLocalScope.key)" }
+
+    private func migrateLegacyGuestPersonasIfNeeded() {
+        guard CloudDataLocalScope.key == "guest", defaults.object(forKey: scopedPersonasKey) == nil,
+              let legacy = defaults.string(forKey: "persona.items")
+        else { return }
+        defaults.set(legacy, forKey: scopedPersonasKey)
     }
 
     var personaAppBindings: [PersonaAppBinding] {

--- a/Sources/Typeflux/Settings/SettingsStore.swift
+++ b/Sources/Typeflux/Settings/SettingsStore.swift
@@ -2,6 +2,7 @@ import Foundation
 
 // swiftlint:disable type_body_length file_length
 extension Notification.Name {
+    static let personaStoreDidChange = Notification.Name("SettingsStore.personaStoreDidChange")
     static let personaSelectionDidChange = Notification.Name(
         "SettingsStore.personaSelectionDidChange"
     )
@@ -451,6 +452,11 @@ final class SettingsStore {
             let customPersonas = newValue.filter { !$0.isSystem }
             let data = (try? JSONEncoder().encode(customPersonas)) ?? Data("[]".utf8)
             personasJSON = String(decoding: data, as: UTF8.self)
+            NotificationCenter.default.post(
+                name: .personaStoreDidChange,
+                object: self,
+                userInfo: ["personas": customPersonas]
+            )
         }
     }
 

--- a/Sources/Typeflux/Settings/SettingsViewModel.swift
+++ b/Sources/Typeflux/Settings/SettingsViewModel.swift
@@ -249,6 +249,7 @@ final class StudioViewModel: ObservableObject {
     private let historyRefreshQueue = DispatchQueue(label: "typeflux.settings.history-refresh", qos: .userInitiated)
     private var historyObserver: NSObjectProtocol?
     private var personaSelectionObserver: NSObjectProtocol?
+    private var personaStoreObserver: NSObjectProtocol?
     private var hotkeySettingsObserver: NSObjectProtocol?
     private var appearanceObserver: NSObjectProtocol?
     private var vocabularyObserver: NSObjectProtocol?
@@ -429,6 +430,20 @@ final class StudioViewModel: ObservableObject {
                 self?.syncPersonaSelectionFromStore()
             }
         }
+        personaStoreObserver = NotificationCenter.default.addObserver(
+            forName: .personaStoreDidChange,
+            object: settingsStore,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                personas = self.settingsStore.personas
+                if let selectedPersonaID, !personas.contains(where: { $0.id == selectedPersonaID }) {
+                    self.selectedPersonaID = personas.first?.id
+                }
+                loadPersonaDraft()
+            }
+        }
         hotkeySettingsObserver = NotificationCenter.default.addObserver(
             forName: .hotkeySettingsDidChange,
             object: settingsStore,
@@ -504,6 +519,9 @@ final class StudioViewModel: ObservableObject {
         }
         if let personaSelectionObserver {
             NotificationCenter.default.removeObserver(personaSelectionObserver)
+        }
+        if let personaStoreObserver {
+            NotificationCenter.default.removeObserver(personaStoreObserver)
         }
         if let hotkeySettingsObserver {
             NotificationCenter.default.removeObserver(hotkeySettingsObserver)

--- a/Sources/Typeflux/Settings/VocabularyStore.swift
+++ b/Sources/Typeflux/Settings/VocabularyStore.swift
@@ -102,8 +102,9 @@ enum VocabularyStore {
     static let activeTermLimit = 500
 
     static func load() -> [VocabularyEntry] {
-        migrateLegacyGuestDataIfNeeded()
-        guard let data = UserDefaults.standard.data(forKey: key) else {
+        let storageKey = key
+        migrateLegacyGuestDataIfNeeded(storageKey: storageKey)
+        guard let data = UserDefaults.standard.data(forKey: storageKey) else {
             return []
         }
 
@@ -117,12 +118,13 @@ enum VocabularyStore {
     }
 
     static func save(_ entries: [VocabularyEntry]) {
-        migrateLegacyGuestDataIfNeeded()
+        let storageKey = key
+        migrateLegacyGuestDataIfNeeded(storageKey: storageKey)
         let deduplicatedEntries = deduplicated(entries)
 
         do {
             let data = try JSONEncoder().encode(deduplicatedEntries)
-            UserDefaults.standard.set(data, forKey: key)
+            UserDefaults.standard.set(data, forKey: storageKey)
             NotificationCenter.default.post(
                 name: .vocabularyStoreDidChange,
                 object: nil,
@@ -133,12 +135,12 @@ enum VocabularyStore {
         }
     }
 
-    private static func migrateLegacyGuestDataIfNeeded() {
-        guard CloudDataLocalScope.key == "guest",
-              UserDefaults.standard.object(forKey: key) == nil,
+    private static func migrateLegacyGuestDataIfNeeded(storageKey: String) {
+        guard storageKey == "\(legacyKey).guest",
+              UserDefaults.standard.object(forKey: storageKey) == nil,
               let legacy = UserDefaults.standard.data(forKey: legacyKey)
         else { return }
-        UserDefaults.standard.set(legacy, forKey: key)
+        UserDefaults.standard.set(legacy, forKey: storageKey)
     }
 
     static func exportData() throws -> Data {

--- a/Sources/Typeflux/Settings/VocabularyStore.swift
+++ b/Sources/Typeflux/Settings/VocabularyStore.swift
@@ -94,13 +94,15 @@ enum VocabularyImportError: LocalizedError, Equatable {
 }
 
 enum VocabularyStore {
-    private static let key = "vocabulary.entries"
+    private static let legacyKey = "vocabulary.entries"
+    private static var key: String { "\(legacyKey).\(CloudDataLocalScope.key)" }
     /// Maximum number of terms returned to speech recognition as hints. Beyond this
     /// point most ASR backends either truncate silently or waste prompt budget, so
     /// we cap the list and let ranking decide who stays.
     static let activeTermLimit = 500
 
     static func load() -> [VocabularyEntry] {
+        migrateLegacyGuestDataIfNeeded()
         guard let data = UserDefaults.standard.data(forKey: key) else {
             return []
         }
@@ -115,6 +117,7 @@ enum VocabularyStore {
     }
 
     static func save(_ entries: [VocabularyEntry]) {
+        migrateLegacyGuestDataIfNeeded()
         let deduplicatedEntries = deduplicated(entries)
 
         do {
@@ -128,6 +131,14 @@ enum VocabularyStore {
         } catch {
             ErrorLogStore.shared.log("Vocabulary save failed: \(error.localizedDescription)")
         }
+    }
+
+    private static func migrateLegacyGuestDataIfNeeded() {
+        guard CloudDataLocalScope.key == "guest",
+              UserDefaults.standard.object(forKey: key) == nil,
+              let legacy = UserDefaults.standard.data(forKey: legacyKey)
+        else { return }
+        UserDefaults.standard.set(legacy, forKey: key)
     }
 
     static func exportData() throws -> Data {

--- a/Sources/Typeflux/Sync/CloudDataSyncAPIService.swift
+++ b/Sources/Typeflux/Sync/CloudDataSyncAPIService.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+struct CloudDataSyncAPIService: Sendable {
+    private let executor: CloudRequestExecutor
+
+    init(executor: CloudRequestExecutor = CloudRequestExecutor()) {
+        self.executor = executor
+    }
+
+    static func sync(token: String, request: CloudSyncRequest) async throws -> CloudSyncResponse {
+        try await CloudDataSyncAPIService().sync(token: token, request: request)
+    }
+
+    func sync(token: String, request: CloudSyncRequest) async throws -> CloudSyncResponse {
+        let payload = try JSONEncoder.cloudSync.encode(request)
+        let path = "/api/v1/sync"
+        let (data, response) = try await executor.execute(apiPath: path) { baseURL in
+            var urlRequest = URLRequest(
+                url: AuthEndpointResolver.resolve(baseURL: baseURL, path: path)
+            )
+            urlRequest.httpMethod = "POST"
+            urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
+            urlRequest.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+            urlRequest.httpBody = payload
+            urlRequest.timeoutInterval = 30
+            return urlRequest
+        }
+        guard response.statusCode >= 200, response.statusCode < 300 else {
+            throw AuthError.invalidResponse
+        }
+        let envelope = try JSONDecoder.cloudSync.decode(APIResponse<CloudSyncResponse>.self, from: data)
+        guard envelope.code == "OK", let result = envelope.data else { throw AuthError.invalidResponse }
+        return result
+    }
+}
+
+private extension JSONEncoder {
+    static var cloudSync: JSONEncoder {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        return encoder
+    }
+}
+
+private extension JSONDecoder {
+    static var cloudSync: JSONDecoder {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return decoder
+    }
+}

--- a/Sources/Typeflux/Sync/CloudDataSyncAPIService.swift
+++ b/Sources/Typeflux/Sync/CloudDataSyncAPIService.swift
@@ -11,6 +11,10 @@ struct CloudDataSyncAPIService: Sendable {
         try await CloudDataSyncAPIService().sync(token: token, request: request)
     }
 
+    static func reset(token: String) async throws -> CloudSyncResetResponse {
+        try await CloudDataSyncAPIService().reset(token: token)
+    }
+
     func sync(token: String, request: CloudSyncRequest) async throws -> CloudSyncResponse {
         let payload = try JSONEncoder.cloudSync.encode(request)
         let path = "/api/v1/sync"
@@ -29,6 +33,23 @@ struct CloudDataSyncAPIService: Sendable {
             throw AuthError.invalidResponse
         }
         let envelope = try JSONDecoder.cloudSync.decode(APIResponse<CloudSyncResponse>.self, from: data)
+        guard envelope.code == "OK", let result = envelope.data else { throw AuthError.invalidResponse }
+        return result
+    }
+
+    func reset(token: String) async throws -> CloudSyncResetResponse {
+        let path = "/api/v1/sync"
+        let (data, response) = try await executor.execute(apiPath: path) { baseURL in
+            var request = URLRequest(url: AuthEndpointResolver.resolve(baseURL: baseURL, path: path))
+            request.httpMethod = "DELETE"
+            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+            request.timeoutInterval = 30
+            return request
+        }
+        guard response.statusCode >= 200, response.statusCode < 300 else {
+            throw AuthError.invalidResponse
+        }
+        let envelope = try JSONDecoder.cloudSync.decode(APIResponse<CloudSyncResetResponse>.self, from: data)
         guard envelope.code == "OK", let result = envelope.data else { throw AuthError.invalidResponse }
         return result
     }

--- a/Sources/Typeflux/Sync/CloudDataSyncCoordinator.swift
+++ b/Sources/Typeflux/Sync/CloudDataSyncCoordinator.swift
@@ -9,6 +9,7 @@ final class CloudDataSyncCoordinator: ObservableObject {
 
     @Published private(set) var isEnabled = false
     @Published private(set) var isSyncing = false
+    @Published private(set) var isDeletingCloudData = false
     @Published private(set) var lastSyncAt: Date?
     @Published private(set) var lastError: String?
     @Published private(set) var requiresInitialChoice = false
@@ -26,6 +27,10 @@ final class CloudDataSyncCoordinator: ObservableObject {
     private var applyingRemote = false
     private var localChangeDuringSync = false
     private var syncGeneration = 0
+    var canDeleteCloudData: Bool {
+        guard let userID = authState.userProfile?.id else { return false }
+        return store.hasAccount(userID: userID)
+    }
 
     private static let deviceID: UUID = {
         let key = "cloudDataSync.deviceID"
@@ -64,10 +69,24 @@ final class CloudDataSyncCoordinator: ObservableObject {
             lastError = store.initializationError?.localizedDescription ?? "Local sync storage is unavailable"
             return
         }
-        if enabled && !store.hasAccount(userID: userID) {
+        let hasAccount = store.hasAccount(userID: userID)
+        let state = store.state(userID: userID)
+        if enabled && !hasAccount {
             prepareInitialAccountScope(userID: userID, mergeGuestData: mergeGuestData)
+        } else if enabled && state.needsReauthorization && !mergeGuestData {
+            do {
+                try applyCloudBaseline(userID: userID)
+            } catch {
+                lastError = error.localizedDescription
+                return
+            }
         }
-        store.setEnabled(enabled, userID: userID)
+        do {
+            try store.setEnabled(enabled, userID: userID)
+        } catch {
+            lastError = error.localizedDescription
+            return
+        }
         isEnabled = enabled
         requiresInitialChoice = false
         lastError = nil
@@ -77,6 +96,63 @@ final class CloudDataSyncCoordinator: ObservableObject {
             syncTask?.cancel()
             syncTask = nil
             isSyncing = false
+        }
+    }
+
+    func deleteCloudData() {
+        guard !isDeletingCloudData, let userID = authState.userProfile?.id,
+              let token = authState.accessToken, store.isAvailable else { return }
+        let wasEnabled = isEnabled
+        do {
+            try store.setEnabled(false, userID: userID)
+        } catch {
+            lastError = error.localizedDescription
+            return
+        }
+        let activeSync = syncTask
+        isDeletingCloudData = true
+        syncGeneration += 1
+        debounceTask?.cancel()
+        activeSync?.cancel()
+        syncTask = nil
+        isSyncing = false
+        isEnabled = false
+        Task { [weak self] in
+            guard let self else { return }
+            defer { isDeletingCloudData = false }
+            do {
+                await activeSync?.value
+                let response = try await CloudDataSyncAPIService.reset(token: token)
+                try store.replaceBaseline(
+                    userID: userID, datasetGeneration: response.datasetGeneration,
+                    cursor: 0, snapshot: []
+                )
+                if authState.userProfile?.id == userID {
+                    isEnabled = false
+                    requiresInitialChoice = true
+                    lastSyncAt = nil
+                    lastError = nil
+                    syncGeneration += 1
+                    debounceTask?.cancel()
+                    syncTask?.cancel()
+                    syncTask = nil
+                    isSyncing = false
+                }
+            } catch {
+                let failure = error.localizedDescription
+                var restored = false
+                var restoreFailure: String?
+                do {
+                    try store.setEnabled(wasEnabled, userID: userID)
+                    restored = true
+                } catch let restoreError {
+                    restoreFailure = restoreError.localizedDescription
+                }
+                if authState.userProfile?.id == userID {
+                    isEnabled = restored && wasEnabled
+                    lastError = restoreFailure ?? failure
+                }
+            }
         }
     }
 
@@ -137,8 +213,9 @@ final class CloudDataSyncCoordinator: ObservableObject {
             return
         }
         let hasAccount = store.hasAccount(userID: userID)
-        isEnabled = store.state(userID: userID).enabled
-        requiresInitialChoice = !hasAccount
+        let state = store.state(userID: userID)
+        isEnabled = state.enabled
+        requiresInitialChoice = !hasAccount || state.needsReauthorization
         if switchScope {
             applyingRemote = true
             if hasAccount { CloudDataLocalScope.useAccount(userID) } else { CloudDataLocalScope.useGuest() }
@@ -164,6 +241,37 @@ final class CloudDataSyncCoordinator: ObservableObject {
             settingsStore.personas = []
         }
         applyingRemote = false
+        postScopeChangeNotifications()
+    }
+
+    private func applyCloudBaseline(userID: String) throws {
+        applyingRemote = true
+        defer { applyingRemote = false }
+        let vocabulary = try store.knownEntities(userID: userID, type: .vocabulary).map { id, record in
+            let value = try JSONDecoder.cloudSyncDates.decode(
+                VocabularyCloudPayload.self, from: record.payload
+            )
+            return VocabularyEntry(
+                id: id, term: value.term,
+                source: VocabularySource(rawValue: value.source) ?? .manual,
+                createdAt: value.createdAt, occurrenceCount: value.occurrenceCount
+            )
+        }
+        let personas = try store.knownEntities(userID: userID, type: .persona).map { id, record in
+            let value = try JSONDecoder().decode(PersonaCloudPayload.self, from: record.payload)
+            return PersonaProfile(id: id, name: value.name, prompt: value.prompt)
+        }
+        VocabularyStore.save(vocabulary)
+        settingsStore.personas = personas
+        let personaIDs = Set(settingsStore.personas.map(\.id))
+        if let activeID = UUID(uuidString: settingsStore.activePersonaID),
+           !settingsStore.personas.contains(where: { $0.id == activeID }) {
+            settingsStore.activePersonaID = ""
+        }
+        settingsStore.personaAppBindings.removeAll { binding in
+            guard let personaID = binding.personaID else { return false }
+            return !personaIDs.contains(personaID)
+        }
         postScopeChangeNotifications()
     }
 
@@ -223,7 +331,7 @@ final class CloudDataSyncCoordinator: ObservableObject {
     }
 
     private func syncContext() -> (userID: String, token: String, state: SQLiteCloudDataSyncStore.State)? {
-        guard store.isAvailable else { return nil }
+        guard store.isAvailable, !isDeletingCloudData else { return nil }
         guard let userID = authState.userProfile?.id, let token = authState.accessToken else { return nil }
         let state = store.state(userID: userID)
         guard state.enabled else { return nil }
@@ -243,11 +351,24 @@ final class CloudDataSyncCoordinator: ObservableObject {
                 let response = try await CloudDataSyncAPIService.sync(
                     token: context.token,
                     request: CloudSyncRequest(
+                        datasetGeneration: context.state.datasetGeneration,
                         deviceID: Self.deviceID, cursor: context.state.cursor,
                         ackCursor: context.state.cursor, checkpoint: context.state.checkpoint,
                         mutations: pending
                     )
                 )
+                guard !Task.isCancelled, authState.userProfile?.id == context.userID else { return }
+                if response.resetRequired {
+                    try store.replaceBaseline(
+                        userID: context.userID, datasetGeneration: response.datasetGeneration,
+                        cursor: response.cursor, snapshot: response.snapshot
+                    )
+                    isEnabled = false
+                    requiresInitialChoice = true
+                    lastSyncAt = nil
+                    lastError = L("cloudDataSync.resetRequired")
+                    return
+                }
                 try resolve(
                     results: response.results, mutations: pending, userID: context.userID,
                     applyAccepted: !localChangeDuringSync
@@ -264,10 +385,14 @@ final class CloudDataSyncCoordinator: ObservableObject {
                     continue
                 }
                 try apply(changes: response.changes, userID: context.userID)
-                store.setProgress(userID: context.userID, cursor: response.cursor,
-                                  checkpoint: response.hasMore ? response.checkpoint : 0)
+                store.setProgress(
+                    userID: context.userID, cursor: response.cursor,
+                    checkpoint: response.hasMore ? response.checkpoint : 0,
+                    datasetGeneration: response.datasetGeneration
+                )
                 context.state.cursor = response.cursor
                 context.state.checkpoint = response.hasMore ? response.checkpoint : 0
+                context.state.datasetGeneration = response.datasetGeneration
                 try stageLocalData(userID: context.userID)
                 hasMore = response.hasMore || !store.pending(userID: context.userID).isEmpty
             }

--- a/Sources/Typeflux/Sync/CloudDataSyncCoordinator.swift
+++ b/Sources/Typeflux/Sync/CloudDataSyncCoordinator.swift
@@ -11,6 +11,7 @@ final class CloudDataSyncCoordinator: ObservableObject {
     @Published private(set) var isSyncing = false
     @Published private(set) var lastSyncAt: Date?
     @Published private(set) var lastError: String?
+    @Published private(set) var requiresInitialChoice = false
 
     private let authState: AuthState
     private let settingsStore: SettingsStore
@@ -18,10 +19,13 @@ final class CloudDataSyncCoordinator: ObservableObject {
     private let monitor = NWPathMonitor()
     private let monitorQueue = DispatchQueue(label: "typeflux.cloud-data-sync.network")
     private var observers: [NSObjectProtocol] = []
+    private var workspaceObservers: [NSObjectProtocol] = []
     private var periodicTask: Task<Void, Never>?
     private var debounceTask: Task<Void, Never>?
     private var syncTask: Task<Void, Never>?
     private var applyingRemote = false
+    private var localChangeDuringSync = false
+    private var syncGeneration = 0
 
     private static let deviceID: UUID = {
         let key = "cloudDataSync.deviceID"
@@ -40,45 +44,59 @@ final class CloudDataSyncCoordinator: ObservableObject {
         self.settingsStore = settingsStore
         self.store = store
         observe()
-        refreshEnabledState()
+        refreshEnabledState(switchScope: true)
         startPeriodicSync()
+        synchronizeNow()
     }
 
     deinit {
         observers.forEach(NotificationCenter.default.removeObserver)
+        workspaceObservers.forEach(NSWorkspace.shared.notificationCenter.removeObserver)
         monitor.cancel()
         periodicTask?.cancel()
         debounceTask?.cancel()
         syncTask?.cancel()
     }
 
-    func setEnabled(_ enabled: Bool) {
+    func setEnabled(_ enabled: Bool, mergeGuestData: Bool = true) {
         guard let userID = authState.userProfile?.id else { return }
+        guard store.isAvailable else {
+            lastError = store.initializationError?.localizedDescription ?? "Local sync storage is unavailable"
+            return
+        }
+        if enabled && !store.hasAccount(userID: userID) {
+            prepareInitialAccountScope(userID: userID, mergeGuestData: mergeGuestData)
+        }
         store.setEnabled(enabled, userID: userID)
         isEnabled = enabled
+        requiresInitialChoice = false
         lastError = nil
         if enabled { synchronizeNow() } else {
+            syncGeneration += 1
             debounceTask?.cancel()
             syncTask?.cancel()
+            syncTask = nil
             isSyncing = false
         }
     }
 
     func synchronizeNow() {
         guard syncTask == nil, syncContext() != nil else { return }
+        let generation = syncGeneration
         syncTask = Task { [weak self] in
             guard let self else { return }
             await performSync()
+            guard generation == syncGeneration else { return }
             syncTask = nil
         }
     }
 
     private func observe() {
         let center = NotificationCenter.default
-        for name in [Notification.Name.authDidLogin, .authDidLogout] {
+        for name in [Notification.Name.authDidLogin, .authDidLogout, .authTokenDidRefresh] {
             observers.append(center.addObserver(forName: name, object: nil, queue: .main) { [weak self] _ in
                 Task { @MainActor [weak self] in
-                    self?.refreshEnabledState()
+                    self?.refreshEnabledState(switchScope: true)
                     self?.synchronizeNow()
                 }
             })
@@ -88,11 +106,17 @@ final class CloudDataSyncCoordinator: ObservableObject {
                 Task { @MainActor [weak self] in self?.scheduleLocalPush() }
             })
         }
-        for name in [NSApplication.didBecomeActiveNotification, NSWorkspace.didWakeNotification] {
-            observers.append(center.addObserver(forName: name, object: nil, queue: .main) { [weak self] _ in
-                Task { @MainActor [weak self] in self?.synchronizeNow() }
-            })
-        }
+        observers.append(center.addObserver(
+            forName: NSApplication.didBecomeActiveNotification, object: nil, queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor [weak self] in self?.synchronizeNow() }
+        })
+        let workspaceCenter = NSWorkspace.shared.notificationCenter
+        workspaceObservers.append(workspaceCenter.addObserver(
+            forName: NSWorkspace.didWakeNotification, object: nil, queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor [weak self] in self?.synchronizeNow() }
+        })
         monitor.pathUpdateHandler = { [weak self] path in
             guard path.status == .satisfied else { return }
             Task { @MainActor [weak self] in self?.synchronizeNow() }
@@ -100,16 +124,81 @@ final class CloudDataSyncCoordinator: ObservableObject {
         monitor.start(queue: monitorQueue)
     }
 
-    private func refreshEnabledState() {
+    private func refreshEnabledState(switchScope: Bool = false) {
         guard let userID = authState.userProfile?.id else {
+            if switchScope { switchToGuestScope() }
             isEnabled = false
+            requiresInitialChoice = false
+            syncGeneration += 1
             debounceTask?.cancel()
             syncTask?.cancel()
             syncTask = nil
             isSyncing = false
             return
         }
+        let hasAccount = store.hasAccount(userID: userID)
         isEnabled = store.state(userID: userID).enabled
+        requiresInitialChoice = !hasAccount
+        if switchScope {
+            applyingRemote = true
+            if hasAccount { CloudDataLocalScope.useAccount(userID) } else { CloudDataLocalScope.useGuest() }
+            applyingRemote = false
+            postScopeChangeNotifications()
+        }
+    }
+
+    private func prepareInitialAccountScope(userID: String, mergeGuestData: Bool) {
+        applyingRemote = true
+        let guestVocabulary = VocabularyStore.load()
+        let guestPersonas = settingsStore.personas.filter { !$0.isSystem }
+        CloudDataLocalScope.useAccount(userID)
+        if mergeGuestData {
+            VocabularyStore.save(mergeVocabulary(VocabularyStore.load(), guestVocabulary))
+            var personas = settingsStore.personas
+            for guest in guestPersonas where !personas.contains(where: { $0.id == guest.id }) {
+                personas.append(guest)
+            }
+            settingsStore.personas = personas
+        } else {
+            VocabularyStore.save([])
+            settingsStore.personas = []
+        }
+        applyingRemote = false
+        postScopeChangeNotifications()
+    }
+
+    private func switchToGuestScope() {
+        applyingRemote = true
+        CloudDataLocalScope.useGuest()
+        applyingRemote = false
+        postScopeChangeNotifications()
+    }
+
+    private func postScopeChangeNotifications() {
+        NotificationCenter.default.post(name: .vocabularyStoreDidChange, object: nil)
+        NotificationCenter.default.post(name: .personaStoreDidChange, object: settingsStore)
+    }
+
+    private func mergeVocabulary(
+        _ account: [VocabularyEntry], _ guest: [VocabularyEntry]
+    ) -> [VocabularyEntry] {
+        var result = account
+        for entry in guest {
+            if let index = result.firstIndex(where: {
+                $0.term.compare(entry.term, options: [.caseInsensitive, .widthInsensitive]) == .orderedSame
+            }) {
+                let existing = result[index]
+                result[index] = VocabularyEntry(
+                    id: existing.id, term: existing.term,
+                    source: existing.source == .manual ? existing.source : entry.source,
+                    createdAt: min(existing.createdAt, entry.createdAt),
+                    occurrenceCount: max(existing.occurrenceCount, entry.occurrenceCount)
+                )
+            } else {
+                result.append(entry)
+            }
+        }
+        return result
     }
 
     private func startPeriodicSync() {
@@ -124,6 +213,7 @@ final class CloudDataSyncCoordinator: ObservableObject {
 
     private func scheduleLocalPush() {
         guard !applyingRemote, syncContext() != nil else { return }
+        if syncTask != nil { localChangeDuringSync = true }
         debounceTask?.cancel()
         debounceTask = Task { [weak self] in
             try? await Task.sleep(for: .seconds(3))
@@ -133,6 +223,7 @@ final class CloudDataSyncCoordinator: ObservableObject {
     }
 
     private func syncContext() -> (userID: String, token: String, state: SQLiteCloudDataSyncStore.State)? {
+        guard store.isAvailable else { return nil }
         guard let userID = authState.userProfile?.id, let token = authState.accessToken else { return nil }
         let state = store.state(userID: userID)
         guard state.enabled else { return nil }
@@ -148,6 +239,7 @@ final class CloudDataSyncCoordinator: ObservableObject {
             var hasMore = true
             while hasMore, !Task.isCancelled {
                 let pending = store.pending(userID: context.userID)
+                localChangeDuringSync = false
                 let response = try await CloudDataSyncAPIService.sync(
                     token: context.token,
                     request: CloudSyncRequest(
@@ -156,14 +248,28 @@ final class CloudDataSyncCoordinator: ObservableObject {
                         mutations: pending
                     )
                 )
-                try resolve(results: response.results, mutations: pending, userID: context.userID)
+                try resolve(
+                    results: response.results, mutations: pending, userID: context.userID,
+                    applyAccepted: !localChangeDuringSync
+                )
+                store.accept(
+                    response.results, mutations: pending, userID: context.userID,
+                    removeRejected: !localChangeDuringSync
+                )
+                if localChangeDuringSync {
+                    // A local edit landed while the request was in flight. Keep the old cursor so
+                    // the response can be replayed after that newer local intent has been staged.
+                    try stageLocalData(userID: context.userID)
+                    hasMore = true
+                    continue
+                }
                 try apply(changes: response.changes, userID: context.userID)
-                store.accept(response.results, mutations: pending, userID: context.userID)
                 store.setProgress(userID: context.userID, cursor: response.cursor,
                                   checkpoint: response.hasMore ? response.checkpoint : 0)
                 context.state.cursor = response.cursor
                 context.state.checkpoint = response.hasMore ? response.checkpoint : 0
-                hasMore = response.hasMore
+                try stageLocalData(userID: context.userID)
+                hasMore = response.hasMore || !store.pending(userID: context.userID).isEmpty
             }
             lastSyncAt = Date()
             lastError = nil
@@ -193,25 +299,72 @@ final class CloudDataSyncCoordinator: ObservableObject {
         store.stageLocalChanges(userID: userID, type: .persona, entities: personas)
     }
 
-    private func resolve(results: [CloudSyncMutationResult], mutations: [CloudSyncMutation], userID: String) throws {
+    private func resolve(
+        results: [CloudSyncMutationResult], mutations: [CloudSyncMutation], userID: String,
+        applyAccepted: Bool
+    ) throws {
+        applyingRemote = true
+        defer { applyingRemote = false }
         let byID = Dictionary(uniqueKeysWithValues: mutations.map { ($0.mutationID, $0) })
-        for result in results where result.status != "accepted" {
+        for result in results {
             guard let mutation = byID[result.mutationID] else { continue }
+            if result.status == "invalid" {
+                throw CloudDataSyncError.invalidMutation(result.message ?? "Invalid cloud sync data")
+            }
+            if result.status == "accepted" {
+                if let current = result.current, applyAccepted {
+                    try applyCurrent(result: result, mutation: mutation, payload: current, userID: userID)
+                }
+                continue
+            }
+            guard applyAccepted else { continue }
             if mutation.entityType == .persona, mutation.operation != "delete" {
                 let payload = try JSONDecoder().decode(PersonaCloudPayload.self, from: mutation.payload)
                 var personas = settingsStore.personas
-                personas.append(PersonaProfile(name: payload.name + " (冲突副本)", prompt: payload.prompt))
-                applyingRemote = true
+                personas.removeAll { $0.id == result.mutationID && !$0.isSystem }
+                let conflictSuffix = " (冲突副本)"
+                let conflictName = String(payload.name.prefix(max(0, 100 - conflictSuffix.count)))
+                    + conflictSuffix
+                personas.append(PersonaProfile(
+                    id: result.mutationID, name: conflictName, prompt: payload.prompt
+                ))
                 settingsStore.personas = personas
-                applyingRemote = false
+                if let current = result.current {
+                    try applyPersona(id: result.canonicalID, payload: current.data, deleted: result.deleted)
+                    store.apply(change: syntheticChange(result: result, type: .persona), userID: userID)
+                } else {
+                    try applyPersona(id: mutation.entityID, payload: mutation.payload, deleted: true)
+                }
+            } else if mutation.entityType == .persona, let current = result.current {
+                try applyPersona(id: result.canonicalID, payload: current.data, deleted: result.deleted)
+                store.apply(change: syntheticChange(result: result, type: .persona), userID: userID)
             } else if mutation.entityType == .vocabulary, let current = result.current {
-                try applyVocabulary(id: result.canonicalID, payload: current.data, deleted: false)
-                store.apply(change: CloudSyncChange(
-                    sequence: 0, entityType: .vocabulary, entityID: result.canonicalID,
-                    operation: "update", revision: result.revision, payload: current
-                ), userID: userID)
+                try applyVocabulary(id: result.canonicalID, payload: current.data, deleted: result.deleted)
+                store.apply(change: syntheticChange(result: result, type: .vocabulary), userID: userID)
             }
         }
+    }
+
+    private func applyCurrent(
+        result: CloudSyncMutationResult, mutation: CloudSyncMutation, payload: JSONValue, userID: String
+    ) throws {
+        switch mutation.entityType {
+        case .vocabulary:
+            try applyVocabulary(id: result.canonicalID, payload: payload.data, deleted: result.deleted)
+        case .persona:
+            try applyPersona(id: result.canonicalID, payload: payload.data, deleted: result.deleted)
+        }
+        store.apply(change: syntheticChange(result: result, type: mutation.entityType), userID: userID)
+    }
+
+    private func syntheticChange(
+        result: CloudSyncMutationResult, type: CloudSyncEntityType
+    ) -> CloudSyncChange {
+        CloudSyncChange(
+            sequence: 0, entityType: type, entityID: result.canonicalID,
+            operation: result.deleted ? "delete" : "update", revision: result.revision,
+            payload: result.current ?? JSONValue(data: Data("{}".utf8))
+        )
     }
 
     private func apply(changes: [CloudSyncChange], userID: String) throws {
@@ -258,6 +411,22 @@ final class CloudDataSyncCoordinator: ObservableObject {
             personas.append(PersonaProfile(id: id, name: value.name, prompt: value.prompt))
         }
         settingsStore.personas = personas
+        if deleted {
+            if settingsStore.activePersonaID == id.uuidString {
+                settingsStore.activePersonaID = ""
+            }
+            settingsStore.personaAppBindings.removeAll { $0.personaID == id }
+        }
+    }
+}
+
+private enum CloudDataSyncError: LocalizedError {
+    case invalidMutation(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidMutation(let message): message
+        }
     }
 }
 

--- a/Sources/Typeflux/Sync/CloudDataSyncCoordinator.swift
+++ b/Sources/Typeflux/Sync/CloudDataSyncCoordinator.swift
@@ -1,0 +1,270 @@
+import AppKit
+import Foundation
+import Network
+import os
+
+@MainActor
+final class CloudDataSyncCoordinator: ObservableObject {
+    static let shared = CloudDataSyncCoordinator()
+
+    @Published private(set) var isEnabled = false
+    @Published private(set) var isSyncing = false
+    @Published private(set) var lastSyncAt: Date?
+    @Published private(set) var lastError: String?
+
+    private let authState: AuthState
+    private let settingsStore: SettingsStore
+    private let store: SQLiteCloudDataSyncStore
+    private let monitor = NWPathMonitor()
+    private let monitorQueue = DispatchQueue(label: "typeflux.cloud-data-sync.network")
+    private var observers: [NSObjectProtocol] = []
+    private var periodicTask: Task<Void, Never>?
+    private var debounceTask: Task<Void, Never>?
+    private var syncTask: Task<Void, Never>?
+    private var applyingRemote = false
+
+    private static let deviceID: UUID = {
+        let key = "cloudDataSync.deviceID"
+        if let value = UserDefaults.standard.string(forKey: key), let id = UUID(uuidString: value) { return id }
+        let id = UUID()
+        UserDefaults.standard.set(id.uuidString, forKey: key)
+        return id
+    }()
+
+    init(
+        authState: AuthState? = nil,
+        settingsStore: SettingsStore = SettingsStore(),
+        store: SQLiteCloudDataSyncStore = SQLiteCloudDataSyncStore()
+    ) {
+        self.authState = authState ?? .shared
+        self.settingsStore = settingsStore
+        self.store = store
+        observe()
+        refreshEnabledState()
+        startPeriodicSync()
+    }
+
+    deinit {
+        observers.forEach(NotificationCenter.default.removeObserver)
+        monitor.cancel()
+        periodicTask?.cancel()
+        debounceTask?.cancel()
+        syncTask?.cancel()
+    }
+
+    func setEnabled(_ enabled: Bool) {
+        guard let userID = authState.userProfile?.id else { return }
+        store.setEnabled(enabled, userID: userID)
+        isEnabled = enabled
+        lastError = nil
+        if enabled { synchronizeNow() } else {
+            debounceTask?.cancel()
+            syncTask?.cancel()
+            isSyncing = false
+        }
+    }
+
+    func synchronizeNow() {
+        guard syncTask == nil, syncContext() != nil else { return }
+        syncTask = Task { [weak self] in
+            guard let self else { return }
+            await performSync()
+            syncTask = nil
+        }
+    }
+
+    private func observe() {
+        let center = NotificationCenter.default
+        for name in [Notification.Name.authDidLogin, .authDidLogout] {
+            observers.append(center.addObserver(forName: name, object: nil, queue: .main) { [weak self] _ in
+                Task { @MainActor [weak self] in
+                    self?.refreshEnabledState()
+                    self?.synchronizeNow()
+                }
+            })
+        }
+        for name in [Notification.Name.vocabularyStoreDidChange, .personaStoreDidChange] {
+            observers.append(center.addObserver(forName: name, object: nil, queue: .main) { [weak self] _ in
+                Task { @MainActor [weak self] in self?.scheduleLocalPush() }
+            })
+        }
+        for name in [NSApplication.didBecomeActiveNotification, NSWorkspace.didWakeNotification] {
+            observers.append(center.addObserver(forName: name, object: nil, queue: .main) { [weak self] _ in
+                Task { @MainActor [weak self] in self?.synchronizeNow() }
+            })
+        }
+        monitor.pathUpdateHandler = { [weak self] path in
+            guard path.status == .satisfied else { return }
+            Task { @MainActor [weak self] in self?.synchronizeNow() }
+        }
+        monitor.start(queue: monitorQueue)
+    }
+
+    private func refreshEnabledState() {
+        guard let userID = authState.userProfile?.id else {
+            isEnabled = false
+            debounceTask?.cancel()
+            syncTask?.cancel()
+            syncTask = nil
+            isSyncing = false
+            return
+        }
+        isEnabled = store.state(userID: userID).enabled
+    }
+
+    private func startPeriodicSync() {
+        periodicTask = Task { [weak self] in
+            while !Task.isCancelled {
+                try? await Task.sleep(for: .seconds(60))
+                guard !Task.isCancelled else { return }
+                self?.synchronizeNow()
+            }
+        }
+    }
+
+    private func scheduleLocalPush() {
+        guard !applyingRemote, syncContext() != nil else { return }
+        debounceTask?.cancel()
+        debounceTask = Task { [weak self] in
+            try? await Task.sleep(for: .seconds(3))
+            guard !Task.isCancelled else { return }
+            self?.synchronizeNow()
+        }
+    }
+
+    private func syncContext() -> (userID: String, token: String, state: SQLiteCloudDataSyncStore.State)? {
+        guard let userID = authState.userProfile?.id, let token = authState.accessToken else { return nil }
+        let state = store.state(userID: userID)
+        guard state.enabled else { return nil }
+        return (userID, token, state)
+    }
+
+    private func performSync() async {
+        guard var context = syncContext() else { return }
+        isSyncing = true
+        defer { isSyncing = false }
+        do {
+            try stageLocalData(userID: context.userID)
+            var hasMore = true
+            while hasMore, !Task.isCancelled {
+                let pending = store.pending(userID: context.userID)
+                let response = try await CloudDataSyncAPIService.sync(
+                    token: context.token,
+                    request: CloudSyncRequest(
+                        deviceID: Self.deviceID, cursor: context.state.cursor,
+                        ackCursor: context.state.cursor, checkpoint: context.state.checkpoint,
+                        mutations: pending
+                    )
+                )
+                try resolve(results: response.results, mutations: pending, userID: context.userID)
+                try apply(changes: response.changes, userID: context.userID)
+                store.accept(response.results, mutations: pending, userID: context.userID)
+                store.setProgress(userID: context.userID, cursor: response.cursor,
+                                  checkpoint: response.hasMore ? response.checkpoint : 0)
+                context.state.cursor = response.cursor
+                context.state.checkpoint = response.hasMore ? response.checkpoint : 0
+                hasMore = response.hasMore
+            }
+            lastSyncAt = Date()
+            lastError = nil
+        } catch is CancellationError {
+        } catch {
+            lastError = error.localizedDescription
+            Logger(subsystem: "ai.gulu.app.typeflux", category: "CloudDataSync")
+                .error("Sync failed: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    private func stageLocalData(userID: String) throws {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let vocabulary = try Dictionary(uniqueKeysWithValues: VocabularyStore.load().map { entry in
+            (entry.id, try encoder.encode(VocabularyCloudPayload(
+                term: entry.term, source: entry.source.rawValue,
+                createdAt: entry.createdAt, occurrenceCount: entry.occurrenceCount
+            )))
+        })
+        let personas = try Dictionary(
+            uniqueKeysWithValues: settingsStore.personas.filter { !$0.isSystem }.map { persona in
+                (persona.id, try encoder.encode(PersonaCloudPayload(name: persona.name, prompt: persona.prompt)))
+            }
+        )
+        store.stageLocalChanges(userID: userID, type: .vocabulary, entities: vocabulary)
+        store.stageLocalChanges(userID: userID, type: .persona, entities: personas)
+    }
+
+    private func resolve(results: [CloudSyncMutationResult], mutations: [CloudSyncMutation], userID: String) throws {
+        let byID = Dictionary(uniqueKeysWithValues: mutations.map { ($0.mutationID, $0) })
+        for result in results where result.status != "accepted" {
+            guard let mutation = byID[result.mutationID] else { continue }
+            if mutation.entityType == .persona, mutation.operation != "delete" {
+                let payload = try JSONDecoder().decode(PersonaCloudPayload.self, from: mutation.payload)
+                var personas = settingsStore.personas
+                personas.append(PersonaProfile(name: payload.name + " (冲突副本)", prompt: payload.prompt))
+                applyingRemote = true
+                settingsStore.personas = personas
+                applyingRemote = false
+            } else if mutation.entityType == .vocabulary, let current = result.current {
+                try applyVocabulary(id: result.canonicalID, payload: current.data, deleted: false)
+                store.apply(change: CloudSyncChange(
+                    sequence: 0, entityType: .vocabulary, entityID: result.canonicalID,
+                    operation: "update", revision: result.revision, payload: current
+                ), userID: userID)
+            }
+        }
+    }
+
+    private func apply(changes: [CloudSyncChange], userID: String) throws {
+        applyingRemote = true
+        defer { applyingRemote = false }
+        for change in changes {
+            switch change.entityType {
+            case .vocabulary:
+                try applyVocabulary(
+                    id: change.entityID, payload: change.payload.data,
+                    deleted: change.operation == "delete"
+                )
+            case .persona:
+                try applyPersona(
+                    id: change.entityID, payload: change.payload.data,
+                    deleted: change.operation == "delete"
+                )
+            }
+            store.apply(change: change, userID: userID)
+        }
+    }
+
+    private func applyVocabulary(id: UUID, payload: Data, deleted: Bool) throws {
+        var entries = VocabularyStore.load()
+        entries.removeAll { $0.id == id }
+        if !deleted {
+            let value = try JSONDecoder.cloudSyncDates.decode(VocabularyCloudPayload.self, from: payload)
+            entries.removeAll {
+                $0.term.compare(value.term, options: [.caseInsensitive, .widthInsensitive]) == .orderedSame
+            }
+            entries.append(VocabularyEntry(
+                id: id, term: value.term, source: VocabularySource(rawValue: value.source) ?? .manual,
+                createdAt: value.createdAt, occurrenceCount: value.occurrenceCount
+            ))
+        }
+        VocabularyStore.save(entries)
+    }
+
+    private func applyPersona(id: UUID, payload: Data, deleted: Bool) throws {
+        var personas = settingsStore.personas
+        personas.removeAll { $0.id == id && !$0.isSystem }
+        if !deleted {
+            let value = try JSONDecoder().decode(PersonaCloudPayload.self, from: payload)
+            personas.append(PersonaProfile(id: id, name: value.name, prompt: value.prompt))
+        }
+        settingsStore.personas = personas
+    }
+}
+
+private extension JSONDecoder {
+    static var cloudSyncDates: JSONDecoder {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return decoder
+    }
+}

--- a/Sources/Typeflux/Sync/CloudDataSyncModels.swift
+++ b/Sources/Typeflux/Sync/CloudDataSyncModels.swift
@@ -66,7 +66,8 @@ struct CloudSyncMutation: Codable, Equatable {
 }
 
 struct CloudSyncRequest: Encodable {
-    let protocolVersion = 1
+    let protocolVersion = 2
+    let datasetGeneration: Int64
     let deviceID: UUID
     let cursor: Int64
     let ackCursor: Int64
@@ -76,6 +77,7 @@ struct CloudSyncRequest: Encodable {
 
     private enum CodingKeys: String, CodingKey {
         case protocolVersion = "protocol_version"
+        case datasetGeneration = "dataset_generation"
         case deviceID = "device_id"
         case cursor
         case ackCursor = "ack_cursor"
@@ -86,6 +88,10 @@ struct CloudSyncRequest: Encodable {
 }
 
 struct CloudSyncResponse: Decodable {
+    let datasetGeneration: Int64
+    let resetRequired: Bool
+    let resetReason: String?
+    let snapshot: [CloudSyncChange]
     let cursor: Int64
     let checkpoint: Int64
     let hasMore: Bool
@@ -94,7 +100,19 @@ struct CloudSyncResponse: Decodable {
 
     private enum CodingKeys: String, CodingKey {
         case cursor, checkpoint, results, changes
+        case datasetGeneration = "dataset_generation"
+        case resetRequired = "reset_required"
+        case resetReason = "reset_reason"
+        case snapshot
         case hasMore = "has_more"
+    }
+}
+
+struct CloudSyncResetResponse: Decodable {
+    let datasetGeneration: Int64
+
+    private enum CodingKeys: String, CodingKey {
+        case datasetGeneration = "dataset_generation"
     }
 }
 

--- a/Sources/Typeflux/Sync/CloudDataSyncModels.swift
+++ b/Sources/Typeflux/Sync/CloudDataSyncModels.swift
@@ -1,19 +1,28 @@
 import Foundation
 
 enum CloudDataLocalScope {
+    private static let defaultsKey = "cloudDataSync.activeLocalScope"
     private static let lock = NSLock()
-    nonisolated(unsafe) private static var value = "guest"
+    nonisolated(unsafe) private static var value =
+        UserDefaults.standard.string(forKey: defaultsKey) ?? "guest"
 
     static var key: String {
         lock.withLock { value }
     }
 
     static func useGuest() {
-        lock.withLock { value = "guest" }
+        set("guest")
     }
 
     static func useAccount(_ userID: String) {
-        lock.withLock { value = "user.\(userID)" }
+        set("user.\(userID)")
+    }
+
+    private static func set(_ scope: String) {
+        lock.withLock {
+            value = scope
+            UserDefaults.standard.set(scope, forKey: defaultsKey)
+        }
     }
 }
 

--- a/Sources/Typeflux/Sync/CloudDataSyncModels.swift
+++ b/Sources/Typeflux/Sync/CloudDataSyncModels.swift
@@ -1,0 +1,174 @@
+import Foundation
+
+enum CloudSyncEntityType: String, Codable {
+    case vocabulary
+    case persona
+}
+
+struct CloudSyncMutation: Codable, Equatable {
+    let mutationID: UUID
+    let entityType: CloudSyncEntityType
+    let entityID: UUID
+    let operation: String
+    let baseRevision: Int64
+    let payload: Data
+
+    private enum CodingKeys: String, CodingKey {
+        case mutationID = "mutation_id"
+        case entityType = "entity_type"
+        case entityID = "entity_id"
+        case operation
+        case baseRevision = "base_revision"
+        case payload
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(mutationID, forKey: .mutationID)
+        try container.encode(entityType, forKey: .entityType)
+        try container.encode(entityID, forKey: .entityID)
+        try container.encode(operation, forKey: .operation)
+        try container.encode(baseRevision, forKey: .baseRevision)
+        try container.encode(JSONValue(data: payload), forKey: .payload)
+    }
+
+    static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.mutationID == rhs.mutationID && lhs.entityType == rhs.entityType
+            && lhs.entityID == rhs.entityID && lhs.operation == rhs.operation
+            && lhs.baseRevision == rhs.baseRevision && lhs.payload == rhs.payload
+    }
+}
+
+struct CloudSyncRequest: Encodable {
+    let protocolVersion = 1
+    let deviceID: UUID
+    let cursor: Int64
+    let ackCursor: Int64
+    let checkpoint: Int64
+    let limit = 200
+    let mutations: [CloudSyncMutation]
+
+    private enum CodingKeys: String, CodingKey {
+        case protocolVersion = "protocol_version"
+        case deviceID = "device_id"
+        case cursor
+        case ackCursor = "ack_cursor"
+        case checkpoint
+        case limit
+        case mutations
+    }
+}
+
+struct CloudSyncResponse: Decodable {
+    let cursor: Int64
+    let checkpoint: Int64
+    let hasMore: Bool
+    let results: [CloudSyncMutationResult]
+    let changes: [CloudSyncChange]
+
+    private enum CodingKeys: String, CodingKey {
+        case cursor, checkpoint, results, changes
+        case hasMore = "has_more"
+    }
+}
+
+struct CloudSyncMutationResult: Decodable {
+    let mutationID: UUID
+    let status: String
+    let entityID: UUID
+    let canonicalID: UUID
+    let revision: Int64
+    let current: JSONValue?
+
+    private enum CodingKeys: String, CodingKey {
+        case mutationID = "mutation_id"
+        case status
+        case entityID = "entity_id"
+        case canonicalID = "canonical_id"
+        case revision, current
+    }
+}
+
+struct CloudSyncChange: Decodable {
+    let sequence: Int64
+    let entityType: CloudSyncEntityType
+    let entityID: UUID
+    let operation: String
+    let revision: Int64
+    let payload: JSONValue
+
+    private enum CodingKeys: String, CodingKey {
+        case sequence
+        case entityType = "entity_type"
+        case entityID = "entity_id"
+        case operation, revision, payload
+    }
+}
+
+struct VocabularyCloudPayload: Codable {
+    let term: String
+    let source: String
+    let createdAt: Date
+    let occurrenceCount: Int
+
+    private enum CodingKeys: String, CodingKey {
+        case term, source
+        case createdAt = "created_at"
+        case occurrenceCount = "occurrence_count"
+    }
+}
+
+struct PersonaCloudPayload: Codable {
+    let name: String
+    let prompt: String
+}
+
+struct JSONValue: Codable {
+    let data: Data
+
+    init(data: Data) { self.data = data }
+
+    init(from decoder: Decoder) throws {
+        let value = try SyncJSONAny(from: decoder)
+        data = try JSONSerialization.data(withJSONObject: value.value)
+    }
+
+    func encode(to encoder: Encoder) throws {
+        let object = try JSONSerialization.jsonObject(with: data)
+        try SyncJSONAny(object).encode(to: encoder)
+    }
+}
+
+private struct SyncJSONAny: Codable {
+    let value: Any
+    init(_ value: Any) { self.value = value }
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if container.decodeNil() { value = NSNull() }
+        else if let value = try? container.decode(Bool.self) { self.value = value }
+        else if let value = try? container.decode(Int.self) { self.value = value }
+        else if let value = try? container.decode(Double.self) { self.value = value }
+        else if let value = try? container.decode(String.self) { self.value = value }
+        else if let value = try? container.decode([SyncJSONAny].self) { self.value = value.map(\.value) }
+        else if let value = try? container.decode([String: SyncJSONAny].self) {
+            self.value = value.mapValues(\.value)
+        } else { throw DecodingError.dataCorruptedError(in: container, debugDescription: "Invalid JSON") }
+    }
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch value {
+        case is NSNull: try container.encodeNil()
+        case let value as Bool: try container.encode(value)
+        case let value as Int: try container.encode(value)
+        case let value as Double: try container.encode(value)
+        case let value as String: try container.encode(value)
+        case let value as [Any]: try container.encode(value.map(SyncJSONAny.init))
+        case let value as [String: Any]: try container.encode(value.mapValues(SyncJSONAny.init))
+        default:
+            throw EncodingError.invalidValue(
+                value,
+                .init(codingPath: encoder.codingPath, debugDescription: "Invalid JSON")
+            )
+        }
+    }
+}

--- a/Sources/Typeflux/Sync/CloudDataSyncModels.swift
+++ b/Sources/Typeflux/Sync/CloudDataSyncModels.swift
@@ -1,5 +1,22 @@
 import Foundation
 
+enum CloudDataLocalScope {
+    private static let lock = NSLock()
+    nonisolated(unsafe) private static var value = "guest"
+
+    static var key: String {
+        lock.withLock { value }
+    }
+
+    static func useGuest() {
+        lock.withLock { value = "guest" }
+    }
+
+    static func useAccount(_ userID: String) {
+        lock.withLock { value = "user.\(userID)" }
+    }
+}
+
 enum CloudSyncEntityType: String, Codable {
     case vocabulary
     case persona
@@ -79,13 +96,41 @@ struct CloudSyncMutationResult: Decodable {
     let canonicalID: UUID
     let revision: Int64
     let current: JSONValue?
+    let deleted: Bool
+    let message: String?
 
     private enum CodingKeys: String, CodingKey {
         case mutationID = "mutation_id"
         case status
         case entityID = "entity_id"
         case canonicalID = "canonical_id"
-        case revision, current
+        case revision, current, deleted, message
+    }
+
+    init(
+        mutationID: UUID, status: String, entityID: UUID, canonicalID: UUID,
+        revision: Int64, current: JSONValue?, deleted: Bool = false, message: String? = nil
+    ) {
+        self.mutationID = mutationID
+        self.status = status
+        self.entityID = entityID
+        self.canonicalID = canonicalID
+        self.revision = revision
+        self.current = current
+        self.deleted = deleted
+        self.message = message
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        mutationID = try container.decode(UUID.self, forKey: .mutationID)
+        status = try container.decode(String.self, forKey: .status)
+        entityID = try container.decode(UUID.self, forKey: .entityID)
+        canonicalID = try container.decodeIfPresent(UUID.self, forKey: .canonicalID) ?? entityID
+        revision = try container.decodeIfPresent(Int64.self, forKey: .revision) ?? 0
+        current = try container.decodeIfPresent(JSONValue.self, forKey: .current)
+        deleted = try container.decodeIfPresent(Bool.self, forKey: .deleted) ?? false
+        message = try container.decodeIfPresent(String.self, forKey: .message)
     }
 }
 

--- a/Sources/Typeflux/Sync/SQLiteCloudDataSyncStore.swift
+++ b/Sources/Typeflux/Sync/SQLiteCloudDataSyncStore.swift
@@ -12,37 +12,56 @@ final class SQLiteCloudDataSyncStore {
 
     private let queue = DispatchQueue(label: "typeflux.cloud-data-sync.sqlite")
     private var db: OpaquePointer?
+    private(set) var initializationError: Error?
+    var isAvailable: Bool { db != nil && initializationError == nil }
 
     init(baseDirectory: URL? = nil) {
         let directory = baseDirectory ?? FileManager.default.urls(
             for: .applicationSupportDirectory, in: .userDomainMask
         )[0].appendingPathComponent("Typeflux", isDirectory: true)
-        try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        do {
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        } catch {
+            initializationError = error
+            return
+        }
         let url = directory.appendingPathComponent("cloud-sync.sqlite")
-        guard sqlite3_open(url.path, &db) == SQLITE_OK else { return }
-        try? execute("PRAGMA journal_mode=WAL")
-        try? execute("PRAGMA synchronous=NORMAL")
-        try? execute("""
+        guard sqlite3_open(url.path, &db) == SQLITE_OK else {
+            initializationError = databaseError()
+            if let db { sqlite3_close(db) }
+            db = nil
+            return
+        }
+        do {
+            try execute("PRAGMA journal_mode=WAL")
+            try execute("PRAGMA synchronous=NORMAL")
+            try execute("PRAGMA busy_timeout=5000")
+            try execute("""
         CREATE TABLE IF NOT EXISTS sync_accounts(
           user_id TEXT PRIMARY KEY, enabled INTEGER NOT NULL DEFAULT 0,
           cursor INTEGER NOT NULL DEFAULT 0, checkpoint INTEGER NOT NULL DEFAULT 0
         )
         """)
-        try? execute("""
+            try execute("""
         CREATE TABLE IF NOT EXISTS sync_entities(
           user_id TEXT NOT NULL, entity_type TEXT NOT NULL, entity_id TEXT NOT NULL,
           revision INTEGER NOT NULL, payload BLOB NOT NULL, deleted INTEGER NOT NULL DEFAULT 0,
           PRIMARY KEY(user_id,entity_type,entity_id)
         )
         """)
-        try? execute("""
+            try execute("""
         CREATE TABLE IF NOT EXISTS sync_outbox(
           user_id TEXT NOT NULL, mutation_id TEXT PRIMARY KEY, entity_type TEXT NOT NULL,
           entity_id TEXT NOT NULL, operation TEXT NOT NULL, base_revision INTEGER NOT NULL,
           payload BLOB NOT NULL, created_at REAL NOT NULL
         )
         """)
-        try? execute("CREATE INDEX IF NOT EXISTS sync_outbox_user_created ON sync_outbox(user_id,created_at)")
+            try execute("CREATE INDEX IF NOT EXISTS sync_outbox_user_created ON sync_outbox(user_id,created_at)")
+        } catch {
+            initializationError = error
+            if let db { sqlite3_close(db) }
+            db = nil
+        }
     }
 
     deinit { if let db { sqlite3_close(db) } }
@@ -54,6 +73,14 @@ final class SQLiteCloudDataSyncStore {
                 result = State(enabled: row.int(0) != 0, cursor: row.int64(1), checkpoint: row.int64(2))
             }
             return result
+        }
+    }
+
+    func hasAccount(userID: String) -> Bool {
+        queue.sync {
+            var found = false
+            query("SELECT 1 FROM sync_accounts WHERE user_id=? LIMIT 1", [userID]) { _ in found = true }
+            return found
         }
     }
 
@@ -102,9 +129,13 @@ final class SQLiteCloudDataSyncStore {
             let known = knownEntitiesUnsafe(userID: userID, type: type)
             for (id, payload) in entities where known[id]?.payload != payload {
                 let revision = known[id]?.revision ?? 0
+                let mutation = vocabularyIncrement(
+                    type: type, previous: known[id]?.payload, current: payload
+                )
                 upsertOutbox(
                     userID: userID, type: type, id: id,
-                    operation: revision == 0 ? "create" : "update", baseRevision: revision, payload: payload
+                    operation: revision == 0 ? "create" : mutation?.operation ?? "update",
+                    baseRevision: revision, payload: mutation?.payload ?? payload
                 )
             }
             for (id, record) in known where entities[id] == nil {
@@ -138,17 +169,21 @@ final class SQLiteCloudDataSyncStore {
         }
     }
 
-    func accept(_ results: [CloudSyncMutationResult], mutations: [CloudSyncMutation], userID: String) {
+    func accept(
+        _ results: [CloudSyncMutationResult], mutations: [CloudSyncMutation], userID: String,
+        removeRejected: Bool = true
+    ) {
         queue.sync {
             let mutationsByID = Dictionary(uniqueKeysWithValues: mutations.map { ($0.mutationID, $0) })
             for result in results {
                 guard let mutation = mutationsByID[result.mutationID] else { continue }
+                guard result.status == "accepted" || removeRejected else { continue }
                 try? execute(
                     "DELETE FROM sync_outbox WHERE user_id=? AND mutation_id=?",
                     [userID, result.mutationID.uuidString]
                 )
                 guard result.status == "accepted" else { continue }
-                if mutation.operation == "delete" {
+                if mutation.operation == "delete" || result.deleted {
                     try? execute(
                         """
                         UPDATE sync_entities SET revision=?,deleted=1
@@ -157,8 +192,9 @@ final class SQLiteCloudDataSyncStore {
                         [result.revision, userID, mutation.entityType.rawValue, mutation.entityID.uuidString]
                     )
                 } else {
+                    let acceptedPayload = result.current?.data ?? mutation.payload
                     upsertEntity(userID: userID, type: mutation.entityType, id: result.canonicalID,
-                                 revision: result.revision, payload: mutation.payload, deleted: false)
+                                 revision: result.revision, payload: acceptedPayload, deleted: false)
                     if result.canonicalID != mutation.entityID {
                         try? execute("DELETE FROM sync_entities WHERE user_id=? AND entity_type=? AND entity_id=?",
                                      [userID, mutation.entityType.rawValue, mutation.entityID.uuidString])
@@ -166,6 +202,21 @@ final class SQLiteCloudDataSyncStore {
                 }
             }
         }
+    }
+
+    private func vocabularyIncrement(
+        type: CloudSyncEntityType, previous: Data?, current: Data
+    ) -> (operation: String, payload: Data)? {
+        guard type == .vocabulary, let previous,
+              let old = try? JSONDecoder.cloudSyncStore.decode(VocabularyCloudPayload.self, from: previous),
+              let new = try? JSONDecoder.cloudSyncStore.decode(VocabularyCloudPayload.self, from: current),
+              old.term == new.term, old.source == new.source, old.createdAt == new.createdAt,
+              new.occurrenceCount > old.occurrenceCount,
+              let payload = try? JSONSerialization.data(withJSONObject: [
+                  "delta": new.occurrenceCount - old.occurrenceCount
+              ])
+        else { return nil }
+        return ("increment", payload)
     }
 
     func apply(change: CloudSyncChange, userID: String) {
@@ -254,6 +305,14 @@ final class SQLiteCloudDataSyncStore {
     private func databaseError() -> NSError {
         NSError(domain: "CloudDataSyncSQLite", code: Int(sqlite3_errcode(db)),
                 userInfo: [NSLocalizedDescriptionKey: String(cString: sqlite3_errmsg(db))])
+    }
+}
+
+private extension JSONDecoder {
+    static var cloudSyncStore: JSONDecoder {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return decoder
     }
 }
 

--- a/Sources/Typeflux/Sync/SQLiteCloudDataSyncStore.swift
+++ b/Sources/Typeflux/Sync/SQLiteCloudDataSyncStore.swift
@@ -8,6 +8,8 @@ final class SQLiteCloudDataSyncStore {
         var enabled: Bool
         var cursor: Int64
         var checkpoint: Int64
+        var datasetGeneration: Int64
+        var needsReauthorization: Bool
     }
 
     private let queue = DispatchQueue(label: "typeflux.cloud-data-sync.sqlite")
@@ -39,9 +41,19 @@ final class SQLiteCloudDataSyncStore {
             try execute("""
         CREATE TABLE IF NOT EXISTS sync_accounts(
           user_id TEXT PRIMARY KEY, enabled INTEGER NOT NULL DEFAULT 0,
-          cursor INTEGER NOT NULL DEFAULT 0, checkpoint INTEGER NOT NULL DEFAULT 0
+          cursor INTEGER NOT NULL DEFAULT 0, checkpoint INTEGER NOT NULL DEFAULT 0,
+          dataset_generation INTEGER NOT NULL DEFAULT 0,
+          needs_reauthorization INTEGER NOT NULL DEFAULT 0
         )
         """)
+            try addColumnIfMissing(
+                table: "sync_accounts", column: "dataset_generation",
+                definition: "INTEGER NOT NULL DEFAULT 0"
+            )
+            try addColumnIfMissing(
+                table: "sync_accounts", column: "needs_reauthorization",
+                definition: "INTEGER NOT NULL DEFAULT 0"
+            )
             try execute("""
         CREATE TABLE IF NOT EXISTS sync_entities(
           user_id TEXT NOT NULL, entity_type TEXT NOT NULL, entity_id TEXT NOT NULL,
@@ -68,9 +80,18 @@ final class SQLiteCloudDataSyncStore {
 
     func state(userID: String) -> State {
         queue.sync {
-            var result = State(enabled: false, cursor: 0, checkpoint: 0)
-            query("SELECT enabled,cursor,checkpoint FROM sync_accounts WHERE user_id=?", [userID]) { row in
-                result = State(enabled: row.int(0) != 0, cursor: row.int64(1), checkpoint: row.int64(2))
+            var result = State(
+                enabled: false, cursor: 0, checkpoint: 0,
+                datasetGeneration: 0, needsReauthorization: false
+            )
+            query(
+                "SELECT enabled,cursor,checkpoint,dataset_generation,needs_reauthorization FROM sync_accounts WHERE user_id=?",
+                [userID]
+            ) { row in
+                result = State(
+                    enabled: row.int(0) != 0, cursor: row.int64(1), checkpoint: row.int64(2),
+                    datasetGeneration: row.int64(3), needsReauthorization: row.int(4) != 0
+                )
             }
             return result
         }
@@ -84,28 +105,67 @@ final class SQLiteCloudDataSyncStore {
         }
     }
 
-    func setEnabled(_ enabled: Bool, userID: String) {
-        queue.sync {
-            try? execute(
+    func setEnabled(_ enabled: Bool, userID: String) throws {
+        try queue.sync {
+            try execute(
                 """
                 INSERT INTO sync_accounts(user_id,enabled) VALUES(?,?)
-                ON CONFLICT(user_id) DO UPDATE SET enabled=excluded.enabled
+                ON CONFLICT(user_id) DO UPDATE SET
+                  enabled=excluded.enabled,
+                  needs_reauthorization=CASE
+                    WHEN excluded.enabled=1 THEN 0 ELSE sync_accounts.needs_reauthorization
+                  END
                 """,
                 [userID, enabled ? 1 : 0]
             )
         }
     }
 
-    func setProgress(userID: String, cursor: Int64, checkpoint: Int64) {
+    func setProgress(userID: String, cursor: Int64, checkpoint: Int64, datasetGeneration: Int64) {
         queue.sync {
             try? execute(
                 """
-                INSERT INTO sync_accounts(user_id,cursor,checkpoint) VALUES(?,?,?)
+                INSERT INTO sync_accounts(user_id,cursor,checkpoint,dataset_generation) VALUES(?,?,?,?)
                 ON CONFLICT(user_id) DO UPDATE SET
-                  cursor=excluded.cursor,checkpoint=excluded.checkpoint
+                  cursor=excluded.cursor,checkpoint=excluded.checkpoint,
+                  dataset_generation=excluded.dataset_generation
                 """,
-                [userID, cursor, checkpoint]
+                [userID, cursor, checkpoint, datasetGeneration]
             )
+        }
+    }
+
+    func replaceBaseline(
+        userID: String, datasetGeneration: Int64, cursor: Int64,
+        snapshot: [CloudSyncChange]
+    ) throws {
+        try queue.sync {
+            try execute("BEGIN IMMEDIATE")
+            do {
+                try execute("DELETE FROM sync_outbox WHERE user_id=?", [userID])
+                try execute("DELETE FROM sync_entities WHERE user_id=?", [userID])
+                for change in snapshot {
+                    try upsertEntityThrowing(
+                        userID: userID, type: change.entityType, id: change.entityID,
+                        revision: change.revision, payload: change.payload.data, deleted: false
+                    )
+                }
+                try execute(
+                    """
+                    INSERT INTO sync_accounts(
+                      user_id,enabled,cursor,checkpoint,dataset_generation,needs_reauthorization
+                    ) VALUES(?,0,?,0,?,1)
+                    ON CONFLICT(user_id) DO UPDATE SET
+                      enabled=0,cursor=excluded.cursor,checkpoint=0,
+                      dataset_generation=excluded.dataset_generation,needs_reauthorization=1
+                    """,
+                    [userID, cursor, datasetGeneration]
+                )
+                try execute("COMMIT")
+            } catch {
+                try? execute("ROLLBACK")
+                throw error
+            }
         }
     }
 
@@ -257,7 +317,16 @@ final class SQLiteCloudDataSyncStore {
 
     private func upsertEntity(userID: String, type: CloudSyncEntityType, id: UUID,
                               revision: Int64, payload: Data, deleted: Bool) {
-        try? execute(
+        try? upsertEntityThrowing(
+            userID: userID, type: type, id: id, revision: revision, payload: payload, deleted: deleted
+        )
+    }
+
+    private func upsertEntityThrowing(
+        userID: String, type: CloudSyncEntityType, id: UUID,
+        revision: Int64, payload: Data, deleted: Bool
+    ) throws {
+        try execute(
             """
             INSERT INTO sync_entities(user_id,entity_type,entity_id,revision,payload,deleted)
             VALUES(?,?,?,?,?,?)
@@ -266,6 +335,14 @@ final class SQLiteCloudDataSyncStore {
             """,
             [userID, type.rawValue, id.uuidString, revision, payload, deleted ? 1 : 0]
         )
+    }
+
+    private func addColumnIfMissing(table: String, column: String, definition: String) throws {
+        var found = false
+        query("PRAGMA table_info(\(table))", []) { row in
+            if row.string(1) == column { found = true }
+        }
+        if !found { try execute("ALTER TABLE \(table) ADD COLUMN \(column) \(definition)") }
     }
 
     private func execute(_ sql: String, _ values: [Any] = []) throws {

--- a/Sources/Typeflux/Sync/SQLiteCloudDataSyncStore.swift
+++ b/Sources/Typeflux/Sync/SQLiteCloudDataSyncStore.swift
@@ -1,0 +1,269 @@
+import Foundation
+import SQLite3
+
+private let cloudSyncSQLiteTransient = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
+
+final class SQLiteCloudDataSyncStore {
+    struct State {
+        var enabled: Bool
+        var cursor: Int64
+        var checkpoint: Int64
+    }
+
+    private let queue = DispatchQueue(label: "typeflux.cloud-data-sync.sqlite")
+    private var db: OpaquePointer?
+
+    init(baseDirectory: URL? = nil) {
+        let directory = baseDirectory ?? FileManager.default.urls(
+            for: .applicationSupportDirectory, in: .userDomainMask
+        )[0].appendingPathComponent("Typeflux", isDirectory: true)
+        try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let url = directory.appendingPathComponent("cloud-sync.sqlite")
+        guard sqlite3_open(url.path, &db) == SQLITE_OK else { return }
+        try? execute("PRAGMA journal_mode=WAL")
+        try? execute("PRAGMA synchronous=NORMAL")
+        try? execute("""
+        CREATE TABLE IF NOT EXISTS sync_accounts(
+          user_id TEXT PRIMARY KEY, enabled INTEGER NOT NULL DEFAULT 0,
+          cursor INTEGER NOT NULL DEFAULT 0, checkpoint INTEGER NOT NULL DEFAULT 0
+        )
+        """)
+        try? execute("""
+        CREATE TABLE IF NOT EXISTS sync_entities(
+          user_id TEXT NOT NULL, entity_type TEXT NOT NULL, entity_id TEXT NOT NULL,
+          revision INTEGER NOT NULL, payload BLOB NOT NULL, deleted INTEGER NOT NULL DEFAULT 0,
+          PRIMARY KEY(user_id,entity_type,entity_id)
+        )
+        """)
+        try? execute("""
+        CREATE TABLE IF NOT EXISTS sync_outbox(
+          user_id TEXT NOT NULL, mutation_id TEXT PRIMARY KEY, entity_type TEXT NOT NULL,
+          entity_id TEXT NOT NULL, operation TEXT NOT NULL, base_revision INTEGER NOT NULL,
+          payload BLOB NOT NULL, created_at REAL NOT NULL
+        )
+        """)
+        try? execute("CREATE INDEX IF NOT EXISTS sync_outbox_user_created ON sync_outbox(user_id,created_at)")
+    }
+
+    deinit { if let db { sqlite3_close(db) } }
+
+    func state(userID: String) -> State {
+        queue.sync {
+            var result = State(enabled: false, cursor: 0, checkpoint: 0)
+            query("SELECT enabled,cursor,checkpoint FROM sync_accounts WHERE user_id=?", [userID]) { row in
+                result = State(enabled: row.int(0) != 0, cursor: row.int64(1), checkpoint: row.int64(2))
+            }
+            return result
+        }
+    }
+
+    func setEnabled(_ enabled: Bool, userID: String) {
+        queue.sync {
+            try? execute(
+                """
+                INSERT INTO sync_accounts(user_id,enabled) VALUES(?,?)
+                ON CONFLICT(user_id) DO UPDATE SET enabled=excluded.enabled
+                """,
+                [userID, enabled ? 1 : 0]
+            )
+        }
+    }
+
+    func setProgress(userID: String, cursor: Int64, checkpoint: Int64) {
+        queue.sync {
+            try? execute(
+                """
+                INSERT INTO sync_accounts(user_id,cursor,checkpoint) VALUES(?,?,?)
+                ON CONFLICT(user_id) DO UPDATE SET
+                  cursor=excluded.cursor,checkpoint=excluded.checkpoint
+                """,
+                [userID, cursor, checkpoint]
+            )
+        }
+    }
+
+    func knownEntities(userID: String, type: CloudSyncEntityType) -> [UUID: (revision: Int64, payload: Data)] {
+        queue.sync {
+            var result: [UUID: (Int64, Data)] = [:]
+            query(
+                "SELECT entity_id,revision,payload FROM sync_entities WHERE user_id=? AND entity_type=? AND deleted=0",
+                [userID, type.rawValue]
+            ) { row in
+                if let id = UUID(uuidString: row.string(0)), let payload = row.data(2) {
+                    result[id] = (row.int64(1), payload)
+                }
+            }
+            return result
+        }
+    }
+
+    func stageLocalChanges(userID: String, type: CloudSyncEntityType, entities: [UUID: Data]) {
+        queue.sync {
+            let known = knownEntitiesUnsafe(userID: userID, type: type)
+            for (id, payload) in entities where known[id]?.payload != payload {
+                let revision = known[id]?.revision ?? 0
+                upsertOutbox(
+                    userID: userID, type: type, id: id,
+                    operation: revision == 0 ? "create" : "update", baseRevision: revision, payload: payload
+                )
+            }
+            for (id, record) in known where entities[id] == nil {
+                upsertOutbox(
+                    userID: userID, type: type, id: id,
+                    operation: "delete", baseRevision: record.revision, payload: record.payload
+                )
+            }
+        }
+    }
+
+    func pending(userID: String, limit: Int = 100) -> [CloudSyncMutation] {
+        queue.sync {
+            var result: [CloudSyncMutation] = []
+            query(
+                """
+                SELECT mutation_id,entity_type,entity_id,operation,base_revision,payload
+                FROM sync_outbox WHERE user_id=? ORDER BY created_at LIMIT ?
+                """,
+                [userID, limit]
+            ) { row in
+                guard let mutationID = UUID(uuidString: row.string(0)),
+                      let type = CloudSyncEntityType(rawValue: row.string(1)),
+                      let entityID = UUID(uuidString: row.string(2)), let payload = row.data(5) else { return }
+                result.append(CloudSyncMutation(
+                    mutationID: mutationID, entityType: type, entityID: entityID,
+                    operation: row.string(3), baseRevision: row.int64(4), payload: payload
+                ))
+            }
+            return result
+        }
+    }
+
+    func accept(_ results: [CloudSyncMutationResult], mutations: [CloudSyncMutation], userID: String) {
+        queue.sync {
+            let mutationsByID = Dictionary(uniqueKeysWithValues: mutations.map { ($0.mutationID, $0) })
+            for result in results {
+                guard let mutation = mutationsByID[result.mutationID] else { continue }
+                try? execute(
+                    "DELETE FROM sync_outbox WHERE user_id=? AND mutation_id=?",
+                    [userID, result.mutationID.uuidString]
+                )
+                guard result.status == "accepted" else { continue }
+                if mutation.operation == "delete" {
+                    try? execute(
+                        """
+                        UPDATE sync_entities SET revision=?,deleted=1
+                        WHERE user_id=? AND entity_type=? AND entity_id=?
+                        """,
+                        [result.revision, userID, mutation.entityType.rawValue, mutation.entityID.uuidString]
+                    )
+                } else {
+                    upsertEntity(userID: userID, type: mutation.entityType, id: result.canonicalID,
+                                 revision: result.revision, payload: mutation.payload, deleted: false)
+                    if result.canonicalID != mutation.entityID {
+                        try? execute("DELETE FROM sync_entities WHERE user_id=? AND entity_type=? AND entity_id=?",
+                                     [userID, mutation.entityType.rawValue, mutation.entityID.uuidString])
+                    }
+                }
+            }
+        }
+    }
+
+    func apply(change: CloudSyncChange, userID: String) {
+        queue.sync {
+            upsertEntity(userID: userID, type: change.entityType, id: change.entityID,
+                         revision: change.revision, payload: change.payload.data, deleted: change.operation == "delete")
+        }
+    }
+
+    private func knownEntitiesUnsafe(
+        userID: String,
+        type: CloudSyncEntityType
+    ) -> [UUID: (revision: Int64, payload: Data)] {
+        var result: [UUID: (Int64, Data)] = [:]
+        query("SELECT entity_id,revision,payload FROM sync_entities WHERE user_id=? AND entity_type=? AND deleted=0",
+              [userID, type.rawValue]) { row in
+            if let id = UUID(uuidString: row.string(0)), let data = row.data(2) { result[id] = (row.int64(1), data) }
+        }
+        return result
+    }
+
+    private func upsertOutbox(userID: String, type: CloudSyncEntityType, id: UUID,
+                              operation: String, baseRevision: Int64, payload: Data) {
+        try? execute("DELETE FROM sync_outbox WHERE user_id=? AND entity_type=? AND entity_id=?",
+                     [userID, type.rawValue, id.uuidString])
+        try? execute(
+            """
+            INSERT INTO sync_outbox(
+              user_id,mutation_id,entity_type,entity_id,operation,base_revision,payload,created_at
+            ) VALUES(?,?,?,?,?,?,?,?)
+            """,
+            [
+                userID, UUID().uuidString, type.rawValue, id.uuidString,
+                operation, baseRevision, payload, Date().timeIntervalSince1970
+            ]
+        )
+    }
+
+    private func upsertEntity(userID: String, type: CloudSyncEntityType, id: UUID,
+                              revision: Int64, payload: Data, deleted: Bool) {
+        try? execute(
+            """
+            INSERT INTO sync_entities(user_id,entity_type,entity_id,revision,payload,deleted)
+            VALUES(?,?,?,?,?,?)
+            ON CONFLICT(user_id,entity_type,entity_id) DO UPDATE SET
+              revision=excluded.revision,payload=excluded.payload,deleted=excluded.deleted
+            """,
+            [userID, type.rawValue, id.uuidString, revision, payload, deleted ? 1 : 0]
+        )
+    }
+
+    private func execute(_ sql: String, _ values: [Any] = []) throws {
+        var statement: OpaquePointer?
+        defer { sqlite3_finalize(statement) }
+        guard sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK else { throw databaseError() }
+        bind(values, statement)
+        while sqlite3_step(statement) == SQLITE_ROW {}
+        guard sqlite3_errcode(db) == SQLITE_OK || sqlite3_errcode(db) == SQLITE_DONE else { throw databaseError() }
+    }
+
+    private func query(_ sql: String, _ values: [Any], row: (SQLiteRow) -> Void) {
+        var statement: OpaquePointer?
+        defer { sqlite3_finalize(statement) }
+        guard sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK else { return }
+        bind(values, statement)
+        while sqlite3_step(statement) == SQLITE_ROW { row(SQLiteRow(statement: statement!)) }
+    }
+
+    private func bind(_ values: [Any], _ statement: OpaquePointer?) {
+        for (offset, value) in values.enumerated() {
+            let index = Int32(offset + 1)
+            switch value {
+            case let value as String: sqlite3_bind_text(statement, index, value, -1, cloudSyncSQLiteTransient)
+            case let value as Int: sqlite3_bind_int64(statement, index, sqlite3_int64(value))
+            case let value as Int64: sqlite3_bind_int64(statement, index, value)
+            case let value as Double: sqlite3_bind_double(statement, index, value)
+            case let value as Data:
+                _ = value.withUnsafeBytes {
+                    sqlite3_bind_blob(statement, index, $0.baseAddress, Int32(value.count), cloudSyncSQLiteTransient)
+                }
+            default: sqlite3_bind_null(statement, index)
+            }
+        }
+    }
+
+    private func databaseError() -> NSError {
+        NSError(domain: "CloudDataSyncSQLite", code: Int(sqlite3_errcode(db)),
+                userInfo: [NSLocalizedDescriptionKey: String(cString: sqlite3_errmsg(db))])
+    }
+}
+
+private struct SQLiteRow {
+    let statement: OpaquePointer
+    func int(_ index: Int32) -> Int { Int(sqlite3_column_int64(statement, index)) }
+    func int64(_ index: Int32) -> Int64 { sqlite3_column_int64(statement, index) }
+    func string(_ index: Int32) -> String { String(cString: sqlite3_column_text(statement, index)) }
+    func data(_ index: Int32) -> Data? {
+        guard let bytes = sqlite3_column_blob(statement, index) else { return nil }
+        return Data(bytes: bytes, count: Int(sqlite3_column_bytes(statement, index)))
+    }
+}

--- a/Tests/TypefluxTests/CloudDataSyncAPIServiceTests.swift
+++ b/Tests/TypefluxTests/CloudDataSyncAPIServiceTests.swift
@@ -10,11 +10,12 @@ final class CloudDataSyncAPIServiceTests: XCTestCase {
             XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer token-1")
             let body = try XCTUnwrap(request.httpBody)
             let object = try XCTUnwrap(JSONSerialization.jsonObject(with: body) as? [String: Any])
-            XCTAssertEqual(object["protocol_version"] as? Int, 1)
+            XCTAssertEqual(object["protocol_version"] as? Int, 2)
+            XCTAssertEqual(object["dataset_generation"] as? Int, 3)
             XCTAssertEqual(object["device_id"] as? String, "33333333-3333-4333-8333-333333333333")
             return (
                 Data(
-                    #"{"code":"OK","data":{"cursor":4,"checkpoint":4,"has_more":false,"results":[],"changes":[]}}"#.utf8
+                    #"{"code":"OK","data":{"dataset_generation":3,"reset_required":false,"snapshot":[],"cursor":4,"checkpoint":4,"has_more":false,"results":[],"changes":[]}}"#.utf8
                 ),
                 HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
             )
@@ -29,12 +30,34 @@ final class CloudDataSyncAPIServiceTests: XCTestCase {
         let response = try await service.sync(
             token: "token-1",
             request: CloudSyncRequest(
+                datasetGeneration: 3,
                 deviceID: UUID(uuidString: "33333333-3333-4333-8333-333333333333")!,
                 cursor: 0, ackCursor: 0, checkpoint: 0, mutations: []
             )
         )
         XCTAssertEqual(response.cursor, 4)
         XCTAssertFalse(response.hasMore)
+    }
+
+    func testResetBuildsDeleteRequestAndDecodesGeneration() async throws {
+        let session = CloudDataSyncStubSession()
+        await session.setHandler { request in
+            XCTAssertEqual(request.url?.path, "/api/v1/sync")
+            XCTAssertEqual(request.httpMethod, "DELETE")
+            XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer token-1")
+            return (
+                Data(#"{"code":"OK","data":{"dataset_generation":5}}"#.utf8),
+                HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            )
+        }
+        let selector = CloudEndpointSelector(
+            baseURLs: [URL(string: "https://api.example")!], prober: CloudDataSyncNoOpProber()
+        )
+        let service = CloudDataSyncAPIService(
+            executor: CloudRequestExecutor(selector: selector, session: session)
+        )
+        let response = try await service.reset(token: "token-1")
+        XCTAssertEqual(response.datasetGeneration, 5)
     }
 }
 

--- a/Tests/TypefluxTests/CloudDataSyncAPIServiceTests.swift
+++ b/Tests/TypefluxTests/CloudDataSyncAPIServiceTests.swift
@@ -1,0 +1,55 @@
+@testable import Typeflux
+import XCTest
+
+final class CloudDataSyncAPIServiceTests: XCTestCase {
+    func testSyncBuildsAuthenticatedRequestAndDecodesResponse() async throws {
+        let session = CloudDataSyncStubSession()
+        await session.setHandler { request in
+            XCTAssertEqual(request.url?.path, "/api/v1/sync")
+            XCTAssertEqual(request.httpMethod, "POST")
+            XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer token-1")
+            let body = try XCTUnwrap(request.httpBody)
+            let object = try XCTUnwrap(JSONSerialization.jsonObject(with: body) as? [String: Any])
+            XCTAssertEqual(object["protocol_version"] as? Int, 1)
+            XCTAssertEqual(object["device_id"] as? String, "33333333-3333-4333-8333-333333333333")
+            return (
+                Data(
+                    #"{"code":"OK","data":{"cursor":4,"checkpoint":4,"has_more":false,"results":[],"changes":[]}}"#.utf8
+                ),
+                HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            )
+        }
+        let selector = CloudEndpointSelector(
+            baseURLs: [URL(string: "https://api.example")!], prober: CloudDataSyncNoOpProber()
+        )
+        let service = CloudDataSyncAPIService(
+            executor: CloudRequestExecutor(selector: selector, session: session)
+        )
+
+        let response = try await service.sync(
+            token: "token-1",
+            request: CloudSyncRequest(
+                deviceID: UUID(uuidString: "33333333-3333-4333-8333-333333333333")!,
+                cursor: 0, ackCursor: 0, checkpoint: 0, mutations: []
+            )
+        )
+        XCTAssertEqual(response.cursor, 4)
+        XCTAssertFalse(response.hasMore)
+    }
+}
+
+private actor CloudDataSyncStubSession: CloudHTTPSession {
+    typealias Handler = @Sendable (URLRequest) async throws -> (Data, URLResponse)
+    private var handler: Handler?
+    func setHandler(_ handler: @escaping Handler) { self.handler = handler }
+    func data(for request: URLRequest) async throws -> (Data, URLResponse) {
+        guard let handler else { throw URLError(.badServerResponse) }
+        return try await handler(request)
+    }
+}
+
+private struct CloudDataSyncNoOpProber: CloudEndpointProbing {
+    func probe(baseURL _: URL, nonce _: String, timeout _: TimeInterval) async throws -> CloudEndpointProbeResult {
+        CloudEndpointProbeResult(latencyMs: 1, serverID: nil, serverVersion: nil, nonceMatches: true)
+    }
+}

--- a/Tests/TypefluxTests/SQLiteCloudDataSyncStoreTests.swift
+++ b/Tests/TypefluxTests/SQLiteCloudDataSyncStoreTests.swift
@@ -1,0 +1,58 @@
+import Foundation
+import Testing
+@testable import Typeflux
+
+struct SQLiteCloudDataSyncStoreTests {
+    @Test func consentDefaultsOffAndIsScopedByAccount() throws {
+        let directory = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let store = SQLiteCloudDataSyncStore(baseDirectory: directory)
+
+        #expect(store.state(userID: "user-a").enabled == false)
+        store.setEnabled(true, userID: "user-a")
+        #expect(store.state(userID: "user-a").enabled == true)
+        #expect(store.state(userID: "user-b").enabled == false)
+    }
+
+    @Test func localChangesBecomeCreateUpdateAndDeleteMutations() throws {
+        let directory = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let store = SQLiteCloudDataSyncStore(baseDirectory: directory)
+        let userID = "user-a"
+        let entityID = UUID()
+        let first = Data(#"{"term":"Typeflux"}"#.utf8)
+        let second = Data(#"{"term":"Typeflux AI"}"#.utf8)
+
+        store.stageLocalChanges(userID: userID, type: .vocabulary, entities: [entityID: first])
+        let create = try #require(store.pending(userID: userID).first)
+        #expect(create.operation == "create")
+        #expect(create.baseRevision == 0)
+
+        let accepted = CloudSyncMutationResult(
+            mutationID: create.mutationID, status: "accepted", entityID: entityID,
+            canonicalID: entityID, revision: 1, current: nil
+        )
+        store.accept([accepted], mutations: [create], userID: userID)
+        store.stageLocalChanges(userID: userID, type: .vocabulary, entities: [entityID: second])
+        let update = try #require(store.pending(userID: userID).first)
+        #expect(update.operation == "update")
+        #expect(update.baseRevision == 1)
+
+        store.accept([
+            CloudSyncMutationResult(
+                mutationID: update.mutationID, status: "accepted", entityID: entityID,
+                canonicalID: entityID, revision: 2, current: nil
+            )
+        ], mutations: [update], userID: userID)
+        store.stageLocalChanges(userID: userID, type: .vocabulary, entities: [:])
+        let delete = try #require(store.pending(userID: userID).first)
+        #expect(delete.operation == "delete")
+        #expect(delete.baseRevision == 2)
+    }
+
+    private func temporaryDirectory() throws -> URL {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+}

--- a/Tests/TypefluxTests/SQLiteCloudDataSyncStoreTests.swift
+++ b/Tests/TypefluxTests/SQLiteCloudDataSyncStoreTests.swift
@@ -9,9 +9,40 @@ struct SQLiteCloudDataSyncStoreTests {
         let store = SQLiteCloudDataSyncStore(baseDirectory: directory)
 
         #expect(store.state(userID: "user-a").enabled == false)
-        store.setEnabled(true, userID: "user-a")
+        try store.setEnabled(true, userID: "user-a")
         #expect(store.state(userID: "user-a").enabled == true)
         #expect(store.state(userID: "user-b").enabled == false)
+    }
+
+    @Test func resetBaselineDropsStaleOutboxAndRequiresNewConsent() throws {
+        let directory = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let store = SQLiteCloudDataSyncStore(baseDirectory: directory)
+        let localID = UUID()
+        let cloudID = UUID()
+        try store.setEnabled(true, userID: "u")
+        store.stageLocalChanges(
+            userID: "u", type: .persona,
+            entities: [localID: Data(#"{"name":"Local","prompt":"draft"}"#.utf8)]
+        )
+        let snapshot = [CloudSyncChange(
+            sequence: 42, entityType: .persona, entityID: cloudID, operation: "create",
+            revision: 7, payload: JSONValue(data: Data(#"{"name":"Cloud","prompt":"latest"}"#.utf8))
+        )]
+
+        try store.replaceBaseline(userID: "u", datasetGeneration: 4, cursor: 42, snapshot: snapshot)
+
+        let state = store.state(userID: "u")
+        #expect(state.enabled == false)
+        #expect(state.needsReauthorization == true)
+        #expect(state.datasetGeneration == 4)
+        #expect(state.cursor == 42)
+        #expect(store.pending(userID: "u").isEmpty)
+        #expect(store.knownEntities(userID: "u", type: .persona)[localID] == nil)
+        #expect(store.knownEntities(userID: "u", type: .persona)[cloudID]?.revision == 7)
+
+        try store.setEnabled(true, userID: "u")
+        #expect(store.state(userID: "u").needsReauthorization == false)
     }
 
     @Test func localChangesBecomeCreateUpdateAndDeleteMutations() throws {

--- a/Tests/TypefluxTests/SQLiteCloudDataSyncStoreTests.swift
+++ b/Tests/TypefluxTests/SQLiteCloudDataSyncStoreTests.swift
@@ -50,6 +50,85 @@ struct SQLiteCloudDataSyncStoreTests {
         #expect(delete.baseRevision == 2)
     }
 
+    @Test func occurrenceOnlyChangeUsesIncrementAndStoresServerCurrent() throws {
+        let directory = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let store = SQLiteCloudDataSyncStore(baseDirectory: directory)
+        let userID = "user-a"
+        let entityID = UUID()
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let createdAt = Date(timeIntervalSince1970: 1_700_000_000)
+        let first = try encoder.encode(VocabularyCloudPayload(
+            term: "Typeflux", source: "manual", createdAt: createdAt, occurrenceCount: 2
+        ))
+        let current = try encoder.encode(VocabularyCloudPayload(
+            term: "Typeflux", source: "manual", createdAt: createdAt, occurrenceCount: 5
+        ))
+
+        store.stageLocalChanges(userID: userID, type: .vocabulary, entities: [entityID: first])
+        let create = try #require(store.pending(userID: userID).first)
+        store.accept([
+            CloudSyncMutationResult(
+                mutationID: create.mutationID, status: "accepted", entityID: entityID,
+                canonicalID: entityID, revision: 1, current: JSONValue(data: first)
+            )
+        ], mutations: [create], userID: userID)
+
+        store.stageLocalChanges(userID: userID, type: .vocabulary, entities: [entityID: current])
+        let increment = try #require(store.pending(userID: userID).first)
+        #expect(increment.operation == "increment")
+        #expect(String(decoding: increment.payload, as: UTF8.self).contains("3"))
+        store.accept([
+            CloudSyncMutationResult(
+                mutationID: increment.mutationID, status: "accepted", entityID: entityID,
+                canonicalID: entityID, revision: 2, current: JSONValue(data: current)
+            )
+        ], mutations: [increment], userID: userID)
+        #expect(store.knownEntities(userID: userID, type: .vocabulary)[entityID]?.payload == current)
+    }
+
+    @Test func acceptedCanonicalEntityUsesServerPayload() throws {
+        let directory = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let store = SQLiteCloudDataSyncStore(baseDirectory: directory)
+        let localID = UUID()
+        let canonicalID = UUID()
+        let local = Data(#"{"term":"typeflux","occurrence_count":1}"#.utf8)
+        let server = Data(#"{"term":"Typeflux","occurrence_count":8}"#.utf8)
+        store.stageLocalChanges(userID: "u", type: .vocabulary, entities: [localID: local])
+        let mutation = try #require(store.pending(userID: "u").first)
+        store.accept([
+            CloudSyncMutationResult(
+                mutationID: mutation.mutationID, status: "accepted", entityID: localID,
+                canonicalID: canonicalID, revision: 4, current: JSONValue(data: server)
+            )
+        ], mutations: [mutation], userID: "u")
+
+        let entities = store.knownEntities(userID: "u", type: .vocabulary)
+        #expect(entities[localID] == nil)
+        #expect(entities[canonicalID]?.payload == server)
+    }
+
+    @Test func rejectedMutationCanBeRetainedWhenLocalEditArrivesInFlight() throws {
+        let directory = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let store = SQLiteCloudDataSyncStore(baseDirectory: directory)
+        let entityID = UUID()
+        let payload = Data(#"{"name":"Local","prompt":"draft"}"#.utf8)
+        store.stageLocalChanges(userID: "u", type: .persona, entities: [entityID: payload])
+        let mutation = try #require(store.pending(userID: "u").first)
+
+        store.accept([
+            CloudSyncMutationResult(
+                mutationID: mutation.mutationID, status: "conflict", entityID: entityID,
+                canonicalID: entityID, revision: 2, current: nil
+            )
+        ], mutations: [mutation], userID: "u", removeRejected: false)
+
+        #expect(store.pending(userID: "u").map(\.mutationID) == [mutation.mutationID])
+    }
+
     private func temporaryDirectory() throws -> URL {
         let url = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
         try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)

--- a/Tests/TypefluxTests/VocabularyStoreTests.swift
+++ b/Tests/TypefluxTests/VocabularyStoreTests.swift
@@ -109,6 +109,26 @@ final class VocabularyStoreTests: XCTestCase {
         CloudDataLocalScope.useAccount("test-user")
         XCTAssertEqual(VocabularyStore.load().map(\.term), ["AccountOnly"])
     }
+
+    func testPersonasAreIsolatedBetweenGuestAndAccountScopes() {
+        let suiteName = "VocabularyStoreTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let store = SettingsStore(defaults: defaults)
+        let guest = PersonaProfile(name: "Guest", prompt: "guest")
+        let account = PersonaProfile(name: "Account", prompt: "account")
+
+        CloudDataLocalScope.useGuest()
+        store.personas = [guest]
+        CloudDataLocalScope.useAccount("test-user")
+        XCTAssertTrue(store.personas.filter { !$0.isSystem }.isEmpty)
+        store.personas = [account]
+
+        CloudDataLocalScope.useGuest()
+        XCTAssertEqual(store.personas.filter { !$0.isSystem }.map(\.id), [guest.id])
+        CloudDataLocalScope.useAccount("test-user")
+        XCTAssertEqual(store.personas.filter { !$0.isSystem }.map(\.id), [account.id])
+    }
 }
 
 private final class InMemoryHistoryStore: HistoryStore {

--- a/Tests/TypefluxTests/VocabularyStoreTests.swift
+++ b/Tests/TypefluxTests/VocabularyStoreTests.swift
@@ -5,11 +5,16 @@ import XCTest
 final class VocabularyStoreTests: XCTestCase {
     override func setUp() {
         super.setUp()
+        CloudDataLocalScope.useGuest()
         UserDefaults.standard.removeObject(forKey: "vocabulary.entries")
+        UserDefaults.standard.removeObject(forKey: "vocabulary.entries.guest")
     }
 
     override func tearDown() {
+        CloudDataLocalScope.useGuest()
         UserDefaults.standard.removeObject(forKey: "vocabulary.entries")
+        UserDefaults.standard.removeObject(forKey: "vocabulary.entries.guest")
+        UserDefaults.standard.removeObject(forKey: "vocabulary.entries.user.test-user")
         super.tearDown()
     }
 
@@ -91,6 +96,19 @@ final class VocabularyStoreTests: XCTestCase {
 
         XCTAssertEqual(viewModel.filteredVocabularyEntries.map(\.term), ["Alpha", "beta", "zeta"])
     }
+
+    func testVocabularyIsIsolatedBetweenGuestAndAccountScopes() {
+        VocabularyStore.save([VocabularyEntry(term: "GuestOnly", source: .manual)])
+
+        CloudDataLocalScope.useAccount("test-user")
+        XCTAssertTrue(VocabularyStore.load().isEmpty)
+        VocabularyStore.save([VocabularyEntry(term: "AccountOnly", source: .manual)])
+
+        CloudDataLocalScope.useGuest()
+        XCTAssertEqual(VocabularyStore.load().map(\.term), ["GuestOnly"])
+        CloudDataLocalScope.useAccount("test-user")
+        XCTAssertEqual(VocabularyStore.load().map(\.term), ["AccountOnly"])
+    }
 }
 
 private final class InMemoryHistoryStore: HistoryStore {
@@ -118,15 +136,19 @@ private final class InMemoryHistoryStore: HistoryStore {
 // MARK: - Extended VocabularyStore tests
 
 final class VocabularyStoreExtendedTests: XCTestCase {
-    private let defaultsKey = "vocabulary.entries"
+    private let defaultsKey = "vocabulary.entries.guest"
 
     override func setUp() {
         super.setUp()
+        CloudDataLocalScope.useGuest()
+        UserDefaults.standard.removeObject(forKey: "vocabulary.entries")
         UserDefaults.standard.removeObject(forKey: defaultsKey)
     }
 
     override func tearDown() {
+        CloudDataLocalScope.useGuest()
         UserDefaults.standard.removeObject(forKey: defaultsKey)
+        UserDefaults.standard.removeObject(forKey: "vocabulary.entries")
         super.tearDown()
     }
 


### PR DESCRIPTION
## Summary

- add an account-and-device scoped cloud sync setting that remains off until explicit user consent
- sync only custom vocabulary and custom personas using a durable SQLite outbox and local-first materialized data
- upload after a 3-second debounce; pull every 60 seconds and immediately on enable, login, foreground, wake, network recovery, or manual action
- preserve offline edits, canonicalize vocabulary conflicts, create persona conflict copies, and stop in-flight work on disable/logout
- add localized consent/status UI and synchronization storage/API tests

## Verification

- `swift test --disable-automatic-resolution` — 2,388 tests passed
- focused sync/API/persona tests — 20 tests passed
- SwiftLint was unavailable in the runtime; `git diff --check` and Swift compilation passed

Depends on https://github.com/mylxsw/typeflux-api/pull/59.

Closes GUL-57.
