### PR TITLE
GUL-57: Preserve numeric cloud sync payloads

### DIFF
--- a/Sources/Typeflux/Sync/CloudDataSyncModels.swift
+++ b/Sources/Typeflux/Sync/CloudDataSyncModels.swift
@@ -1,3 +1,4 @@
+import CoreFoundation
 import Foundation
 
 enum CloudDataLocalScope {
@@ -230,6 +231,18 @@ private struct SyncJSONAny: Codable {
         var container = encoder.singleValueContainer()
         switch value {
         case is NSNull: try container.encodeNil()
+        case let value as NSNumber:
+            // JSONSerialization represents both JSON booleans and numbers as
+            // NSNumber. Swift's bridging also lets NSNumber(0/1) match Bool,
+            // so checking `Bool` first corrupts numeric payload fields such as
+            // occurrence_count and delta into false/true.
+            if CFGetTypeID(value) == CFBooleanGetTypeID() {
+                try container.encode(value.boolValue)
+            } else if ["f", "d"].contains(String(cString: value.objCType)) {
+                try container.encode(value.doubleValue)
+            } else {
+                try container.encode(value.int64Value)
+            }
         case let value as Bool: try container.encode(value)
         case let value as Int: try container.encode(value)
         case let value as Double: try container.encode(value)

--- a/Tests/TypefluxTests/CloudDataSyncAPIServiceTests.swift
+++ b/Tests/TypefluxTests/CloudDataSyncAPIServiceTests.swift
@@ -1,4 +1,5 @@
 @testable import Typeflux
+import CoreFoundation
 import XCTest
 
 final class CloudDataSyncAPIServiceTests: XCTestCase {
@@ -13,6 +14,19 @@ final class CloudDataSyncAPIServiceTests: XCTestCase {
             XCTAssertEqual(object["protocol_version"] as? Int, 2)
             XCTAssertEqual(object["dataset_generation"] as? Int, 3)
             XCTAssertEqual(object["device_id"] as? String, "33333333-3333-4333-8333-333333333333")
+            let mutations = try XCTUnwrap(object["mutations"] as? [[String: Any]])
+            let payload = try XCTUnwrap(mutations.first?["payload"] as? [String: Any])
+            let count = try XCTUnwrap(payload["occurrence_count"] as? NSNumber)
+            XCTAssertNotEqual(CFGetTypeID(count), CFBooleanGetTypeID())
+            XCTAssertEqual(count.intValue, 1)
+            for (key, expected) in [("zero", 0), ("one", 1), ("two", 2)] {
+                let number = try XCTUnwrap(payload[key] as? NSNumber)
+                XCTAssertNotEqual(CFGetTypeID(number), CFBooleanGetTypeID())
+                XCTAssertEqual(number.intValue, expected)
+            }
+            let flag = try XCTUnwrap(payload["flag"] as? NSNumber)
+            XCTAssertEqual(CFGetTypeID(flag), CFBooleanGetTypeID())
+            XCTAssertTrue(flag.boolValue)
             return (
                 Data(
                     #"{"code":"OK","data":{"dataset_generation":3,"reset_required":false,"snapshot":[],"cursor":4,"checkpoint":4,"has_more":false,"results":[],"changes":[]}}"#.utf8
@@ -32,7 +46,16 @@ final class CloudDataSyncAPIServiceTests: XCTestCase {
             request: CloudSyncRequest(
                 datasetGeneration: 3,
                 deviceID: UUID(uuidString: "33333333-3333-4333-8333-333333333333")!,
-                cursor: 0, ackCursor: 0, checkpoint: 0, mutations: []
+                cursor: 0, ackCursor: 0, checkpoint: 0,
+                mutations: [CloudSyncMutation(
+                    mutationID: UUID(uuidString: "11111111-1111-4111-8111-111111111111")!,
+                    entityType: .vocabulary,
+                    entityID: UUID(uuidString: "22222222-2222-4222-8222-222222222222")!,
+                    operation: "create", baseRevision: 0,
+                    payload: Data(
+                        #"{"term":"Typeflux","source":"manual","created_at":"2026-08-27T00:00:00Z","occurrence_count":1,"zero":0,"one":1,"two":2,"flag":true}"#.utf8
+                    )
+                )]
             )
         )
         XCTAssertEqual(response.cursor, 4)


### PR DESCRIPTION
## Summary

- distinguish JSON booleans from numeric `NSNumber` values before encoding sync payloads
- preserve `0`, `1`, and other integers while keeping real booleans unchanged
- add request-level regression coverage for the vocabulary payload that failed in Typeflux 0.4.0

## Verification

- `swift test --disable-automatic-resolution --filter CloudDataSyncAPIServiceTests`
- `swift test --disable-automatic-resolution --quiet` (2413 XCTest + 6 Swift Testing tests)
