### PR TITLE
GUL-60: extend tap recovery window to 600ms

### DIFF
--- a/Sources/Typeflux/Workflow/WorkflowController.swift
+++ b/Sources/Typeflux/Workflow/WorkflowController.swift
@@ -12,7 +12,7 @@ final class WorkflowController {
     /// Ambiguous short releases stay recoverable by switching to locked recording.
     /// Keep this above `minimumRecordingDuration` so a release is never classified
     /// as hold-to-talk and then immediately rejected as too short.
-    static let tapToLockThreshold: TimeInterval = minimumRecordingDuration + 0.10
+    static let tapToLockThreshold: TimeInterval = 0.60
     static let selectionRestoreDelayMicroseconds: useconds_t = 120_000
     static let automaticVocabularyObservationWindow: TimeInterval = 30
     static let automaticVocabularyPollInterval: Duration = .seconds(1)

--- a/Tests/TypefluxTests/WorkflowControllerProcessingTests.swift
+++ b/Tests/TypefluxTests/WorkflowControllerProcessingTests.swift
@@ -904,8 +904,8 @@ final class WorkflowControllerProcessingTests: XCTestCase {
         await controller.beginRecording(intent: .dictation, startLocked: false)
 
         let now = controller.monotonicNow()
-        controller.hotkeyPressedAt = now - 0.5
-        controller.audioRecorderStartedAt = now - 0.5
+        controller.hotkeyPressedAt = now - 0.7
+        controller.audioRecorderStartedAt = now - 0.7
         controller.handlePressEnded()
         await audioRecorder.waitUntilStopCount(isAtLeast: 1)
 
@@ -921,18 +921,19 @@ final class WorkflowControllerProcessingTests: XCTestCase {
         )
     }
 
-    func testReleaseWithinTapToleranceKeepsRecordingLocked() async {
+    func testReleaseAt599MillisecondsKeepsRecordingLocked() async {
         let audioRecorder = MockProcessingAudioRecorder()
+        let releasedAt: TimeInterval = 0.599
         let controller = makeWorkflowController(
             audioRecorder: audioRecorder,
-            sleep: { _ in }
+            sleep: { _ in },
+            monotonicNow: { releasedAt }
         )
 
         await controller.beginRecording(intent: .dictation, startLocked: false)
 
-        let now = controller.monotonicNow()
-        controller.hotkeyPressedAt = now - 0.3
-        controller.audioRecorderStartedAt = now - 0.3
+        controller.hotkeyPressedAt = 0
+        controller.audioRecorderStartedAt = 0
         controller.handlePressEnded()
 
         XCTAssertTrue(controller.isRecording)
@@ -943,18 +944,19 @@ final class WorkflowControllerProcessingTests: XCTestCase {
         await waitForMainActorWork()
     }
 
-    func testReleaseAtTapBoundaryStopsRecording() async {
+    func testReleaseAt600MillisecondBoundaryStopsRecording() async {
         let audioRecorder = MockProcessingAudioRecorder()
+        let releasedAt = WorkflowController.tapToLockThreshold
         let controller = makeWorkflowController(
             audioRecorder: audioRecorder,
-            sleep: { _ in }
+            sleep: { _ in },
+            monotonicNow: { releasedAt }
         )
 
         await controller.beginRecording(intent: .dictation, startLocked: false)
 
-        let now = controller.monotonicNow()
-        controller.hotkeyPressedAt = now - WorkflowController.tapToLockThreshold
-        controller.audioRecorderStartedAt = now - WorkflowController.minimumRecordingDuration
+        controller.hotkeyPressedAt = 0
+        controller.audioRecorderStartedAt = 0
         controller.handlePressEnded()
         await audioRecorder.waitUntilStopCount(isAtLeast: 1)
 
@@ -1618,6 +1620,7 @@ final class WorkflowControllerProcessingTests: XCTestCase {
         localModelDownloadAlertPresenter: any LocalModelDownloadAlertPresenting =
             MockLocalModelDownloadAlertPresenter(),
         sleep: @escaping @Sendable (Duration) async -> Void = { _ in },
+        monotonicNow: @escaping () -> TimeInterval = { ProcessInfo.processInfo.systemUptime },
         configureSettings: ((SettingsStore) -> Void)? = nil
     ) -> WorkflowController {
         let suiteName = "WorkflowControllerProcessingTests.\(UUID().uuidString)"
@@ -1668,7 +1671,8 @@ final class WorkflowControllerProcessingTests: XCTestCase {
             localModelManager: localModelManager,
             localModelDownloadAlertPresenter: localModelDownloadAlertPresenter,
             outputPostProcessor: NoopOutputPostProcessor(),
-            sleep: sleep
+            sleep: sleep,
+            monotonicNow: monotonicNow
         )
     }
 

--- a/docs/scenario-behavior-table.md
+++ b/docs/scenario-behavior-table.md
@@ -7,9 +7,9 @@ This document describes the trigger conditions and corresponding system behavior
 | Scenario | Behavior |
 |----------|----------|
 | Hold-to-talk mode | User holds the activation hotkey (default FN) → recording starts, floating recording capsule appears, start sound effect plays |
-| Tap-to-lock mode | User taps the hotkey (<450ms) → enters locked recording mode, overlay shows confirm/cancel buttons |
-| Hotkey release (short press) | Hotkey released with hold duration <450ms, or before 350ms of audio has been captured → switches to locked recording mode |
-| Hotkey release (long press ends) | Hotkey released with hold duration ≥450ms and captured audio duration ≥350ms → recording stops, post-processing begins |
+| Tap-to-lock mode | User taps the hotkey (<600ms) → enters locked recording mode, overlay shows confirm/cancel buttons |
+| Hotkey release (short press) | Hotkey released with hold duration <600ms, or before 350ms of audio has been captured → switches to locked recording mode |
+| Hotkey release (long press ends) | Hotkey released with hold duration ≥600ms and captured audio duration ≥350ms → recording stops, post-processing begins |
 | Ask hotkey triggered | Ask hotkey pressed (⌘⇧Space) → starts locked recording for querying selected text |
 | Persona selection hotkey triggered | Persona hotkey pressed (⌘⇧P) → displays the persona selector overlay |
 


### PR DESCRIPTION
## Summary

- extend the release-to-lock recovery window from 450 ms to 600 ms
- keep recording startup immediate and preserve the existing actual-audio-duration fallback
- add deterministic 599 ms / 600 ms boundary coverage and update behavior documentation

## Validation

- `swift test --filter WorkflowControllerProcessingTests` — 77 tests passed
- `swift test --filter AudioContentAnalyzer` — 13 tests passed
- `git diff --check` — passed

Dependency validation used a temporary `swift package update` because the checked-in Swift HTTP Types resolution is incompatible with the local Swift 6.3 planner. `Package.resolved` was restored and is not changed by this PR.

Closes GUL-60
