### PR TITLE
GUL-60: make short hotkey releases recoverable

### DIFF
--- a/Sources/Typeflux/Hotkey/EventTapHotkeyService.swift
+++ b/Sources/Typeflux/Hotkey/EventTapHotkeyService.swift
@@ -135,7 +135,9 @@ private final class SystemHotkeyRegistrar {
 }
 
 final class EventTapHotkeyService: HotkeyService {
-    private static let modifierActivationHoldDelay: TimeInterval = 0.22
+    /// Allows competing modifier shortcuts to win without delaying recording start.
+    /// Recording mode is decided by `WorkflowController`, not by this timer.
+    private static let modifierShortcutArbitrationDelay: TimeInterval = 0.22
     private static let duplicateHistoryRequestSuppression: TimeInterval = 0.18
 
     var onActivationTap: (() -> Void)?
@@ -504,7 +506,7 @@ final class EventTapHotkeyService: HotkeyService {
         }
         pendingModifierActivationWorkItem = workItem
         DispatchQueue.main.asyncAfter(
-            deadline: .now() + Self.modifierActivationHoldDelay,
+            deadline: .now() + Self.modifierShortcutArbitrationDelay,
             execute: workItem
         )
     }

--- a/Sources/Typeflux/Workflow/WorkflowController.swift
+++ b/Sources/Typeflux/Workflow/WorkflowController.swift
@@ -8,8 +8,11 @@ final class WorkflowController {
     static let recordingTimeoutNanoseconds: UInt64 = 600_000_000_000 // 10 minutes
     static let minimumProcessingTimeoutSeconds: TimeInterval = 120
     static let processingTimeoutGraceSeconds: TimeInterval = 90
-    static let tapToLockThreshold: TimeInterval = 0.22
     static let minimumRecordingDuration: TimeInterval = 0.35
+    /// Ambiguous short releases stay recoverable by switching to locked recording.
+    /// Keep this above `minimumRecordingDuration` so a release is never classified
+    /// as hold-to-talk and then immediately rejected as too short.
+    static let tapToLockThreshold: TimeInterval = minimumRecordingDuration + 0.10
     static let selectionRestoreDelayMicroseconds: useconds_t = 120_000
     static let automaticVocabularyObservationWindow: TimeInterval = 30
     static let automaticVocabularyPollInterval: Duration = .seconds(1)
@@ -100,6 +103,7 @@ final class WorkflowController {
     let localModelDownloadAlertPresenter: any LocalModelDownloadAlertPresenting
     let outputPostProcessor: OutputPostProcessing
     let sleep: @Sendable (Duration) async -> Void
+    let monotonicNow: () -> TimeInterval
 
     var currentSelectedText: String?
     var isRecording = false
@@ -110,7 +114,8 @@ final class WorkflowController {
     var suppressActivationTapUntil: Date?
     var recordingMode: RecordingMode = .holdToTalk
     var recordingIntent: RecordingIntent = .dictation
-    var hotkeyPressedAt: Date?
+    var hotkeyPressedAt: TimeInterval?
+    var audioRecorderStartedAt: TimeInterval?
     var recordingTimeoutTask: Task<Void, Never>?
     var processingTimeoutTask: Task<Void, Never>?
     var selectionTask: Task<TextSelectionSnapshot, Never>?
@@ -200,7 +205,8 @@ final class WorkflowController {
         outputPostProcessor: OutputPostProcessing,
         sleep: @escaping @Sendable (Duration) async -> Void = { duration in
             try? await Task.sleep(for: duration)
-        }
+        },
+        monotonicNow: @escaping () -> TimeInterval = { ProcessInfo.processInfo.systemUptime }
     ) {
         self.appState = appState
         self.settingsStore = settingsStore
@@ -225,6 +231,7 @@ final class WorkflowController {
         self.localModelDownloadAlertPresenter = localModelDownloadAlertPresenter
         self.outputPostProcessor = outputPostProcessor
         self.sleep = sleep
+        self.monotonicNow = monotonicNow
         self.overlayController.setRecordingActionHandlers(
             onCancel: { [weak self] in
                 guard let self else { return }
@@ -419,6 +426,7 @@ final class WorkflowController {
         isAudioRecorderStarted = false
         isAudioRecorderStarting = false
         shouldFinishRecordingAfterAudioStart = false
+        audioRecorderStartedAt = nil
         pendingRecordingStartID = nil
         suppressActivationTapUntil = nil
         recordingMode = .holdToTalk
@@ -599,7 +607,7 @@ final class WorkflowController {
             dismissClarification()
         }
 
-        hotkeyPressedAt = startLocked ? nil : Date()
+        hotkeyPressedAt = startLocked ? nil : monotonicNow()
 
         cancelCurrentProcessing(resetUI: false, reason: L("workflow.cancel.newRecording"))
         isRecording = true
@@ -977,6 +985,7 @@ final class WorkflowController {
         isAudioRecorderStarted = false
         isAudioRecorderStarting = true
         shouldFinishRecordingAfterAudioStart = false
+        audioRecorderStartedAt = nil
         recordingMode = effectiveStartLocked ? .locked : .holdToTalk
         recordingIntent = effectiveIntent
         lastRetryableFailureRecord = nil
@@ -1065,6 +1074,7 @@ final class WorkflowController {
             RecordingStartupLatencyTrace.shared.mark("workflow.audio_start_return")
             isAudioRecorderStarting = false
             isAudioRecorderStarted = true
+            audioRecorderStartedAt = monotonicNow()
             pendingRecordingStartID = nil
             if usesLivePreview {
                 startLiveTranscriptionPreviewIfNeeded(livePreviewer)
@@ -1072,6 +1082,7 @@ final class WorkflowController {
 
             guard isRecording else {
                 isAudioRecorderStarted = false
+                audioRecorderStartedAt = nil
                 _ = try? audioRecorder.stop()
                 Task { await livePreviewer?.cancel() }
                 realtimeAudioBufferPump?.cancel()
@@ -1154,6 +1165,7 @@ final class WorkflowController {
             isAudioRecorderStarted = false
             isAudioRecorderStarting = false
             shouldFinishRecordingAfterAudioStart = false
+            audioRecorderStartedAt = nil
             pendingRecordingStartID = nil
             suppressActivationTapUntil = nil
             recordingMode = .holdToTalk
@@ -1193,18 +1205,15 @@ final class WorkflowController {
 
         guard recordingMode == .holdToTalk else { return }
 
-        let pressDuration = Date().timeIntervalSince(hotkeyPressedAt ?? Date.distantPast)
+        let releasedAt = monotonicNow()
+        let pressDuration = hotkeyPressedAt.map { max(0, releasedAt - $0) } ?? .infinity
         hotkeyPressedAt = nil
 
-        if pressDuration < Self.tapToLockThreshold {
-            recordingMode = .locked
-            let recordingHint = currentRecordingHintPresentation()
-            Task { @MainActor in
-                overlayController.showLockedRecording(
-                    hintText: recordingHint.text,
-                    autoHideHintAfter: recordingHint.autoHideAfter
-                )
-            }
+        let recordedDuration = audioRecorderStartedAt.map { max(0, releasedAt - $0) } ?? 0
+        if pressDuration < Self.tapToLockThreshold
+            || isAudioRecorderStarting
+            || recordedDuration < Self.minimumRecordingDuration {
+            lockActiveRecording()
             return
         }
 
@@ -1251,6 +1260,7 @@ final class WorkflowController {
         pendingRecordingStartID = nil
         recordingMode = .holdToTalk
         hotkeyPressedAt = nil
+        audioRecorderStartedAt = nil
         recordingTimeoutTask?.cancel()
         recordingTimeoutTask = nil
         NSLog("[Workflow] Recording stopped")

--- a/Tests/TypefluxTests/WorkflowControllerProcessingTests.swift
+++ b/Tests/TypefluxTests/WorkflowControllerProcessingTests.swift
@@ -903,13 +903,85 @@ final class WorkflowControllerProcessingTests: XCTestCase {
 
         await controller.beginRecording(intent: .dictation, startLocked: false)
 
-        controller.hotkeyPressedAt = Date(timeIntervalSinceNow: -0.5)
+        let now = controller.monotonicNow()
+        controller.hotkeyPressedAt = now - 0.5
+        controller.audioRecorderStartedAt = now - 0.5
         controller.handlePressEnded()
         await audioRecorder.waitUntilStopCount(isAtLeast: 1)
 
         XCTAssertEqual(audioRecorder.startCallCount, 1)
         XCTAssertEqual(audioRecorder.stopCallCount, 1)
         XCTAssertTrue(eventRecorder.snapshot().contains("audio-start"))
+    }
+
+    func testTapToLockThresholdExceedsMinimumRecordingDuration() {
+        XCTAssertGreaterThan(
+            WorkflowController.tapToLockThreshold,
+            WorkflowController.minimumRecordingDuration
+        )
+    }
+
+    func testReleaseWithinTapToleranceKeepsRecordingLocked() async {
+        let audioRecorder = MockProcessingAudioRecorder()
+        let controller = makeWorkflowController(
+            audioRecorder: audioRecorder,
+            sleep: { _ in }
+        )
+
+        await controller.beginRecording(intent: .dictation, startLocked: false)
+
+        let now = controller.monotonicNow()
+        controller.hotkeyPressedAt = now - 0.3
+        controller.audioRecorderStartedAt = now - 0.3
+        controller.handlePressEnded()
+
+        XCTAssertTrue(controller.isRecording)
+        XCTAssertEqual(controller.recordingMode, .locked)
+        XCTAssertEqual(audioRecorder.stopCallCount, 0)
+
+        controller.cancelRecording()
+        await waitForMainActorWork()
+    }
+
+    func testReleaseAtTapBoundaryStopsRecording() async {
+        let audioRecorder = MockProcessingAudioRecorder()
+        let controller = makeWorkflowController(
+            audioRecorder: audioRecorder,
+            sleep: { _ in }
+        )
+
+        await controller.beginRecording(intent: .dictation, startLocked: false)
+
+        let now = controller.monotonicNow()
+        controller.hotkeyPressedAt = now - WorkflowController.tapToLockThreshold
+        controller.audioRecorderStartedAt = now - WorkflowController.minimumRecordingDuration
+        controller.handlePressEnded()
+        await audioRecorder.waitUntilStopCount(isAtLeast: 1)
+
+        XCTAssertFalse(controller.isRecording)
+        XCTAssertEqual(audioRecorder.stopCallCount, 1)
+    }
+
+    func testReleaseWithInsufficientCapturedAudioKeepsRecordingLocked() async {
+        let audioRecorder = MockProcessingAudioRecorder()
+        let controller = makeWorkflowController(
+            audioRecorder: audioRecorder,
+            sleep: { _ in }
+        )
+
+        await controller.beginRecording(intent: .dictation, startLocked: false)
+
+        let now = controller.monotonicNow()
+        controller.hotkeyPressedAt = now - 0.5
+        controller.audioRecorderStartedAt = now - 0.2
+        controller.handlePressEnded()
+
+        XCTAssertTrue(controller.isRecording)
+        XCTAssertEqual(controller.recordingMode, .locked)
+        XCTAssertEqual(audioRecorder.stopCallCount, 0)
+
+        controller.cancelRecording()
+        await waitForMainActorWork()
     }
 
     func testAskPressDuringActiveDictationPromotesExistingRecording() async {
@@ -1022,7 +1094,7 @@ final class WorkflowControllerProcessingTests: XCTestCase {
         await waitForMainActorWork()
     }
 
-    func testReleasingWhileAudioStartIsPendingStopsAfterStartCompletes() async {
+    func testReleasingWhileAudioStartIsPendingKeepsRecordingLocked() async {
         let audioRecorder = BlockingStartAudioRecorder()
         let controller = makeWorkflowController(
             audioRecorder: audioRecorder,
@@ -1034,21 +1106,25 @@ final class WorkflowControllerProcessingTests: XCTestCase {
         }
         audioRecorder.waitUntilStartIsPending()
 
-        controller.hotkeyPressedAt = Date(timeIntervalSinceNow: -0.5)
+        controller.hotkeyPressedAt = controller.monotonicNow() - 0.5
         controller.handlePressEnded()
 
         XCTAssertTrue(controller.isRecording)
-        XCTAssertTrue(controller.shouldFinishRecordingAfterAudioStart)
+        XCTAssertEqual(controller.recordingMode, .locked)
+        XCTAssertFalse(controller.shouldFinishRecordingAfterAudioStart)
         XCTAssertEqual(audioRecorder.stopCallCount, 0)
 
         audioRecorder.releasePendingStart()
         await recordingTask.value
-        await audioRecorder.waitUntilStopCount(isAtLeast: 1)
 
-        XCTAssertFalse(controller.isRecording)
+        XCTAssertTrue(controller.isRecording)
+        XCTAssertEqual(controller.recordingMode, .locked)
         XCTAssertFalse(controller.isAudioRecorderStarting)
         XCTAssertEqual(audioRecorder.startCallCount, 1)
-        XCTAssertEqual(audioRecorder.stopCallCount, 1)
+        XCTAssertEqual(audioRecorder.stopCallCount, 0)
+
+        controller.cancelRecording()
+        await waitForMainActorWork()
     }
 
     func testNewPressIsIgnoredWhileAudioRecorderStopIsPending() async {

--- a/docs/scenario-behavior-table.md
+++ b/docs/scenario-behavior-table.md
@@ -7,9 +7,9 @@ This document describes the trigger conditions and corresponding system behavior
 | Scenario | Behavior |
 |----------|----------|
 | Hold-to-talk mode | User holds the activation hotkey (default FN) → recording starts, floating recording capsule appears, start sound effect plays |
-| Tap-to-lock mode | User quickly taps the hotkey (<220ms) → enters locked recording mode, overlay shows confirm/cancel buttons |
-| Hotkey release (short press) | Hotkey released with hold duration <220ms → switches to locked recording mode |
-| Hotkey release (long press ends) | Hotkey released with hold duration ≥220ms → recording stops, post-processing begins |
+| Tap-to-lock mode | User taps the hotkey (<450ms) → enters locked recording mode, overlay shows confirm/cancel buttons |
+| Hotkey release (short press) | Hotkey released with hold duration <450ms, or before 350ms of audio has been captured → switches to locked recording mode |
+| Hotkey release (long press ends) | Hotkey released with hold duration ≥450ms and captured audio duration ≥350ms → recording stops, post-processing begins |
 | Ask hotkey triggered | Ask hotkey pressed (⌘⇧Space) → starts locked recording for querying selected text |
 | Persona selection hotkey triggered | Persona hotkey pressed (⌘⇧P) → displays the persona selector overlay |
 


### PR DESCRIPTION
## Summary

- start recording immediately and use a 450 ms release threshold only to choose hold-to-talk versus locked mode
- keep releases recoverable while audio startup is pending or less than 350 ms of audio has been captured
- use monotonic timing, document the behavior, and cover short, boundary, delayed-start, and sufficient-audio cases

## Validation

- `swift test --filter WorkflowControllerProcessingTests` (77 tests, 0 failures)
- `swift package update && make coverage` (passed; 30.87% repository line coverage)
- `git diff --check`

The checked-in dependency lock file was restored after validation; its older Swift HTTP Types resolution is incompatible with the local Swift 6.3 dependency planner, so validation used a temporary dependency update that is not included in this PR.

Closes GUL-60
