### PR TITLE
GUL-61: add analytics privacy controls

### DIFF
--- a/Sources/Typeflux/Analytics/AppAnalyticsReporter.swift
+++ b/Sources/Typeflux/Analytics/AppAnalyticsReporter.swift
@@ -1,4 +1,5 @@
 import Foundation
+import os
 
 protocol AnalyticsEventReporting: AnyObject, Sendable {
     func report(eventName: String, properties: [String: String])
@@ -10,6 +11,75 @@ final class NoopAnalyticsEventReporter: AnalyticsEventReporting, @unchecked Send
     private init() {}
     func report(eventName _: String, properties _: [String: String]) {}
     func reportFirstOpenIfNeeded() {}
+}
+
+enum AnalyticsPropertyKeys {
+    static let appVersion = "app_version"
+    static let osName = "os_name"
+    static let osVersion = "os_version"
+    static let locale = "locale"
+    static let sessionID = "session_id"
+
+    static let allowedEventProperties: Set<String> = [
+        "attempt_id", "job_id", "model_kind", "model_type", "model_identifier",
+        "download_source", "source_host", "normalized_path", "retry_index",
+        "duration_ms", "job_duration_ms", "status", "error_category"
+    ]
+}
+
+final class SettingsAwareAnalyticsEventReporter: AnalyticsEventReporting, @unchecked Sendable {
+    private let settingsStore: SettingsStore
+    private let reporter: AppAnalyticsReporter
+    private let lock = NSLock()
+    private var isEnabled: Bool
+    private var settingsObserver: NSObjectProtocol?
+
+    init(
+        settingsStore: SettingsStore,
+        reporter: AppAnalyticsReporter? = nil
+    ) {
+        self.settingsStore = settingsStore
+        self.reporter = reporter ?? AppAnalyticsReporter(defaults: settingsStore.defaults)
+        isEnabled = settingsStore.analyticsSharingEnabled
+        self.reporter.setEnabled(isEnabled)
+        settingsObserver = NotificationCenter.default.addObserver(
+            forName: .analyticsSharingDidChange,
+            object: settingsStore.defaults,
+            queue: nil
+        ) { [weak self] _ in
+            self?.refreshEnabledState()
+        }
+    }
+
+    deinit {
+        if let settingsObserver { NotificationCenter.default.removeObserver(settingsObserver) }
+    }
+
+    func report(eventName: String, properties: [String: String]) {
+        activeReporter().report(eventName: eventName, properties: properties)
+    }
+
+    func reportFirstOpenIfNeeded() {
+        activeReporter().reportFirstOpenIfNeeded()
+    }
+
+    private func activeReporter() -> AnalyticsEventReporting {
+        refreshEnabledState()
+        return lock.withLock {
+            if isEnabled { return reporter }
+            return NoopAnalyticsEventReporter.shared
+        }
+    }
+
+    private func refreshEnabledState() {
+        let nextValue = settingsStore.analyticsSharingEnabled
+        let changed = lock.withLock { () -> Bool in
+            guard isEnabled != nextValue else { return false }
+            isEnabled = nextValue
+            return true
+        }
+        if changed { reporter.setEnabled(nextValue) }
+    }
 }
 
 struct AppAnalyticsEvent: Codable, Equatable, Sendable {
@@ -107,6 +177,7 @@ struct URLSessionAppAnalyticsTransport: AppAnalyticsTransporting {
 }
 
 final class AppAnalyticsReporter: AnalyticsEventReporting, @unchecked Sendable {
+    private static let logger = Logger(subsystem: "ai.gulu.app.typeflux", category: "AppAnalyticsReporter")
     private let defaults: UserDefaults
     private let transport: AppAnalyticsTransporting
     private let clientInfoProvider: TypefluxCloudClientInfoProvider
@@ -116,8 +187,12 @@ final class AppAnalyticsReporter: AnalyticsEventReporting, @unchecked Sendable {
     private let firstOpenKey: String
     private let maximumQueueSize: Int
     private let retryDelay: Duration
+    private let sessionID: String
+    private var isEnabled = true
+    private var generation = 0
     private var isFlushing = false
     private var retryTask: Task<Void, Never>?
+    private var flushTask: Task<Void, Never>?
 
     init(
         defaults: UserDefaults = .standard,
@@ -127,6 +202,7 @@ final class AppAnalyticsReporter: AnalyticsEventReporting, @unchecked Sendable {
         firstOpenKey: String = "analytics.firstOpenReported",
         maximumQueueSize: Int = 100,
         retryDelay: Duration = .seconds(30),
+        sessionID: String = UUID().uuidString.lowercased(),
         now: @escaping @Sendable () -> Date = { Date() }
     ) {
         self.defaults = defaults
@@ -136,11 +212,29 @@ final class AppAnalyticsReporter: AnalyticsEventReporting, @unchecked Sendable {
         self.firstOpenKey = firstOpenKey
         self.maximumQueueSize = maximumQueueSize
         self.retryDelay = retryDelay
+        self.sessionID = sessionID
         self.now = now
+    }
+
+    func setEnabled(_ enabled: Bool) {
+        lock.withLock {
+            guard isEnabled != enabled else { return }
+            isEnabled = enabled
+            generation += 1
+            guard !enabled else { return }
+            retryTask?.cancel()
+            retryTask = nil
+            flushTask?.cancel()
+            flushTask = nil
+            isFlushing = false
+            defaults.removeObject(forKey: queueKey)
+        }
+        if enabled { flush() }
     }
 
     func reportFirstOpenIfNeeded() {
         lock.withLock {
+            guard isEnabled else { return }
             guard !defaults.bool(forKey: firstOpenKey) else { return }
             appendToQueue(makeEvent(eventName: "app_first_open", properties: clientProperties()))
             defaults.set(true, forKey: firstOpenKey)
@@ -149,31 +243,44 @@ final class AppAnalyticsReporter: AnalyticsEventReporting, @unchecked Sendable {
     }
 
     func report(eventName: String, properties: [String: String] = [:]) {
-        lock.withLock { appendToQueue(makeEvent(eventName: eventName, properties: properties)) }
+        let filteredProperties = properties.filter { key, _ in
+            let allowed = AnalyticsPropertyKeys.allowedEventProperties.contains(key)
+            if !allowed { Self.logger.debug("Dropping non-allowlisted analytics property: \(key, privacy: .public)") }
+            return allowed
+        }
+        lock.withLock {
+            guard isEnabled else { return }
+            appendToQueue(makeEvent(eventName: eventName, properties: filteredProperties))
+        }
         flush()
     }
 
     func flush() {
-        let events = lock.withLock { () -> [AppAnalyticsEvent] in
-            guard !isFlushing else { return [] }
+        let pending = lock.withLock { () -> (events: [AppAnalyticsEvent], generation: Int)? in
+            guard isEnabled, !isFlushing else { return nil }
             let events = loadQueue()
-            guard !events.isEmpty else { return [] }
+            guard !events.isEmpty else { return nil }
             isFlushing = true
-            return Array(events.prefix(20))
+            return (Array(events.prefix(20)), generation)
         }
-        guard !events.isEmpty else { return }
-        Task { [weak self] in
+        guard let pending else { return }
+        let events = pending.events
+        let flushGeneration = pending.generation
+        let task = Task { [weak self] in
             guard let self else { return }
             do {
                 try await transport.send(events: events)
                 let sentIDs = Set(events.map(\.eventID))
-                self.lock.withLock {
+                let shouldContinue = self.lock.withLock { () -> Bool in
+                    guard self.isEnabled, self.generation == flushGeneration else { return false }
                     self.saveQueue(self.loadQueue().filter { !sentIDs.contains($0.eventID) })
                     self.isFlushing = false
+                    self.flushTask = nil
                     self.retryTask?.cancel()
                     self.retryTask = nil
+                    return true
                 }
-                self.flush()
+                if shouldContinue { self.flush() }
             } catch AppAnalyticsTransportError.permanent {
                 var terminalIDs = Set<String>()
                 var hasTransientFailure = false
@@ -188,15 +295,27 @@ final class AppAnalyticsReporter: AnalyticsEventReporting, @unchecked Sendable {
                         break
                     }
                 }
-                self.lock.withLock {
+                let shouldContinue = self.lock.withLock { () -> Bool in
+                    guard self.isEnabled, self.generation == flushGeneration else { return false }
                     self.saveQueue(self.loadQueue().filter { !terminalIDs.contains($0.eventID) })
                     self.isFlushing = false
+                    self.flushTask = nil
+                    return true
                 }
+                guard shouldContinue else { return }
                 if hasTransientFailure { self.scheduleRetry() } else { self.flush() }
             } catch {
-                self.lock.withLock { self.isFlushing = false }
-                self.scheduleRetry()
+                let shouldRetry = self.lock.withLock { () -> Bool in
+                    guard self.isEnabled, self.generation == flushGeneration else { return false }
+                    self.isFlushing = false
+                    self.flushTask = nil
+                    return true
+                }
+                if shouldRetry { self.scheduleRetry() }
             }
+        }
+        lock.withLock {
+            if isEnabled, isFlushing, generation == flushGeneration { flushTask = task } else { task.cancel() }
         }
     }
 
@@ -225,7 +344,7 @@ final class AppAnalyticsReporter: AnalyticsEventReporting, @unchecked Sendable {
     private func scheduleRetry() {
         let delay = retryDelay
         lock.withLock {
-            guard retryTask == nil else { return }
+            guard isEnabled, retryTask == nil else { return }
             retryTask = Task { [weak self] in
                 try? await Task.sleep(for: delay)
                 guard let self, !Task.isCancelled else { return }
@@ -237,8 +356,13 @@ final class AppAnalyticsReporter: AnalyticsEventReporting, @unchecked Sendable {
 
     private func clientProperties() -> [String: String] {
         let info = clientInfoProvider.info()
-        return ["app_version": info.appVersion, "os_name": info.osName, "os_version": info.osVersion,
-                "locale": info.localeIdentifier]
+        return [
+            AnalyticsPropertyKeys.appVersion: info.appVersion,
+            AnalyticsPropertyKeys.osName: info.osName,
+            AnalyticsPropertyKeys.osVersion: info.osVersion,
+            AnalyticsPropertyKeys.locale: info.localeIdentifier,
+            AnalyticsPropertyKeys.sessionID: sessionID
+        ]
     }
 
     private func loadQueue() -> [AppAnalyticsEvent] {

--- a/Sources/Typeflux/App/DIContainer.swift
+++ b/Sources/Typeflux/App/DIContainer.swift
@@ -25,7 +25,7 @@ final class DIContainer {
     let localModelManager: LocalModelManager
     let bundledModelAutoSetup: BundledModelAutoSetup
     let autoModelDownloadService: AutoModelDownloadService
-    let analyticsReporter: AppAnalyticsReporter
+    let analyticsReporter: AnalyticsEventReporting
     let agentJobStore: AgentJobStore
     let agentExecutionRegistry: AgentExecutionRegistry
     let agentJobsWindowController: AgentJobsWindowController
@@ -62,7 +62,7 @@ final class DIContainer {
             executionRegistry: agentExecutionRegistry
         )
         mcpRegistry = MCPRegistry()
-        analyticsReporter = AppAnalyticsReporter()
+        analyticsReporter = SettingsAwareAnalyticsEventReporter(settingsStore: settingsStore)
         ollamaModelManager = OllamaLocalModelManager(analyticsReporter: analyticsReporter)
         llmAgentService = LLMAgentRouter(
             settingsStore: settingsStore,

--- a/Sources/Typeflux/Resources/en.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/en.lproj/Localizable.strings
@@ -153,6 +153,8 @@
 "settings.advanced.soundEffects.subtitle" = "Play start, done, and error sounds during recording workflow feedback.";
 "settings.advanced.autoUpdate.title" = "Automatic Updates";
 "settings.advanced.autoUpdate.subtitle" = "Automatically check for and install updates every 3 hours.";
+"settings.analyticsSharing.title" = "Share anonymous usage analytics";
+"settings.analyticsSharing.subtitle" = "Help improve Typeflux by sharing anonymous app and model download events. Voice and text content is never collected.";
 "settings.permissionStatus.title" = "Permission Status";
 "settings.permissionStatus.subtitle" = "Review the macOS permissions Typeflux depends on, then grant access where needed.";
 

--- a/Sources/Typeflux/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/ja.lproj/Localizable.strings
@@ -153,6 +153,8 @@
 "settings.advanced.soundEffects.subtitle" = "ワークフローのフィードバックの記録中に、開始音、完了音、エラー音を再生します。";
 "settings.advanced.autoUpdate.title" = "自動アップデート";
 "settings.advanced.autoUpdate.subtitle" = "3 時間ごとに自動的に新しいバージョンを確認してインストールします。";
+"settings.analyticsSharing.title" = "匿名の使用状況分析を共有";
+"settings.analyticsSharing.subtitle" = "匿名のアプリおよびモデルダウンロードイベントを共有し、Typeflux の改善に役立てます。音声やテキストの内容は収集されません。";
 "settings.permissionStatus.title" = "許可ステータス";
 "settings.permissionStatus.subtitle" = "Typeflux が依存する macOS 権限を確認し、必要に応じてアクセスを許可します。";
 

--- a/Sources/Typeflux/Resources/ko.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/ko.lproj/Localizable.strings
@@ -153,6 +153,8 @@
 "settings.advanced.soundEffects.subtitle" = "워크플로 피드백을 기록하는 동안 시작, 완료 및 오류 소리를 재생합니다.";
 "settings.advanced.autoUpdate.title" = "자동 업데이트";
 "settings.advanced.autoUpdate.subtitle" = "3시간마다 자동으로 새 버전을 확인하고 설치합니다.";
+"settings.analyticsSharing.title" = "익명 사용 분석 공유";
+"settings.analyticsSharing.subtitle" = "익명의 앱 및 모델 다운로드 이벤트를 공유하여 Typeflux 개선에 도움을 줍니다. 음성 및 텍스트 내용은 수집되지 않습니다.";
 "settings.permissionStatus.title" = "허가현황";
 "settings.permissionStatus.subtitle" = "Typeflux이 의존하는 macOS 권한을 검토한 후 필요한 경우 액세스 권한을 부여하세요.";
 

--- a/Sources/Typeflux/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/zh-Hans.lproj/Localizable.strings
@@ -145,6 +145,8 @@
 "settings.advanced.soundEffects.subtitle" = "在开始录音、完成操作和发生错误时播放提示音。";
 "settings.advanced.autoUpdate.title" = "自动更新";
 "settings.advanced.autoUpdate.subtitle" = "每 3 小时自动检查并安装新版本。";
+"settings.analyticsSharing.title" = "共享匿名使用情况分析";
+"settings.analyticsSharing.subtitle" = "共享匿名应用与模型下载事件，帮助改进 Typeflux。绝不会采集语音和文本内容。";
 "settings.permissionStatus.title" = "权限状态";
 "settings.permissionStatus.subtitle" = "查看 Typeflux 依赖的 macOS 权限，并在需要时完成授权。";
 "settings.output.title" = "输出";

--- a/Sources/Typeflux/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/zh-Hant.lproj/Localizable.strings
@@ -145,6 +145,8 @@
 "settings.advanced.soundEffects.subtitle" = "在開始錄音、完成操作與發生錯誤時播放提示音。";
 "settings.advanced.autoUpdate.title" = "自動更新";
 "settings.advanced.autoUpdate.subtitle" = "每 3 小時自動檢查並安裝新版本。";
+"settings.analyticsSharing.title" = "分享匿名使用情況分析";
+"settings.analyticsSharing.subtitle" = "分享匿名應用程式與模型下載事件，協助改進 Typeflux。絕不會收集語音和文字內容。";
 "settings.permissionStatus.title" = "權限狀態";
 "settings.permissionStatus.subtitle" = "檢視 Typeflux 依賴的 macOS 權限，並在需要時完成授權。";
 "settings.output.title" = "輸出";

--- a/Sources/Typeflux/Settings/SettingsStore.swift
+++ b/Sources/Typeflux/Settings/SettingsStore.swift
@@ -11,6 +11,7 @@ extension Notification.Name {
     static let preferredMicrophoneDidChange = Notification.Name("SettingsStore.preferredMicrophoneDidChange")
     static let agentConfigurationDidChange = Notification.Name("SettingsStore.agentConfigurationDidChange")
     static let localOptimizationDidEnable = Notification.Name("SettingsStore.localOptimizationDidEnable")
+    static let analyticsSharingDidChange = Notification.Name("SettingsStore.analyticsSharingDidChange")
 }
 
 enum HistoryRetentionPolicy: String, CaseIterable, Identifiable {
@@ -180,6 +181,18 @@ final class SettingsStore {
     var autoUpdateEnabled: Bool {
         get { defaults.object(forKey: "app.autoUpdate.enabled") as? Bool ?? true }
         set { defaults.set(newValue, forKey: "app.autoUpdate.enabled") }
+    }
+
+    var analyticsSharingEnabled: Bool {
+        get { defaults.object(forKey: "analytics.sharingEnabled") as? Bool ?? true }
+        set {
+            guard analyticsSharingEnabled != newValue else { return }
+            defaults.set(newValue, forKey: "analytics.sharingEnabled")
+            if !newValue {
+                defaults.removeObject(forKey: "analytics.pendingEvents")
+            }
+            NotificationCenter.default.post(name: .analyticsSharingDidChange, object: defaults)
+        }
     }
 
     var historyRetentionPolicy: HistoryRetentionPolicy {

--- a/Sources/Typeflux/Settings/SettingsView.swift
+++ b/Sources/Typeflux/Settings/SettingsView.swift
@@ -2729,6 +2729,23 @@ struct StudioView: View {
                         .labelsHidden()
                         .toggleStyle(.switch)
                     }
+
+                    Divider().overlay(StudioTheme.border.opacity(StudioTheme.Opacity.divider))
+
+                    StudioSettingRow(
+                        title: L("settings.analyticsSharing.title"),
+                        subtitle: L("settings.analyticsSharing.subtitle")
+                    ) {
+                        Toggle(
+                            "",
+                            isOn: Binding(
+                                get: { viewModel.analyticsSharingEnabled },
+                                set: viewModel.setAnalyticsSharingEnabled
+                            )
+                        )
+                        .labelsHidden()
+                        .toggleStyle(.switch)
+                    }
                 }
             }
 

--- a/Sources/Typeflux/Settings/SettingsViewModel.swift
+++ b/Sources/Typeflux/Settings/SettingsViewModel.swift
@@ -171,6 +171,7 @@ final class StudioViewModel: ObservableObject {
     @Published var textTransformationEnabled: Bool
     @Published var textTransformationRule: String
     @Published var autoUpdateEnabled: Bool
+    @Published var analyticsSharingEnabled: Bool
 
     var isTextTransformationAvailable: Bool {
         appLanguage == .traditionalChinese
@@ -372,6 +373,7 @@ final class StudioViewModel: ObservableObject {
         textTransformationEnabled = settingsStore.outputOpenCCEnabled
         textTransformationRule = settingsStore.outputOpenCCConfig
         autoUpdateEnabled = settingsStore.autoUpdateEnabled
+        analyticsSharingEnabled = settingsStore.analyticsSharingEnabled
         stubbornPasteFallbackEnabled = settingsStore.stubbornPasteFallbackEnabled
         agentFrameworkEnabled = settingsStore.agentFrameworkEnabled
         agentEnabled = settingsStore.agentEnabled
@@ -1475,6 +1477,11 @@ final class StudioViewModel: ObservableObject {
         } else {
             AutoUpdater.shared.stopAutoCheck()
         }
+    }
+
+    func setAnalyticsSharingEnabled(_ value: Bool) {
+        analyticsSharingEnabled = value
+        settingsStore.analyticsSharingEnabled = value
     }
 
     // MARK: - Output Post-Processing

--- a/Tests/TypefluxTests/AppAnalyticsReporterTests.swift
+++ b/Tests/TypefluxTests/AppAnalyticsReporterTests.swift
@@ -24,11 +24,13 @@ final class AppAnalyticsReporterTests: XCTestCase {
         defer { defaults.removePersistentDomain(forName: suite) }
         let reporter = makeReporter(defaults: defaults, transport: FailingAnalyticsTransport(), maximumQueueSize: 3)
 
-        for index in 0..<5 { reporter.report(eventName: "model_download_started", properties: ["index": "\(index)"]) }
+        for index in 0..<5 {
+            reporter.report(eventName: "model_download_started", properties: ["retry_index": "\(index)"])
+        }
 
         let events = queuedEvents(defaults: defaults)
         XCTAssertEqual(events.count, 3)
-        XCTAssertEqual(events.map { $0.properties["index"] }, ["2", "3", "4"])
+        XCTAssertEqual(events.map { $0.properties["retry_index"] }, ["2", "3", "4"])
     }
 
     func testSuccessfulFlushRemovesPersistedEvent() async throws {
@@ -95,10 +97,90 @@ final class AppAnalyticsReporterTests: XCTestCase {
         defer { defaults.removePersistentDomain(forName: suite) }
         let reporter = makeReporter(defaults: defaults, transport: FailingAnalyticsTransport(), maximumQueueSize: 2)
         reporter.reportFirstOpenIfNeeded()
-        reporter.report(eventName: "model_download_started", properties: ["index": "1"])
-        reporter.report(eventName: "model_download_started", properties: ["index": "2"])
+        reporter.report(eventName: "model_download_started", properties: ["retry_index": "1"])
+        reporter.report(eventName: "model_download_started", properties: ["retry_index": "2"])
 
         XCTAssertEqual(queuedEvents(defaults: defaults).map(\.eventName), ["app_first_open", "model_download_started"])
+    }
+
+    func testNonAllowlistedPropertiesAreDroppedAndSessionIsStable() throws {
+        let suite = "AppAnalyticsReporterTests-\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suite))
+        defer { defaults.removePersistentDomain(forName: suite) }
+        let reporter = makeReporter(defaults: defaults, transport: FailingAnalyticsTransport())
+
+        reporter.report(
+            eventName: "model_download_started",
+            properties: ["model_kind": "stt", "transcript": "sensitive text"]
+        )
+        reporter.report(eventName: "app_login", properties: [:])
+
+        let events = queuedEvents(defaults: defaults)
+        XCTAssertEqual(events.count, 2)
+        XCTAssertEqual(events[0].properties["model_kind"], "stt")
+        XCTAssertNil(events[0].properties["transcript"])
+        XCTAssertEqual(events[0].properties["session_id"], events[1].properties["session_id"])
+        XCTAssertEqual(events[0].properties["session_id"], "test-session")
+    }
+
+    func testNewReporterGetsNewSessionID() throws {
+        let firstSuite = "AppAnalyticsReporterTests-first-\(UUID().uuidString)"
+        let secondSuite = "AppAnalyticsReporterTests-second-\(UUID().uuidString)"
+        let firstDefaults = try XCTUnwrap(UserDefaults(suiteName: firstSuite))
+        let secondDefaults = try XCTUnwrap(UserDefaults(suiteName: secondSuite))
+        defer {
+            firstDefaults.removePersistentDomain(forName: firstSuite)
+            secondDefaults.removePersistentDomain(forName: secondSuite)
+        }
+        let first = AppAnalyticsReporter(defaults: firstDefaults, transport: FailingAnalyticsTransport())
+        let second = AppAnalyticsReporter(defaults: secondDefaults, transport: FailingAnalyticsTransport())
+
+        first.report(eventName: "app_login", properties: [:])
+        second.report(eventName: "app_login", properties: [:])
+
+        XCTAssertNotEqual(
+            queuedEvents(defaults: firstDefaults)[0].properties["session_id"],
+            queuedEvents(defaults: secondDefaults)[0].properties["session_id"]
+        )
+    }
+
+    func testSettingsAwareReporterDisablesImmediatelyAndClearsQueue() throws {
+        let suite = "AppAnalyticsReporterTests-\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suite))
+        defer { defaults.removePersistentDomain(forName: suite) }
+        let settingsStore = SettingsStore(defaults: defaults)
+        let appReporter = makeReporter(defaults: defaults, transport: FailingAnalyticsTransport())
+        let reporter = SettingsAwareAnalyticsEventReporter(settingsStore: settingsStore, reporter: appReporter)
+
+        reporter.report(eventName: "app_login", properties: [:])
+        XCTAssertEqual(queuedEvents(defaults: defaults).count, 1)
+
+        settingsStore.analyticsSharingEnabled = false
+        XCTAssertTrue(queuedEvents(defaults: defaults).isEmpty)
+        reporter.report(eventName: "app_login", properties: [:])
+        XCTAssertTrue(queuedEvents(defaults: defaults).isEmpty)
+
+        settingsStore.analyticsSharingEnabled = true
+        reporter.report(eventName: "app_login", properties: [:])
+        XCTAssertEqual(queuedEvents(defaults: defaults).count, 1)
+    }
+
+    func testDisabledSettingsAwareReporterDoesNotUseTransport() async throws {
+        let suite = "AppAnalyticsReporterTests-\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suite))
+        defer { defaults.removePersistentDomain(forName: suite) }
+        let settingsStore = SettingsStore(defaults: defaults)
+        settingsStore.analyticsSharingEnabled = false
+        let transport = CountingAnalyticsTransport()
+        let appReporter = makeReporter(defaults: defaults, transport: transport)
+        let reporter = SettingsAwareAnalyticsEventReporter(settingsStore: settingsStore, reporter: appReporter)
+
+        reporter.reportFirstOpenIfNeeded()
+        reporter.report(eventName: "app_login", properties: [:])
+        try await Task.sleep(for: .milliseconds(30))
+
+        XCTAssertEqual(transport.attemptCount, 0)
+        XCTAssertTrue(queuedEvents(defaults: defaults).isEmpty)
     }
 
     func testTransportRetriesWithoutInvalidAuthorization() async throws {
@@ -135,6 +217,7 @@ final class AppAnalyticsReporterTests: XCTestCase {
             transport: transport,
             clientInfoProvider: TypefluxCloudClientInfoProvider { Self.clientInfo },
             maximumQueueSize: maximumQueueSize,
+            sessionID: "test-session",
             now: { Date(timeIntervalSince1970: 1_700_000_000) }
         )
     }
@@ -201,6 +284,16 @@ private final class RetryOnceAnalyticsTransport: AppAnalyticsTransporting, @unch
             return attempts
         }
         if attempt == 1 { throw URLError(.notConnectedToInternet) }
+    }
+}
+
+private final class CountingAnalyticsTransport: AppAnalyticsTransporting, @unchecked Sendable {
+    private let lock = NSLock()
+    private var attempts = 0
+    var attemptCount: Int { lock.withLock { attempts } }
+
+    func send(events _: [AppAnalyticsEvent]) async throws {
+        lock.withLock { attempts += 1 }
     }
 }
 

--- a/Tests/TypefluxTests/SettingsStoreTests.swift
+++ b/Tests/TypefluxTests/SettingsStoreTests.swift
@@ -136,6 +136,25 @@ final class SettingsStoreTests: XCTestCase {
         XCTAssertFalse(store.soundEffectsEnabled)
     }
 
+    // MARK: - Analytics Sharing
+
+    func testAnalyticsSharingDefaultsToEnabledAndPersists() {
+        XCTAssertTrue(store.analyticsSharingEnabled)
+
+        store.analyticsSharingEnabled = false
+
+        XCTAssertFalse(store.analyticsSharingEnabled)
+        XCTAssertFalse(SettingsStore(defaults: defaults).analyticsSharingEnabled)
+    }
+
+    func testDisablingAnalyticsSharingClearsPendingEvents() {
+        defaults.set(Data("pending".utf8), forKey: "analytics.pendingEvents")
+
+        store.analyticsSharingEnabled = false
+
+        XCTAssertNil(defaults.object(forKey: "analytics.pendingEvents"))
+    }
+
     // MARK: - Mute System Output
 
     func testDefaultMuteSystemOutput() {


### PR DESCRIPTION
## Summary
- add a localized, default-on anonymous analytics sharing switch that takes effect immediately
- route analytics through AppAnalyticsReporter or NoopAnalyticsEventReporter, cancelling retries and clearing queued events on opt-out
- enforce a centralized event-property allowlist and attach one launch-scoped session_id to every event
- add unit coverage for persistence, opt-out networking/queue behavior, allowlist filtering, and session lifecycle

## Validation
- `swift test --filter AppAnalyticsReporterTests` (11 passed)
- `swift test --filter SettingsStoreTests` (133 passed)
- `make coverage` (2,405 passed; AppAnalyticsReporter.swift line coverage 95.11%, SettingsStore.swift 91.74%)
- `git diff --check`

Closes GUL-61