### PR TITLE
GUL-66: reduce recording startup latency

### DIFF
--- a/Sources/Typeflux/Audio/AVFoundationAudioRecorder.swift
+++ b/Sources/Typeflux/Audio/AVFoundationAudioRecorder.swift
@@ -43,6 +43,8 @@ final class AVFoundationAudioRecorder: AudioRecorder {
     private var startedAt: Date?
     private var levelHandler: ((Float) -> Void)?
     private var audioBufferHandler: ((AVAudioPCMBuffer) -> Void)?
+    private var audioEngineStartedAt: Date?
+    private var firstAudioBufferAt: Date?
     private var muteTask: Task<Void, Never>?
     private var inputHealthCheckWorkItem: DispatchWorkItem?
     private var isRecording = false
@@ -128,6 +130,8 @@ final class AVFoundationAudioRecorder: AudioRecorder {
         self.startedAt = startedAt
         self.levelHandler = levelHandler
         self.audioBufferHandler = audioBufferHandler
+        audioEngineStartedAt = preparedSession.audioEngineStartedAt
+        firstAudioBufferAt = nil
         activeRecordingID = preparedSession.id
         activeInputGenerationID = preparedSession.inputGenerationID
         isRecording = true
@@ -174,6 +178,10 @@ final class AVFoundationAudioRecorder: AudioRecorder {
         let currentAudioFile = audioFile
         let currentStartedAt = startedAt
         let currentlyRecording = isRecording
+        let startupTiming = AudioRecorderStartupTiming(
+            audioEngineStartedAt: audioEngineStartedAt,
+            firstAudioBufferAt: firstAudioBufferAt
+        )
         stateCondition.unlock()
 
         guard currentlyRecording, let currentAudioFile else {
@@ -202,6 +210,8 @@ final class AVFoundationAudioRecorder: AudioRecorder {
         startedAt = nil
         levelHandler = nil
         audioBufferHandler = nil
+        audioEngineStartedAt = nil
+        firstAudioBufferAt = nil
         isRecording = false
         activeRecordingID = nil
         activeInputGenerationID = nil
@@ -211,7 +221,7 @@ final class AVFoundationAudioRecorder: AudioRecorder {
         muteTask = nil
         outputMuter.endMutedSession()
 
-        return AudioFile(fileURL: fileURL, duration: duration)
+        return AudioFile(fileURL: fileURL, duration: duration, startupTiming: startupTiming)
     }
 
     private func stopInternal() {
@@ -241,6 +251,8 @@ final class AVFoundationAudioRecorder: AudioRecorder {
         startedAt = nil
         levelHandler = nil
         audioBufferHandler = nil
+        audioEngineStartedAt = nil
+        firstAudioBufferAt = nil
         isRecording = false
         activeRecordingID = nil
         activeInputGenerationID = nil
@@ -323,9 +335,11 @@ final class AVFoundationAudioRecorder: AudioRecorder {
             throw RecorderError.inputStartupTimedOut
         }
 
+        let audioEngineStartedAt: Date
         do {
             sessionEngine.prepare()
             try sessionEngine.start()
+            audioEngineStartedAt = Date()
             RecordingStartupLatencyTrace.shared.mark("audio.engine_start_return")
         } catch {
             inputNode.removeTap(onBus: 0)
@@ -347,7 +361,8 @@ final class AVFoundationAudioRecorder: AudioRecorder {
             audioFile: outputFile,
             recordingBufferConverter: recordingBufferConverter,
             inputGenerationID: inputGenerationID,
-            startupBufferRelay: startupBufferRelay
+            startupBufferRelay: startupBufferRelay,
+            audioEngineStartedAt: audioEngineStartedAt
         )
     }
 
@@ -831,6 +846,9 @@ final class AVFoundationAudioRecorder: AudioRecorder {
             let audioBufferHandler = self.audioBufferHandler
             activeBufferCallbacks += 1
             inputBufferCallbackCount += 1
+            if firstAudioBufferAt == nil {
+                firstAudioBufferAt = Date()
+            }
             stateCondition.unlock()
 
             RecordingStartupLatencyTrace.shared.markFirstAudioBuffer()
@@ -957,6 +975,7 @@ private struct PreparedRecordingSession {
     let recordingBufferConverter: AudioRecordingBufferConverter
     let inputGenerationID: UUID
     let startupBufferRelay: RecordingStartupAudioBufferRelay
+    let audioEngineStartedAt: Date
 }
 
 /// Preserves tap buffers emitted after AVAudioEngine starts but before the

--- a/Sources/Typeflux/Audio/AudioRecorder.swift
+++ b/Sources/Typeflux/Audio/AudioRecorder.swift
@@ -1,9 +1,25 @@
 import AVFoundation
 import Foundation
 
+struct AudioRecorderStartupTiming: Sendable, Equatable {
+    let audioEngineStartedAt: Date?
+    let firstAudioBufferAt: Date?
+}
+
 struct AudioFile: Sendable {
     let fileURL: URL
     let duration: TimeInterval
+    let startupTiming: AudioRecorderStartupTiming?
+
+    init(
+        fileURL: URL,
+        duration: TimeInterval,
+        startupTiming: AudioRecorderStartupTiming? = nil
+    ) {
+        self.fileURL = fileURL
+        self.duration = duration
+        self.startupTiming = startupTiming
+    }
 }
 
 protocol AudioRecorder {

--- a/Sources/Typeflux/History/FileHistoryStore.swift
+++ b/Sources/Typeflux/History/FileHistoryStore.swift
@@ -112,6 +112,10 @@ final class FileHistoryStore: HistoryStore {
             if let pipelineTiming = r.pipelineTiming, pipelineTiming.hasData {
                 let pipelineStats = r.pipelineStats ?? pipelineTiming.generatedStats()
                 md += "\n### Pipeline Stats\n\n"
+                md += "- Hotkey detected: \(pipelineStats.hotkeyDetectedAt?.ISO8601Format() ?? "<none>")\n"
+                md += "- Recording workflow started: \(pipelineStats.recordingWorkflowStartedAt?.ISO8601Format() ?? "<none>")\n"
+                md += "- Audio engine started: \(pipelineStats.audioEngineStartedAt?.ISO8601Format() ?? "<none>")\n"
+                md += "- First audio buffer: \(pipelineStats.firstAudioBufferAt?.ISO8601Format() ?? "<none>")\n"
                 md += "- Recording stopped: \(pipelineStats.recordingStoppedAt?.ISO8601Format() ?? "<none>")\n"
                 md += "- Audio file ready: \(pipelineStats.audioFileReadyAt?.ISO8601Format() ?? "<none>")\n"
                 md += "- STT started: \(pipelineStats.transcriptionStartedAt?.ISO8601Format() ?? "<none>")\n"
@@ -120,6 +124,18 @@ final class FileHistoryStore: HistoryStore {
                 md += "- LLM completed: \(pipelineStats.llmProcessingCompletedAt?.ISO8601Format() ?? "<none>")\n"
                 md += "- Apply started: \(pipelineStats.applyStartedAt?.ISO8601Format() ?? "<none>")\n"
                 md += "- Apply completed: \(pipelineStats.applyCompletedAt?.ISO8601Format() ?? "<none>")\n"
+                if let value = pipelineStats.hotkeyToFirstAudioMilliseconds {
+                    md += "- Hotkey -> first audio: \(value) ms\n"
+                }
+                if let value = pipelineStats.hotkeyDispatchMilliseconds {
+                    md += "- Hotkey dispatch: \(value) ms\n"
+                }
+                if let value = pipelineStats.recordingPreparationMilliseconds {
+                    md += "- Recording preparation: \(value) ms\n"
+                }
+                if let value = pipelineStats.audioEngineToFirstBufferMilliseconds {
+                    md += "- Audio engine -> first buffer: \(value) ms\n"
+                }
                 if let value = pipelineStats.stopToAudioReadyMilliseconds {
                     md += "- Stop -> audio ready: \(value) ms\n"
                 }
@@ -144,6 +160,10 @@ final class FileHistoryStore: HistoryStore {
                 md += diagnosticMarkdown(for: pipelineStats)
             } else if let pipelineStats = r.pipelineStats, pipelineStats.hasData {
                 md += "\n### Pipeline Stats\n\n"
+                md += "- Hotkey detected: \(pipelineStats.hotkeyDetectedAt?.ISO8601Format() ?? "<none>")\n"
+                md += "- Recording workflow started: \(pipelineStats.recordingWorkflowStartedAt?.ISO8601Format() ?? "<none>")\n"
+                md += "- Audio engine started: \(pipelineStats.audioEngineStartedAt?.ISO8601Format() ?? "<none>")\n"
+                md += "- First audio buffer: \(pipelineStats.firstAudioBufferAt?.ISO8601Format() ?? "<none>")\n"
                 md += "- Recording stopped: \(pipelineStats.recordingStoppedAt?.ISO8601Format() ?? "<none>")\n"
                 md += "- Audio file ready: \(pipelineStats.audioFileReadyAt?.ISO8601Format() ?? "<none>")\n"
                 md += "- STT started: \(pipelineStats.transcriptionStartedAt?.ISO8601Format() ?? "<none>")\n"
@@ -152,6 +172,18 @@ final class FileHistoryStore: HistoryStore {
                 md += "- LLM completed: \(pipelineStats.llmProcessingCompletedAt?.ISO8601Format() ?? "<none>")\n"
                 md += "- Apply started: \(pipelineStats.applyStartedAt?.ISO8601Format() ?? "<none>")\n"
                 md += "- Apply completed: \(pipelineStats.applyCompletedAt?.ISO8601Format() ?? "<none>")\n"
+                if let value = pipelineStats.hotkeyToFirstAudioMilliseconds {
+                    md += "- Hotkey -> first audio: \(value) ms\n"
+                }
+                if let value = pipelineStats.hotkeyDispatchMilliseconds {
+                    md += "- Hotkey dispatch: \(value) ms\n"
+                }
+                if let value = pipelineStats.recordingPreparationMilliseconds {
+                    md += "- Recording preparation: \(value) ms\n"
+                }
+                if let value = pipelineStats.audioEngineToFirstBufferMilliseconds {
+                    md += "- Audio engine -> first buffer: \(value) ms\n"
+                }
                 md += diagnosticMarkdown(for: pipelineStats)
             }
             if let personaResultText = r.personaResultText, !personaResultText.isEmpty {

--- a/Sources/Typeflux/History/HistoryStore.swift
+++ b/Sources/Typeflux/History/HistoryStore.swift
@@ -1,6 +1,10 @@
 import Foundation
 
 struct HistoryPipelineTiming: Codable, Equatable {
+    var hotkeyDetectedAt: Date?
+    var recordingWorkflowStartedAt: Date?
+    var audioEngineStartedAt: Date?
+    var firstAudioBufferAt: Date?
     var recordingStoppedAt: Date?
     var audioFileReadyAt: Date?
     var transcriptionStartedAt: Date?
@@ -23,7 +27,11 @@ struct HistoryPipelineTiming: Codable, Equatable {
     var applyCompletedAt: Date?
 
     var hasData: Bool {
-        recordingStoppedAt != nil ||
+        hotkeyDetectedAt != nil ||
+            recordingWorkflowStartedAt != nil ||
+            audioEngineStartedAt != nil ||
+            firstAudioBufferAt != nil ||
+            recordingStoppedAt != nil ||
             audioFileReadyAt != nil ||
             transcriptionStartedAt != nil ||
             transcriptionCompletedAt != nil ||
@@ -52,6 +60,10 @@ struct HistoryPipelineTiming: Codable, Equatable {
 
     func generatedStats() -> HistoryPipelineStats {
         HistoryPipelineStats(
+            hotkeyDetectedAt: hotkeyDetectedAt,
+            recordingWorkflowStartedAt: recordingWorkflowStartedAt,
+            audioEngineStartedAt: audioEngineStartedAt,
+            firstAudioBufferAt: firstAudioBufferAt,
             recordingStoppedAt: recordingStoppedAt,
             audioFileReadyAt: audioFileReadyAt,
             transcriptionStartedAt: transcriptionStartedAt,
@@ -72,6 +84,10 @@ struct HistoryPipelineTiming: Codable, Equatable {
             llmOutcome: llmOutcome,
             applyStartedAt: applyStartedAt,
             applyCompletedAt: applyCompletedAt,
+            hotkeyToFirstAudioMilliseconds: millisecondsBetween(hotkeyDetectedAt, firstAudioBufferAt),
+            hotkeyDispatchMilliseconds: millisecondsBetween(hotkeyDetectedAt, recordingWorkflowStartedAt),
+            recordingPreparationMilliseconds: millisecondsBetween(recordingWorkflowStartedAt, audioEngineStartedAt),
+            audioEngineToFirstBufferMilliseconds: millisecondsBetween(audioEngineStartedAt, firstAudioBufferAt),
             stopToAudioReadyMilliseconds: millisecondsBetween(recordingStoppedAt, audioFileReadyAt),
             transcriptionDurationMilliseconds: millisecondsBetween(transcriptionStartedAt, transcriptionCompletedAt),
             stopToTranscriptionCompletedMilliseconds: millisecondsBetween(recordingStoppedAt, transcriptionCompletedAt),
@@ -114,6 +130,10 @@ struct HistoryPipelineTiming: Codable, Equatable {
 }
 
 struct HistoryPipelineStats: Codable, Equatable {
+    var hotkeyDetectedAt: Date?
+    var recordingWorkflowStartedAt: Date?
+    var audioEngineStartedAt: Date?
+    var firstAudioBufferAt: Date?
     var recordingStoppedAt: Date?
     var audioFileReadyAt: Date?
     var transcriptionStartedAt: Date?
@@ -134,6 +154,10 @@ struct HistoryPipelineStats: Codable, Equatable {
     var llmOutcome: LLMProcessingOutcomeDiagnostics?
     var applyStartedAt: Date?
     var applyCompletedAt: Date?
+    var hotkeyToFirstAudioMilliseconds: Int?
+    var hotkeyDispatchMilliseconds: Int?
+    var recordingPreparationMilliseconds: Int?
+    var audioEngineToFirstBufferMilliseconds: Int?
     var stopToAudioReadyMilliseconds: Int?
     var transcriptionDurationMilliseconds: Int?
     var stopToTranscriptionCompletedMilliseconds: Int?
@@ -149,7 +173,11 @@ struct HistoryPipelineStats: Codable, Equatable {
     var endToEndMilliseconds: Int?
 
     var hasData: Bool {
-        recordingStoppedAt != nil ||
+        hotkeyDetectedAt != nil ||
+            recordingWorkflowStartedAt != nil ||
+            audioEngineStartedAt != nil ||
+            firstAudioBufferAt != nil ||
+            recordingStoppedAt != nil ||
             audioFileReadyAt != nil ||
             transcriptionStartedAt != nil ||
             transcriptionCompletedAt != nil ||
@@ -169,6 +197,10 @@ struct HistoryPipelineStats: Codable, Equatable {
             llmOutcome != nil ||
             applyStartedAt != nil ||
             applyCompletedAt != nil ||
+            hotkeyToFirstAudioMilliseconds != nil ||
+            hotkeyDispatchMilliseconds != nil ||
+            recordingPreparationMilliseconds != nil ||
+            audioEngineToFirstBufferMilliseconds != nil ||
             stopToAudioReadyMilliseconds != nil ||
             transcriptionDurationMilliseconds != nil ||
             stopToTranscriptionCompletedMilliseconds != nil ||

--- a/Sources/Typeflux/History/SQLiteHistoryStore.swift
+++ b/Sources/Typeflux/History/SQLiteHistoryStore.swift
@@ -614,6 +614,10 @@ final class SQLiteHistoryStore: HistoryStore {
         var lines: [String] = []
 
         let timestamps: [(String, Date?)] = [
+            ("Hotkey detected", stats.hotkeyDetectedAt),
+            ("Recording workflow started", stats.recordingWorkflowStartedAt),
+            ("Audio engine started", stats.audioEngineStartedAt),
+            ("First audio buffer", stats.firstAudioBufferAt),
             ("Recording stopped", stats.recordingStoppedAt),
             ("Audio file ready", stats.audioFileReadyAt),
             ("STT started", stats.transcriptionStartedAt),
@@ -638,6 +642,10 @@ final class SQLiteHistoryStore: HistoryStore {
         }
 
         let durations: [(String, Int?)] = [
+            ("Hotkey -> first audio", stats.hotkeyToFirstAudioMilliseconds),
+            ("Hotkey dispatch", stats.hotkeyDispatchMilliseconds),
+            ("Recording preparation", stats.recordingPreparationMilliseconds),
+            ("Audio engine -> first buffer", stats.audioEngineToFirstBufferMilliseconds),
             ("Stop -> audio ready", stats.stopToAudioReadyMilliseconds),
             ("STT duration", stats.transcriptionDurationMilliseconds),
             ("Stop -> STT completed", stats.stopToTranscriptionCompletedMilliseconds),

--- a/Sources/Typeflux/Hotkey/EventTapHotkeyService.swift
+++ b/Sources/Typeflux/Hotkey/EventTapHotkeyService.swift
@@ -140,11 +140,11 @@ final class EventTapHotkeyService: HotkeyService {
     private static let modifierShortcutArbitrationDelay: TimeInterval = 0.22
     private static let duplicateHistoryRequestSuppression: TimeInterval = 0.18
 
-    var onActivationTap: (() -> Void)?
-    var onActivationPressBegan: (() -> Void)?
+    var onActivationTap: ((HotkeyEventContext) -> Void)?
+    var onActivationPressBegan: ((HotkeyEventContext) -> Void)?
     var onActivationPressEnded: (() -> Void)?
     var onActivationCancelled: (() -> Void)?
-    var onAskPressBegan: (() -> Void)?
+    var onAskPressBegan: ((HotkeyEventContext) -> Void)?
     var onAskPressEnded: (() -> Void)?
     var onPersonaPickerRequested: (() -> Void)?
     var onHistoryRequested: (() -> Void)?
@@ -428,14 +428,16 @@ final class EventTapHotkeyService: HotkeyService {
             case .activationTapped:
                 ErrorLogStore.shared.log("Hotkey(NSEvent): activation tap")
                 RecordingStartupLatencyTrace.shared.mark("hotkey.activation_tap")
+                let context = HotkeyEventContext()
                 DispatchQueue.main.async { [weak self] in
-                    self?.onActivationTap?()
+                    self?.onActivationTap?(context)
                 }
             case .begin(.activation):
                 ErrorLogStore.shared.log("Hotkey(NSEvent): activation down")
                 RecordingStartupLatencyTrace.shared.begin("hotkey.activation_begin")
+                let context = HotkeyEventContext()
                 DispatchQueue.main.async { [weak self] in
-                    self?.onActivationPressBegan?()
+                    self?.onActivationPressBegan?(context)
                 }
             case .end(.activation):
                 ErrorLogStore.shared.log("Hotkey(NSEvent): activation up")
@@ -454,8 +456,9 @@ final class EventTapHotkeyService: HotkeyService {
             case .begin(.ask):
                 ErrorLogStore.shared.log("Hotkey(NSEvent): ask down")
                 RecordingStartupLatencyTrace.shared.mark("hotkey.ask_begin")
+                let context = HotkeyEventContext()
                 DispatchQueue.main.async { [weak self] in
-                    self?.onAskPressBegan?()
+                    self?.onAskPressBegan?(context)
                 }
             case .end(.ask):
                 ErrorLogStore.shared.log("Hotkey(NSEvent): ask up")

--- a/Sources/Typeflux/Hotkey/HotkeyService.swift
+++ b/Sources/Typeflux/Hotkey/HotkeyService.swift
@@ -7,12 +7,20 @@ enum HotkeyAction {
     case history
 }
 
+struct HotkeyEventContext: Sendable, Equatable {
+    let detectedAt: Date
+
+    init(detectedAt: Date = Date()) {
+        self.detectedAt = detectedAt
+    }
+}
+
 protocol HotkeyService: AnyObject {
-    var onActivationTap: (() -> Void)? { get set }
-    var onActivationPressBegan: (() -> Void)? { get set }
+    var onActivationTap: ((HotkeyEventContext) -> Void)? { get set }
+    var onActivationPressBegan: ((HotkeyEventContext) -> Void)? { get set }
     var onActivationPressEnded: (() -> Void)? { get set }
     var onActivationCancelled: (() -> Void)? { get set }
-    var onAskPressBegan: (() -> Void)? { get set }
+    var onAskPressBegan: ((HotkeyEventContext) -> Void)? { get set }
     var onAskPressEnded: (() -> Void)? { get set }
     var onPersonaPickerRequested: (() -> Void)? { get set }
     var onHistoryRequested: (() -> Void)? { get set }

--- a/Sources/Typeflux/Resources/en.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/en.lproj/Localizable.strings
@@ -444,6 +444,10 @@
 "history.detail.error" = "Error";
 "history.stats.recordingStoppedAt" = "Recording stopped";
 "history.stats.audioFileReadyAt" = "Audio file ready";
+"history.stats.hotkeyToFirstAudio" = "User key press";
+"history.stats.hotkeyDispatch" = "Hotkey dispatch";
+"history.stats.recordingPreparation" = "Recording preparation";
+"history.stats.audioEngineToFirstBuffer" = "Device first buffer";
 "history.stats.transcriptionStartedAt" = "STT started";
 "history.stats.transcriptionCompletedAt" = "STT completed";
 "history.stats.llmProcessingStartedAt" = "Submitted to LLM";
@@ -516,6 +520,8 @@
 "history.timeline.slowest" = "Longest stage";
 "history.timeline.keyWaits" = "Key waits";
 "history.timeline.audio" = "Audio prep";
+"history.timeline.recordingStartup" = "Recording startup";
+"history.timeline.recording" = "Recording";
 "history.timeline.realtime" = "Realtime speech";
 "history.timeline.transcription" = "Recognition finalization";
 "history.timeline.llm" = "AI generation";

--- a/Sources/Typeflux/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/ja.lproj/Localizable.strings
@@ -438,6 +438,10 @@
 "history.detail.error" = "エラー";
 "history.stats.recordingStoppedAt" = "録音停止";
 "history.stats.audioFileReadyAt" = "音声ファイルの準備ができました";
+"history.stats.hotkeyToFirstAudio" = "キー入力から録音開始";
+"history.stats.hotkeyDispatch" = "ホットキー処理";
+"history.stats.recordingPreparation" = "録音準備";
+"history.stats.audioEngineToFirstBuffer" = "デバイス初回バッファ待機";
 "history.stats.transcriptionStartedAt" = "STT が開始されました";
 "history.stats.transcriptionCompletedAt" = "STT が完了しました";
 "history.stats.llmProcessingStartedAt" = "LLM に送信されました";
@@ -510,6 +514,8 @@
 "history.timeline.slowest" = "最長ステージ";
 "history.timeline.keyWaits" = "主な待ち時間";
 "history.timeline.audio" = "音声準備";
+"history.timeline.recordingStartup" = "録音開始準備";
+"history.timeline.recording" = "録音中";
 "history.timeline.realtime" = "リアルタイム音声";
 "history.timeline.transcription" = "認識確定";
 "history.timeline.llm" = "AI 生成";

--- a/Sources/Typeflux/Resources/ko.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/ko.lproj/Localizable.strings
@@ -438,6 +438,10 @@
 "history.detail.error" = "오류";
 "history.stats.recordingStoppedAt" = "녹음이 중지되었습니다.";
 "history.stats.audioFileReadyAt" = "오디오 파일 준비됨";
+"history.stats.hotkeyToFirstAudio" = "키 입력 후 녹음 시작";
+"history.stats.hotkeyDispatch" = "단축키 이벤트 처리";
+"history.stats.recordingPreparation" = "녹음 준비";
+"history.stats.audioEngineToFirstBuffer" = "장치 첫 버퍼 대기";
 "history.stats.transcriptionStartedAt" = "STT 시작됨";
 "history.stats.transcriptionCompletedAt" = "STT 완료됨";
 "history.stats.llmProcessingStartedAt" = "LLM에 제출됨";
@@ -510,6 +514,8 @@
 "history.timeline.slowest" = "가장 긴 단계";
 "history.timeline.keyWaits" = "주요 대기 시간";
 "history.timeline.audio" = "오디오 준비";
+"history.timeline.recordingStartup" = "녹음 시작 준비";
+"history.timeline.recording" = "녹음 중";
 "history.timeline.realtime" = "실시간 음성";
 "history.timeline.transcription" = "인식 확정";
 "history.timeline.llm" = "AI 생성";

--- a/Sources/Typeflux/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/zh-Hans.lproj/Localizable.strings
@@ -444,6 +444,10 @@
 "history.detail.error" = "错误信息";
 "history.stats.recordingStoppedAt" = "停止录音";
 "history.stats.audioFileReadyAt" = "音频文件就绪";
+"history.stats.hotkeyToFirstAudio" = "用户按键时间";
+"history.stats.hotkeyDispatch" = "按键事件调度";
+"history.stats.recordingPreparation" = "录音准备";
+"history.stats.audioEngineToFirstBuffer" = "设备首帧等待";
 "history.stats.transcriptionStartedAt" = "开始语音转写";
 "history.stats.transcriptionCompletedAt" = "完成语音转写";
 "history.stats.llmProcessingStartedAt" = "提交给大语言模型";
@@ -516,6 +520,8 @@
 "history.timeline.slowest" = "耗时最长";
 "history.timeline.keyWaits" = "关键等待";
 "history.timeline.audio" = "音频整理";
+"history.timeline.recordingStartup" = "录音启动";
+"history.timeline.recording" = "录音中";
 "history.timeline.realtime" = "实时语音";
 "history.timeline.transcription" = "识别确认";
 "history.timeline.llm" = "AI 生成";

--- a/Sources/Typeflux/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/zh-Hant.lproj/Localizable.strings
@@ -442,6 +442,10 @@
 "history.detail.error" = "錯誤資訊";
 "history.stats.recordingStoppedAt" = "停止錄音";
 "history.stats.audioFileReadyAt" = "音訊檔就緒";
+"history.stats.hotkeyToFirstAudio" = "使用者按鍵時間";
+"history.stats.hotkeyDispatch" = "按鍵事件排程";
+"history.stats.recordingPreparation" = "錄音準備";
+"history.stats.audioEngineToFirstBuffer" = "裝置首幀等待";
 "history.stats.transcriptionStartedAt" = "開始語音轉寫";
 "history.stats.transcriptionCompletedAt" = "完成語音轉寫";
 "history.stats.llmProcessingStartedAt" = "提交給大語言模型";
@@ -514,6 +518,8 @@
 "history.timeline.slowest" = "耗時最長";
 "history.timeline.keyWaits" = "關鍵等待";
 "history.timeline.audio" = "音訊整理";
+"history.timeline.recordingStartup" = "錄音啟動";
+"history.timeline.recording" = "錄音中";
 "history.timeline.realtime" = "即時語音";
 "history.timeline.transcription" = "辨識確認";
 "history.timeline.llm" = "AI 生成";

--- a/Sources/Typeflux/Settings/SettingsViewModel.swift
+++ b/Sources/Typeflux/Settings/SettingsViewModel.swift
@@ -3097,6 +3097,22 @@ final class StudioViewModel: ObservableObject {
 
         var sources = [
             LaneSource(
+                id: "recording-startup",
+                title: L("history.timeline.recordingStartup"),
+                start: stats.hotkeyDetectedAt,
+                end: stats.firstAudioBufferAt,
+                tone: .audio,
+                isDetail: false
+            ),
+            LaneSource(
+                id: "recording",
+                title: L("history.timeline.recording"),
+                start: stats.firstAudioBufferAt,
+                end: stats.recordingStoppedAt,
+                tone: .audio,
+                isDetail: false
+            ),
+            LaneSource(
                 id: "audio",
                 title: L("history.timeline.audio"),
                 start: stats.recordingStoppedAt,
@@ -3402,6 +3418,18 @@ final class StudioViewModel: ObservableObject {
         }
 
         var keyMetricSources: [(String, String, Int?)] = [
+            ("hotkey-to-first-audio", L("history.stats.hotkeyToFirstAudio"), stats.hotkeyToFirstAudioMilliseconds),
+            ("hotkey-dispatch", L("history.stats.hotkeyDispatch"), stats.hotkeyDispatchMilliseconds),
+            (
+                "recording-preparation",
+                L("history.stats.recordingPreparation"),
+                stats.recordingPreparationMilliseconds
+            ),
+            (
+                "audio-engine-first-buffer",
+                L("history.stats.audioEngineToFirstBuffer"),
+                stats.audioEngineToFirstBufferMilliseconds
+            ),
             ("connection", L("history.stats.realtimeConnection"), stats.realtimeConnectionDurationMilliseconds),
             (
                 "first-result",

--- a/Sources/Typeflux/Workflow/WorkflowController+Processing.swift
+++ b/Sources/Typeflux/Workflow/WorkflowController+Processing.swift
@@ -389,6 +389,7 @@ extension WorkflowController {
 
     func finishRecordingAndProcess(
         recordingStoppedAt: Date,
+        startupContext: RecordingStartupContext? = nil,
         bypassPersonaRewrite: Bool = false
     ) async {
         do {
@@ -555,6 +556,10 @@ extension WorkflowController {
                 selectionOriginalText: recordingIntent == .askSelection ? selectedText : nil,
                 recordingDurationSeconds: validatedAudioFile.duration,
                 pipelineTiming: HistoryPipelineTiming(
+                    hotkeyDetectedAt: startupContext?.hotkeyDetectedAt,
+                    recordingWorkflowStartedAt: startupContext?.recordingWorkflowStartedAt,
+                    audioEngineStartedAt: audioFile.startupTiming?.audioEngineStartedAt,
+                    firstAudioBufferAt: audioFile.startupTiming?.firstAudioBufferAt,
                     recordingStoppedAt: recordingStoppedAt,
                     audioFileReadyAt: audioFileReadyAt
                 ),
@@ -2449,6 +2454,16 @@ extension WorkflowController {
         guard let timing = record.pipelineTiming, timing.hasData else { return }
 
         let durations: [(String, Int?)] = [
+            ("hotkey_to_first_audio_ms", timing.millisecondsBetween(timing.hotkeyDetectedAt, timing.firstAudioBufferAt)),
+            ("hotkey_dispatch_ms", timing.millisecondsBetween(timing.hotkeyDetectedAt, timing.recordingWorkflowStartedAt)),
+            (
+                "recording_preparation_ms",
+                timing.millisecondsBetween(timing.recordingWorkflowStartedAt, timing.audioEngineStartedAt)
+            ),
+            (
+                "audio_engine_to_first_buffer_ms",
+                timing.millisecondsBetween(timing.audioEngineStartedAt, timing.firstAudioBufferAt)
+            ),
             ("stop_to_audio_ms", timing.millisecondsBetween(timing.recordingStoppedAt, timing.audioFileReadyAt)),
             ("stt_ms", timing.millisecondsBetween(timing.transcriptionStartedAt, timing.transcriptionCompletedAt)),
             ("stop_to_stt_ms", timing.millisecondsBetween(timing.recordingStoppedAt, timing.transcriptionCompletedAt)),

--- a/Sources/Typeflux/Workflow/WorkflowController.swift
+++ b/Sources/Typeflux/Workflow/WorkflowController.swift
@@ -3,6 +3,11 @@ import AppKit
 import Foundation
 import os
 
+struct RecordingStartupContext: Sendable, Equatable {
+    let hotkeyDetectedAt: Date
+    let recordingWorkflowStartedAt: Date
+}
+
 final class WorkflowController {
     let logger = Logger(subsystem: "ai.gulu.app.typeflux", category: "WorkflowController")
     static let recordingTimeoutNanoseconds: UInt64 = 600_000_000_000 // 10 minutes
@@ -119,6 +124,7 @@ final class WorkflowController {
     var recordingIntent: RecordingIntent = .dictation
     var hotkeyPressedAt: TimeInterval?
     var audioRecorderStartedAt: TimeInterval?
+    var recordingStartupContext: RecordingStartupContext?
     var recordingTimeoutTask: Task<Void, Never>?
     var processingTimeoutTask: Task<Void, Never>?
     var selectionTask: Task<TextSelectionSnapshot, Never>?
@@ -298,11 +304,15 @@ final class WorkflowController {
     }
 
     func start() {
-        hotkeyService.onActivationTap = { [weak self] in
-            self?.handleActivationTap()
+        hotkeyService.onActivationTap = { [weak self] context in
+            self?.handleActivationTap(hotkeyDetectedAt: context.detectedAt)
         }
-        hotkeyService.onActivationPressBegan = { [weak self] in
-            self?.handlePressBegan(intent: .dictation, startLocked: false)
+        hotkeyService.onActivationPressBegan = { [weak self] context in
+            self?.handlePressBegan(
+                intent: .dictation,
+                startLocked: false,
+                hotkeyDetectedAt: context.detectedAt
+            )
         }
         hotkeyService.onActivationPressEnded = { [weak self] in
             self?.handlePressEnded()
@@ -310,8 +320,12 @@ final class WorkflowController {
         hotkeyService.onActivationCancelled = { [weak self] in
             self?.cancelRecording()
         }
-        hotkeyService.onAskPressBegan = { [weak self] in
-            self?.handlePressBegan(intent: .askSelection, startLocked: true)
+        hotkeyService.onAskPressBegan = { [weak self] context in
+            self?.handlePressBegan(
+                intent: .askSelection,
+                startLocked: true,
+                hotkeyDetectedAt: context.detectedAt
+            )
         }
         hotkeyService.onAskPressEnded = { [weak self] in
             self?.handleAskPressEnded()
@@ -436,6 +450,7 @@ final class WorkflowController {
         isAudioRecorderStarting = false
         shouldFinishRecordingAfterAudioStart = false
         audioRecorderStartedAt = nil
+        recordingStartupContext = nil
         pendingRecordingStartID = nil
         suppressActivationTapUntil = nil
         recordingMode = .holdToTalk
@@ -541,7 +556,7 @@ final class WorkflowController {
         }
     }
 
-    func handleActivationTap() {
+    func handleActivationTap(hotkeyDetectedAt: Date = Date()) {
         if suppressNextActivationTapAfterLocalModelDownloadAlert {
             suppressNextActivationTapAfterLocalModelDownloadAlert = false
             RecordingStartupLatencyTrace.shared.mark("workflow.activation_tap_suppressed.local_model_download")
@@ -553,10 +568,18 @@ final class WorkflowController {
             return
         }
         suppressActivationTapUntil = nil
-        handlePressBegan(intent: .dictation, startLocked: true)
+        handlePressBegan(
+            intent: .dictation,
+            startLocked: true,
+            hotkeyDetectedAt: hotkeyDetectedAt
+        )
     }
 
-    func handlePressBegan(intent: RecordingIntent, startLocked: Bool) {
+    func handlePressBegan(
+        intent: RecordingIntent,
+        startLocked: Bool,
+        hotkeyDetectedAt: Date = Date()
+    ) {
         RecordingStartupLatencyTrace.shared.mark("workflow.press_began.\(intent.traceName)")
         if isPersonaPickerPresented {
             dismissPersonaPicker()
@@ -620,6 +643,10 @@ final class WorkflowController {
         }
 
         hotkeyPressedAt = startLocked ? nil : monotonicNow()
+        recordingStartupContext = RecordingStartupContext(
+            hotkeyDetectedAt: hotkeyDetectedAt,
+            recordingWorkflowStartedAt: Date()
+        )
 
         cancelCurrentProcessing(resetUI: false, reason: L("workflow.cancel.newRecording"))
         isRecording = true
@@ -1047,6 +1074,39 @@ final class WorkflowController {
             let livePreviewer = liveTranscriptionPreviewer
             let canUseRealtimeTranscription = effectiveIntent != .askSelection
             let usesLivePreview = canUseRealtimeTranscription && shouldUseLiveTranscriptionPreview()
+            let recordingAudioBufferRelay = canUseRealtimeTranscription
+                ? RecordingStartupAudioBufferRelay()
+                : nil
+            try await startAudioRecorderWithStartupRetry(
+                levelHandler: { [weak self] level in
+                    self?.overlayController.updateLevel(level)
+                },
+                audioBufferHandler: recordingAudioBufferRelay.map { relay in
+                    { buffer in relay.append(buffer) }
+                }
+            )
+            RecordingStartupLatencyTrace.shared.mark("workflow.audio_start_return")
+            isAudioRecorderStarting = false
+            isAudioRecorderStarted = true
+            audioRecorderStartedAt = monotonicNow()
+            pendingRecordingStartID = nil
+
+            guard isRecording else {
+                recordingAudioBufferRelay?.cancel()
+                isAudioRecorderStarted = false
+                audioRecorderStartedAt = nil
+                _ = try? audioRecorder.stop()
+                Task { await livePreviewer?.cancel() }
+                return
+            }
+
+            if shouldFinishRecordingAfterAudioStart {
+                recordingAudioBufferRelay?.cancel()
+                shouldFinishRecordingAfterAudioStart = false
+                finishRecordingFromCurrentMode()
+                return
+            }
+
             if usesLivePreview {
                 await livePreviewer?.prepareForStart()
             }
@@ -1067,6 +1127,11 @@ final class WorkflowController {
             } else {
                 nil
             }
+            guard isRecording else {
+                recordingAudioBufferRelay?.cancel()
+                await realtimeSession?.cancel()
+                return
+            }
             if effectiveIntent == .askSelection {
                 NetworkDebugLogger
                     .logMessage("[Ask Flow] realtime transcription disabled for isolated Ask Anything recording")
@@ -1075,44 +1140,26 @@ final class WorkflowController {
             activeRealtimeTranscriptionSession = realtimeSession
             activeRealtimeAudioBufferPump = realtimeAudioBufferPump
             await realtimeSession?.start()
-            try await startAudioRecorderWithStartupRetry(
-                levelHandler: { [weak self] level in
-                    self?.overlayController.updateLevel(level)
-                },
-                audioBufferHandler: (usesLivePreview || realtimeSession != nil) ? { buffer in
+            guard isRecording else {
+                recordingAudioBufferRelay?.cancel()
+                realtimeAudioBufferPump?.cancel()
+                await realtimeSession?.cancel()
+                return
+            }
+            if usesLivePreview || realtimeAudioBufferPump != nil {
+                recordingAudioBufferRelay?.activate { buffer in
                     realtimeAudioBufferPump?.append(buffer)
                     Task {
                         if usesLivePreview {
                             await livePreviewer?.append(buffer)
                         }
                     }
-                } : nil
-            )
-            RecordingStartupLatencyTrace.shared.mark("workflow.audio_start_return")
-            isAudioRecorderStarting = false
-            isAudioRecorderStarted = true
-            audioRecorderStartedAt = monotonicNow()
-            pendingRecordingStartID = nil
+                }
+            } else {
+                recordingAudioBufferRelay?.cancel()
+            }
             if usesLivePreview {
                 startLiveTranscriptionPreviewIfNeeded(livePreviewer)
-            }
-
-            guard isRecording else {
-                isAudioRecorderStarted = false
-                audioRecorderStartedAt = nil
-                _ = try? audioRecorder.stop()
-                Task { await livePreviewer?.cancel() }
-                realtimeAudioBufferPump?.cancel()
-                Task { await realtimeSession?.cancel() }
-                activeRealtimeTranscriptionSession = nil
-                activeRealtimeAudioBufferPump = nil
-                return
-            }
-
-            if shouldFinishRecordingAfterAudioStart {
-                shouldFinishRecordingAfterAudioStart = false
-                finishRecordingFromCurrentMode()
-                return
             }
 
             let askAnswerWindowIsFrontmost = Self.isTypefluxAskAnswerWindowFrontmost()
@@ -1183,6 +1230,8 @@ final class WorkflowController {
             isAudioRecorderStarting = false
             shouldFinishRecordingAfterAudioStart = false
             audioRecorderStartedAt = nil
+            let startupContext = recordingStartupContext
+            recordingStartupContext = nil
             pendingRecordingStartID = nil
             suppressActivationTapUntil = nil
             recordingMode = .holdToTalk
@@ -1192,6 +1241,10 @@ final class WorkflowController {
                 transcriptionStatus: .skipped,
                 processingStatus: .skipped,
                 applyStatus: .skipped
+            )
+            record.pipelineTiming = HistoryPipelineTiming(
+                hotkeyDetectedAt: startupContext?.hotkeyDetectedAt,
+                recordingWorkflowStartedAt: startupContext?.recordingWorkflowStartedAt
             )
             let userMessage = Self.audioStartFailureMessage(for: error)
             record.errorMessage = userMessage
@@ -1273,6 +1326,8 @@ final class WorkflowController {
             recordingMode: recordingMode,
             recordingIntent: recordingIntent
         )
+        let startupContext = recordingStartupContext
+        recordingStartupContext = nil
         isRecording = false
         if !shouldStopAudioRecorder {
             isAudioRecorderStarted = false
@@ -1303,6 +1358,7 @@ final class WorkflowController {
             guard let self else { return }
             await finishRecordingAndProcess(
                 recordingStoppedAt: recordingStoppedAt,
+                startupContext: startupContext,
                 bypassPersonaRewrite: useQuickInput
             )
         }

--- a/Tests/TypefluxTests/HistoryRecordTests.swift
+++ b/Tests/TypefluxTests/HistoryRecordTests.swift
@@ -58,6 +58,23 @@ final class HistoryRecordTests: XCTestCase {
         XCTAssertEqual(stats.stopToTranscriptionCompletedMilliseconds, 1200)
     }
 
+    func testGeneratedStatsComputesRecordingStartupDurations() {
+        let base = Date(timeIntervalSince1970: 1000)
+        let timing = HistoryPipelineTiming(
+            hotkeyDetectedAt: base,
+            recordingWorkflowStartedAt: base.addingTimeInterval(0.015),
+            audioEngineStartedAt: base.addingTimeInterval(0.095),
+            firstAudioBufferAt: base.addingTimeInterval(0.135)
+        )
+
+        let stats = timing.generatedStats()
+
+        XCTAssertEqual(stats.hotkeyToFirstAudioMilliseconds, 135)
+        XCTAssertEqual(stats.hotkeyDispatchMilliseconds, 15)
+        XCTAssertEqual(stats.recordingPreparationMilliseconds, 80)
+        XCTAssertEqual(stats.audioEngineToFirstBufferMilliseconds, 40)
+    }
+
     func testGeneratedStatsEndToEndUsesLatestAvailableTimestamp() {
         let base = Date(timeIntervalSince1970: 1000)
         var timing = HistoryPipelineTiming()

--- a/Tests/TypefluxTests/SettingsViewModelHistoryAudioTests.swift
+++ b/Tests/TypefluxTests/SettingsViewModelHistoryAudioTests.swift
@@ -138,6 +138,38 @@ final class SettingsViewModelHistoryAudioTests: XCTestCase {
         XCTAssertNotNil(timeline?.totalDurationText)
     }
 
+    func testHistoryPipelineTimelineIncludesRecordingStartupAndUserKeyPressMetric() {
+        let base = Date(timeIntervalSince1970: 1000)
+        let recordID = UUID()
+        let record = HistoryRecord(
+            id: recordID,
+            date: base,
+            pipelineTiming: HistoryPipelineTiming(
+                hotkeyDetectedAt: base,
+                recordingWorkflowStartedAt: base.addingTimeInterval(0.01),
+                audioEngineStartedAt: base.addingTimeInterval(0.08),
+                firstAudioBufferAt: base.addingTimeInterval(0.12),
+                recordingStoppedAt: base.addingTimeInterval(1.12),
+                audioFileReadyAt: base.addingTimeInterval(1.2)
+            )
+        )
+        let viewModel = makeViewModel(
+            records: [record],
+            audioPreviewPlayer: FakeHistoryAudioPreviewPlayer(playResult: true)
+        )
+        waitForHistoryRecord(recordID, in: viewModel)
+
+        let timeline = viewModel.displayedHistory.first?.pipelineTimeline
+
+        XCTAssertEqual(timeline?.lanes.first(where: { $0.id == "recording-startup" })?.durationMilliseconds, 120)
+        XCTAssertEqual(timeline?.lanes.first(where: { $0.id == "recording" })?.durationMilliseconds, 1000)
+        XCTAssertEqual(
+            timeline?.keyMetrics.first(where: { $0.id == "hotkey-to-first-audio" })?.value,
+            "120 ms"
+        )
+        XCTAssertEqual(timeline?.timelineSpanDurationText, "1.20 s")
+    }
+
     func testHistoryPipelineTimelineIncludesASRAndLLMNetworkStages() {
         let base = Date(timeIntervalSince1970: 2_000)
         let recordID = UUID()

--- a/Tests/TypefluxTests/WorkflowControllerAutomaticVocabularyTests.swift
+++ b/Tests/TypefluxTests/WorkflowControllerAutomaticVocabularyTests.swift
@@ -457,11 +457,11 @@ private final class MockWorkflowLLMAgentService: LLMAgentService {
 }
 
 private final class MockWorkflowHotkeyService: HotkeyService {
-    var onActivationTap: (() -> Void)?
-    var onActivationPressBegan: (() -> Void)?
+    var onActivationTap: ((HotkeyEventContext) -> Void)?
+    var onActivationPressBegan: ((HotkeyEventContext) -> Void)?
     var onActivationPressEnded: (() -> Void)?
     var onActivationCancelled: (() -> Void)?
-    var onAskPressBegan: (() -> Void)?
+    var onAskPressBegan: ((HotkeyEventContext) -> Void)?
     var onAskPressEnded: (() -> Void)?
     var onPersonaPickerRequested: (() -> Void)?
     var onHistoryRequested: (() -> Void)?

--- a/Tests/TypefluxTests/WorkflowControllerProcessingTests.swift
+++ b/Tests/TypefluxTests/WorkflowControllerProcessingTests.swift
@@ -914,6 +914,36 @@ final class WorkflowControllerProcessingTests: XCTestCase {
         await waitForMainActorWork()
     }
 
+    func testBeginRecordingStartsAudioBeforeRealtimeSessionSetupCompletes() async throws {
+        let eventRecorder = ThreadSafeEventRecorder()
+        let realtimeTranscriber = DelayedRealtimeSessionFactory(eventRecorder: eventRecorder)
+        let audioRecorder = MockProcessingAudioRecorder {
+            eventRecorder.append("audio-start")
+        }
+        let controller = makeWorkflowController(
+            audioRecorder: audioRecorder,
+            sttTranscriber: realtimeTranscriber,
+            configureSettings: { $0.sttProvider = .aliCloud }
+        )
+
+        let recordingTask = Task {
+            await controller.beginRecording(intent: .dictation, startLocked: false)
+        }
+        await waitUntil {
+            eventRecorder.snapshot().contains("realtime-setup")
+        }
+
+        let events = eventRecorder.snapshot()
+        let audioStartIndex = try XCTUnwrap(events.firstIndex(of: "audio-start"))
+        let realtimeSetupIndex = try XCTUnwrap(events.firstIndex(of: "realtime-setup"))
+        XCTAssertLessThan(audioStartIndex, realtimeSetupIndex)
+
+        realtimeTranscriber.releaseSetup()
+        await recordingTask.value
+        controller.cancelRecording()
+        await waitForMainActorWork()
+    }
+
     func testBeginRecordingDoesNotPlayCueWhileAudioStartIsPending() async {
         let eventRecorder = ThreadSafeEventRecorder()
         let audioRecorder = BlockingStartAudioRecorder()
@@ -2377,11 +2407,11 @@ private final class MockProcessingLLMAgentService: LLMAgentService {
 }
 
 private final class MockProcessingHotkeyService: HotkeyService {
-    var onActivationTap: (() -> Void)?
-    var onActivationPressBegan: (() -> Void)?
+    var onActivationTap: ((HotkeyEventContext) -> Void)?
+    var onActivationPressBegan: ((HotkeyEventContext) -> Void)?
     var onActivationPressEnded: (() -> Void)?
     var onActivationCancelled: (() -> Void)?
-    var onAskPressBegan: (() -> Void)?
+    var onAskPressBegan: ((HotkeyEventContext) -> Void)?
     var onAskPressEnded: (() -> Void)?
     var onPersonaPickerRequested: (() -> Void)?
     var onHistoryRequested: (() -> Void)?
@@ -2891,6 +2921,47 @@ private actor MockOptimizeRealtimeSession: RealtimeTranscriptionSession, Realtim
 
     func callCounts() -> (finish: Int, cancel: Int) {
         (finishCallCount, cancelCallCount)
+    }
+}
+
+private final class DelayedRealtimeSessionFactory: RealtimeTranscriptionSessionFactory, @unchecked Sendable {
+    private let eventRecorder: ThreadSafeEventRecorder
+    private let lock = NSLock()
+    private var setupContinuation: CheckedContinuation<Void, Never>?
+    private var setupWasReleased = false
+
+    init(eventRecorder: ThreadSafeEventRecorder) {
+        self.eventRecorder = eventRecorder
+    }
+
+    func transcribe(audioFile _: AudioFile) async throws -> String {
+        ""
+    }
+
+    func makeRealtimeTranscriptionSession(
+        scenario _: TypefluxCloudScenario,
+        onUpdate _: @escaping @Sendable (TranscriptionSnapshot) async -> Void
+    ) async throws -> any RealtimeTranscriptionSession {
+        eventRecorder.append("realtime-setup")
+        await withCheckedContinuation { continuation in
+            lock.withLock {
+                if setupWasReleased {
+                    continuation.resume()
+                } else {
+                    setupContinuation = continuation
+                }
+            }
+        }
+        return MockOptimizeRealtimeSession(optimize: true, transcript: "")
+    }
+
+    func releaseSetup() {
+        let continuation = lock.withLock { () -> CheckedContinuation<Void, Never>? in
+            setupWasReleased = true
+            defer { setupContinuation = nil }
+            return setupContinuation
+        }
+        continuation?.resume()
     }
 }
 


### PR DESCRIPTION
## Summary

- start audio capture before realtime ASR and live-preview setup, buffering early audio until consumers are ready
- record hotkey, workflow, audio-engine, and first-buffer timestamps for startup diagnostics
- add recording-startup lanes and localized latency metrics to history

## Tests

- `swift test` (2458 XCTest tests + 8 Swift Testing tests passed)
- `swift test --filter 'WorkflowControllerProcessingTests|FileHistoryStoreTests'` (110 tests passed after final self-review changes)
- `make coverage` (completed; repository-wide line coverage: 38.70%)
- `git diff --check`

`make format` could not run because `swiftformat` is not installed in the runtime.

Closes GUL-66
