### PR TITLE
GUL-66: add opt-in instant voice input

### DIFF
--- a/Sources/Typeflux/Audio/AVFoundationAudioRecorder.swift
+++ b/Sources/Typeflux/Audio/AVFoundationAudioRecorder.swift
@@ -1,3 +1,4 @@
+import AppKit
 import AVFoundation
 import AudioToolbox
 import Foundation
@@ -5,11 +6,14 @@ import TypefluxAudioSafety
 
 final class AVFoundationAudioRecorder: AudioRecorder {
     static let inputTapBufferSize: AVAudioFrameCount = 512
+    static let instantVoiceInputPreRollDuration: TimeInterval = 0.5
     private static let outputMuteDelayWithStartCue: Duration = .milliseconds(1225)
     private static let outputMuteDelayWithoutStartCue: Duration = .milliseconds(180)
     private static let silentInputRecoveryDelay: DispatchTimeInterval = .seconds(1)
     private static let silentInputRecoveryPeakPowerThreshold: Float = -58
     private static let audioStartupTimeout: DispatchTimeInterval = .seconds(5)
+    private static let instantCaptureArmingTimeout: DispatchTimeInterval = .seconds(2)
+    private static let preparedInputBuildWaitTimeout: DispatchTimeInterval = .seconds(4)
     private static let configurationRecoveryDelay: DispatchTimeInterval = .milliseconds(200)
     private static let configurationRecoveryContinuationDelay: DispatchTimeInterval = .seconds(1)
     private static let configurationRecoveryRetryDelay: TimeInterval = 0.25
@@ -40,6 +44,7 @@ final class AVFoundationAudioRecorder: AudioRecorder {
     private let inputPreparationQueue = DispatchQueue(label: "typeflux.audio.input-preparation", qos: .userInitiated)
     private let lifecycleLock = NSLock()
     private let preparedInputLock = NSLock()
+    private let preparedInputBuildGroup = DispatchGroup()
     private let stateCondition = NSCondition()
     private var audioFile: AVAudioFile?
     private var recordingBufferConverter: AudioRecordingBufferConverter?
@@ -63,8 +68,13 @@ final class AVFoundationAudioRecorder: AudioRecorder {
     private var preparedInputEngine: PreparedInputEngine?
     private var preparedInputGeneration: UInt64 = 0
     private var preparedInputBuildIsPending = false
+    private var preparedInputBuildNeedsRetry = false
+    private var preparedInputIsSuspended = false
     private var preparedMicrophoneObserver: NSObjectProtocol?
+    private var instantVoiceInputObserver: NSObjectProtocol?
+    private var preparedEngineConfigurationObserver: NSObjectProtocol?
     private var preparedDefaultInputDeviceChangeObservation: AudioInputDeviceChangeObservation?
+    private var workspaceObservers: [NSObjectProtocol] = []
 
     init(
         settingsStore: SettingsStore,
@@ -81,13 +91,13 @@ final class AVFoundationAudioRecorder: AudioRecorder {
         self.makeAudioEngine = makeAudioEngine
         engine = makeAudioEngine()
         self.sleep = sleep
-        observePreparedInputInvalidation()
+        observePreparedInputLifecycle()
         schedulePreparedInputEngineBuild()
     }
 
     deinit {
         removeInputChangeObservers()
-        removePreparedInputInvalidationObservers()
+        removePreparedInputLifecycleObservers()
         discardPreparedInputEngine()
         inputHealthCheckWorkItem?.cancel()
     }
@@ -213,7 +223,11 @@ final class AVFoundationAudioRecorder: AudioRecorder {
 
         writeCoordinator.drain()
 
-        let duration = Date().timeIntervalSince(currentStartedAt ?? Date())
+        let wallClockDuration = Date().timeIntervalSince(currentStartedAt ?? Date())
+        let writtenAudioDuration = currentAudioFile.processingFormat.sampleRate > 0
+            ? Double(currentAudioFile.length) / currentAudioFile.processingFormat.sampleRate
+            : 0
+        let duration = max(wallClockDuration, writtenAudioDuration)
         let fileURL = currentAudioFile.url
 
         stateCondition.lock()
@@ -299,21 +313,27 @@ final class AVFoundationAudioRecorder: AudioRecorder {
         let sessionEngine = preparedInput.engine
         let inputFormat = preparedInput.inputFormat
         let startupBufferRelay = preparedInput.startupBufferRelay
+        let usesInstantPreRoll = preparedInput.includesInstantPreRoll && sessionEngine.isRunning
+
+        if preparedInput.includesInstantPreRoll, !usesInstantPreRoll {
+            startupBufferRelay.discardBufferedAudio()
+        }
 
         guard !startupAttempt.isCancelled else {
             disposePreparedInputEngine(preparedInput)
             throw RecorderError.inputStartupTimedOut
         }
 
-        let audioEngineStartedAt: Date
-        do {
-            try sessionEngine.start()
-            audioEngineStartedAt = Date()
-            RecordingStartupLatencyTrace.shared.mark("audio.engine_start_return")
-        } catch {
-            disposePreparedInputEngine(preparedInput)
-            throw error
+        let audioEngineStartedAt = Date()
+        if !sessionEngine.isRunning {
+            do {
+                try sessionEngine.start()
+            } catch {
+                disposePreparedInputEngine(preparedInput)
+                throw error
+            }
         }
+        RecordingStartupLatencyTrace.shared.mark("audio.engine_start_return")
 
         guard isPreparedInputEngineCurrent(preparedInput.signature) else {
             NetworkDebugLogger.logMessage(
@@ -371,11 +391,16 @@ final class AVFoundationAudioRecorder: AudioRecorder {
             inputGenerationID: inputGenerationID,
             startupBufferRelay: startupBufferRelay,
             audioEngineStartedAt: audioEngineStartedAt,
-            firstAudioBufferAt: startupBufferRelay.firstBufferReceivedAt
+            firstAudioBufferAt: usesInstantPreRoll
+                ? audioEngineStartedAt
+                : startupBufferRelay.firstBufferReceivedAt
         )
     }
 
     private func takePreparedInputEngineOrBuild() throws -> PreparedInputEngine {
+        guard waitForPendingPreparedInputBuild() else {
+            throw RecorderError.inputStartupTimedOut
+        }
         let currentSignature = try currentPreparedInputSignature()
         var cachedInput: PreparedInputEngine?
         var staleInput: PreparedInputEngine?
@@ -404,7 +429,10 @@ final class AVFoundationAudioRecorder: AudioRecorder {
         return try buildPreparedInputEngine(signature: currentSignature)
     }
 
-    private func buildPreparedInputEngine(signature: PreparedInputEngineSignature) throws -> PreparedInputEngine {
+    private func buildPreparedInputEngine(
+        signature: PreparedInputEngineSignature,
+        includesInstantPreRoll: Bool = false
+    ) throws -> PreparedInputEngine {
         var preparedEngine = makeAudioEngine()
         let inputNodeAndFormat: (AVAudioInputNode, AVAudioFormat)
         do {
@@ -420,7 +448,9 @@ final class AVFoundationAudioRecorder: AudioRecorder {
         }
 
         let inputNode = inputNodeAndFormat.0
-        let startupBufferRelay = RecordingStartupAudioBufferRelay()
+        let startupBufferRelay = RecordingStartupAudioBufferRelay(
+            maximumBufferedDuration: includesInstantPreRoll ? Self.instantVoiceInputPreRollDuration : nil
+        )
         inputNode.removeTap(onBus: 0)
         do {
             try installInputTap(on: inputNode) { [startupBufferRelay] buffer, _ in
@@ -437,17 +467,22 @@ final class AVFoundationAudioRecorder: AudioRecorder {
             engine: preparedEngine,
             inputFormat: inputNodeAndFormat.1,
             startupBufferRelay: startupBufferRelay,
-            signature: signature
+            signature: signature,
+            includesInstantPreRoll: includesInstantPreRoll
         )
     }
 
     private func schedulePreparedInputEngineBuild() {
         preparedInputLock.lock()
-        guard preparedInputEngine == nil, !preparedInputBuildIsPending else {
+        guard preparedInputEngine == nil,
+              !preparedInputBuildIsPending,
+              !preparedInputIsSuspended
+        else {
             preparedInputLock.unlock()
             return
         }
         preparedInputBuildIsPending = true
+        preparedInputBuildGroup.enter()
         preparedInputLock.unlock()
 
         inputPreparationQueue.async { [weak self] in
@@ -459,21 +494,49 @@ final class AVFoundationAudioRecorder: AudioRecorder {
         defer {
             preparedInputLock.lock()
             preparedInputBuildIsPending = false
+            let shouldRetry = preparedInputBuildNeedsRetry && !preparedInputIsSuspended
+            preparedInputBuildNeedsRetry = false
             preparedInputLock.unlock()
+            if shouldRetry {
+                schedulePreparedInputEngineBuild()
+            }
+            preparedInputBuildGroup.leave()
         }
         guard !currentRecordingState() else { return }
 
         do {
             let signature = try currentPreparedInputSignature()
-            let preparedInput = try buildPreparedInputEngine(signature: signature)
+            let instantVoiceInputEnabled = settingsStore.instantVoiceInputEnabled
+            let preparedInput = try buildPreparedInputEngine(
+                signature: signature,
+                includesInstantPreRoll: instantVoiceInputEnabled
+            )
+            if instantVoiceInputEnabled {
+                do {
+                    try preparedInput.engine.start()
+                } catch {
+                    disposePreparedInputEngine(preparedInput)
+                    throw error
+                }
+                guard preparedInput.startupBufferRelay.waitForFirstBuffer(
+                    timeout: Self.instantCaptureArmingTimeout
+                ) else {
+                    disposePreparedInputEngine(preparedInput)
+                    throw RecorderError.inputStartupTimedOut
+                }
+            }
             preparedInputLock.lock()
-            let canStore = preparedInputEngine == nil && preparedInputGeneration == signature.generation
+            let canStore = preparedInputEngine == nil
+                && preparedInputGeneration == signature.generation
+                && !preparedInputIsSuspended
+                && settingsStore.instantVoiceInputEnabled == instantVoiceInputEnabled
             if canStore {
                 preparedInputEngine = preparedInput
             }
             preparedInputLock.unlock()
             if canStore {
-                NetworkDebugLogger.logMessage("[Audio Recorder] Prepared microphone input for the next recording.")
+                let mode = instantVoiceInputEnabled ? "armed with in-memory pre-roll" : "prepared"
+                NetworkDebugLogger.logMessage("[Audio Recorder] Microphone input is \(mode) for the next recording.")
             } else {
                 disposePreparedInputEngine(preparedInput)
             }
@@ -482,6 +545,16 @@ final class AVFoundationAudioRecorder: AudioRecorder {
                 "[Audio Recorder] Microphone input preconfiguration unavailable; next recording will use cold start."
             )
         }
+    }
+
+    private func waitForPendingPreparedInputBuild() -> Bool {
+        preparedInputLock.lock()
+        let buildIsPending = preparedInputBuildIsPending
+        preparedInputLock.unlock()
+        guard buildIsPending else { return true }
+        return preparedInputBuildGroup.wait(
+            timeout: .now() + Self.preparedInputBuildWaitTimeout
+        ) == .success
     }
 
     private func currentPreparedInputSignature() throws -> PreparedInputEngineSignature {
@@ -501,7 +574,7 @@ final class AVFoundationAudioRecorder: AudioRecorder {
         return Self.canReusePreparedInputEngine(prepared: signature, current: currentSignature)
     }
 
-    private func observePreparedInputInvalidation() {
+    private func observePreparedInputLifecycle() {
         preparedMicrophoneObserver = NotificationCenter.default.addObserver(
             forName: .preferredMicrophoneDidChange,
             object: settingsStore,
@@ -518,15 +591,70 @@ final class AVFoundationAudioRecorder: AudioRecorder {
             else { return }
             invalidatePreparedInputEngine(reason: "default input device changed")
         }
+        instantVoiceInputObserver = NotificationCenter.default.addObserver(
+            forName: .instantVoiceInputDidChange,
+            object: settingsStore,
+            queue: nil
+        ) { [weak self] _ in
+            self?.invalidatePreparedInputEngine(reason: "instant voice input setting changed")
+        }
+        preparedEngineConfigurationObserver = NotificationCenter.default.addObserver(
+            forName: .AVAudioEngineConfigurationChange,
+            object: nil,
+            queue: nil
+        ) { [weak self] notification in
+            guard let self,
+                  let changedEngine = notification.object as? AVAudioEngine,
+                  preparedInputEngineMatches(changedEngine)
+            else { return }
+            inputPreparationQueue.async { [weak self] in
+                self?.invalidatePreparedInputEngine(reason: "prepared engine configuration changed")
+            }
+        }
+
+        let workspaceCenter = NSWorkspace.shared.notificationCenter
+        workspaceObservers = [
+            workspaceCenter.addObserver(
+                forName: NSWorkspace.willSleepNotification,
+                object: nil,
+                queue: nil
+            ) { [weak self] _ in self?.suspendPreparedInputEngine(reason: "system sleeping") },
+            workspaceCenter.addObserver(
+                forName: NSWorkspace.sessionDidResignActiveNotification,
+                object: nil,
+                queue: nil
+            ) { [weak self] _ in self?.suspendPreparedInputEngine(reason: "session locked") },
+            workspaceCenter.addObserver(
+                forName: NSWorkspace.didWakeNotification,
+                object: nil,
+                queue: nil
+            ) { [weak self] _ in self?.resumePreparedInputEngine(reason: "system woke") },
+            workspaceCenter.addObserver(
+                forName: NSWorkspace.sessionDidBecomeActiveNotification,
+                object: nil,
+                queue: nil
+            ) { [weak self] _ in self?.resumePreparedInputEngine(reason: "session unlocked") }
+        ]
     }
 
-    private func removePreparedInputInvalidationObservers() {
+    private func removePreparedInputLifecycleObservers() {
         if let preparedMicrophoneObserver {
             NotificationCenter.default.removeObserver(preparedMicrophoneObserver)
             self.preparedMicrophoneObserver = nil
         }
         preparedDefaultInputDeviceChangeObservation?.cancel()
         preparedDefaultInputDeviceChangeObservation = nil
+        if let instantVoiceInputObserver {
+            NotificationCenter.default.removeObserver(instantVoiceInputObserver)
+            self.instantVoiceInputObserver = nil
+        }
+        if let preparedEngineConfigurationObserver {
+            NotificationCenter.default.removeObserver(preparedEngineConfigurationObserver)
+            self.preparedEngineConfigurationObserver = nil
+        }
+        let workspaceCenter = NSWorkspace.shared.notificationCenter
+        workspaceObservers.forEach(workspaceCenter.removeObserver)
+        workspaceObservers.removeAll()
     }
 
     private func invalidatePreparedInputEngine(reason: String) {
@@ -534,11 +662,53 @@ final class AVFoundationAudioRecorder: AudioRecorder {
         preparedInputGeneration &+= 1
         let staleInput = preparedInputEngine
         preparedInputEngine = nil
+        if preparedInputBuildIsPending {
+            preparedInputBuildNeedsRetry = true
+        }
         preparedInputLock.unlock()
         if let staleInput {
             disposePreparedInputEngine(staleInput)
         }
         NetworkDebugLogger.logMessage("[Audio Recorder] Invalidated prepared input: \(reason).")
+        schedulePreparedInputEngineBuild()
+    }
+
+    private func preparedInputEngineMatches(_ changedEngine: AVAudioEngine) -> Bool {
+        preparedInputLock.lock()
+        defer { preparedInputLock.unlock() }
+        return preparedInputEngine?.engine === changedEngine
+    }
+
+    private func suspendPreparedInputEngine(reason: String) {
+        preparedInputLock.lock()
+        guard !preparedInputIsSuspended else {
+            preparedInputLock.unlock()
+            return
+        }
+        preparedInputIsSuspended = true
+        preparedInputGeneration &+= 1
+        let staleInput = preparedInputEngine
+        preparedInputEngine = nil
+        preparedInputLock.unlock()
+        if let staleInput {
+            disposePreparedInputEngine(staleInput)
+        }
+        NetworkDebugLogger.logMessage("[Audio Recorder] Suspended prepared input: \(reason).")
+    }
+
+    private func resumePreparedInputEngine(reason: String) {
+        preparedInputLock.lock()
+        guard preparedInputIsSuspended else {
+            preparedInputLock.unlock()
+            return
+        }
+        preparedInputIsSuspended = false
+        preparedInputGeneration &+= 1
+        if preparedInputBuildIsPending {
+            preparedInputBuildNeedsRetry = true
+        }
+        preparedInputLock.unlock()
+        NetworkDebugLogger.logMessage("[Audio Recorder] Resuming prepared input: \(reason).")
         schedulePreparedInputEngineBuild()
     }
 
@@ -902,6 +1072,20 @@ final class AVFoundationAudioRecorder: AudioRecorder {
             defer { preparedInputLock.unlock() }
             return preparedInputGeneration
         }
+
+        var preparedInputIsSuspendedForTesting: Bool {
+            preparedInputLock.lock()
+            defer { preparedInputLock.unlock() }
+            return preparedInputIsSuspended
+        }
+
+        func suspendPreparedInputForTesting() {
+            suspendPreparedInputEngine(reason: "test")
+        }
+
+        func resumePreparedInputForTesting() {
+            resumePreparedInputEngine(reason: "test")
+        }
     #endif
 
     private func resolveInputDeviceID() -> AudioDeviceID? {
@@ -1196,6 +1380,7 @@ private struct PreparedInputEngine {
     let inputFormat: AVAudioFormat
     let startupBufferRelay: RecordingStartupAudioBufferRelay
     let signature: PreparedInputEngineSignature
+    let includesInstantPreRoll: Bool
 }
 
 /// Preserves tap buffers emitted after AVAudioEngine starts but before the
@@ -1203,10 +1388,17 @@ private struct PreparedInputEngine {
 /// and then forwards subsequent buffers directly.
 final class RecordingStartupAudioBufferRelay: @unchecked Sendable {
     private let lock = NSLock()
+    private let firstBufferSemaphore = DispatchSemaphore(value: 0)
+    private let maximumBufferedDuration: TimeInterval?
     private var pendingBuffers: [AVAudioPCMBuffer] = []
+    private var pendingDuration: TimeInterval = 0
     private var handler: ((AVAudioPCMBuffer) -> Void)?
     private var isCancelled = false
     private var firstReceivedAt: Date?
+
+    init(maximumBufferedDuration: TimeInterval? = nil) {
+        self.maximumBufferedDuration = maximumBufferedDuration
+    }
 
     var firstBufferReceivedAt: Date? {
         lock.lock()
@@ -1220,6 +1412,7 @@ final class RecordingStartupAudioBufferRelay: @unchecked Sendable {
         guard !isCancelled else { return }
         if firstReceivedAt == nil {
             firstReceivedAt = receivedAt
+            firstBufferSemaphore.signal()
         }
         if let handler {
             // Once active, stay on the audio tap's zero-copy path. Copies are
@@ -1229,6 +1422,8 @@ final class RecordingStartupAudioBufferRelay: @unchecked Sendable {
         }
         guard let copiedBuffer = Self.copy(buffer) else { return }
         pendingBuffers.append(copiedBuffer)
+        pendingDuration += Self.duration(of: copiedBuffer)
+        trimBufferedAudioIfNeeded()
     }
 
     func activate(_ handler: @escaping (AVAudioPCMBuffer) -> Void) {
@@ -1237,15 +1432,52 @@ final class RecordingStartupAudioBufferRelay: @unchecked Sendable {
         guard !isCancelled, self.handler == nil else { return }
         pendingBuffers.forEach(handler)
         pendingBuffers.removeAll(keepingCapacity: false)
+        pendingDuration = 0
         self.handler = handler
+    }
+
+    func waitForFirstBuffer(timeout: DispatchTimeInterval) -> Bool {
+        lock.lock()
+        let hasReceivedBuffer = firstReceivedAt != nil
+        lock.unlock()
+        return hasReceivedBuffer || firstBufferSemaphore.wait(timeout: .now() + timeout) == .success
     }
 
     func cancel() {
         lock.lock()
         isCancelled = true
         pendingBuffers.removeAll(keepingCapacity: false)
+        pendingDuration = 0
         handler = nil
         lock.unlock()
+    }
+
+    func discardBufferedAudio() {
+        lock.lock()
+        pendingBuffers.removeAll(keepingCapacity: false)
+        pendingDuration = 0
+        firstReceivedAt = nil
+        lock.unlock()
+    }
+
+    #if DEBUG
+        var bufferedFrameCountForTesting: AVAudioFrameCount {
+            lock.lock()
+            defer { lock.unlock() }
+            return pendingBuffers.reduce(0) { $0 + $1.frameLength }
+        }
+    #endif
+
+    private func trimBufferedAudioIfNeeded() {
+        guard let maximumBufferedDuration else { return }
+        while pendingDuration > maximumBufferedDuration, pendingBuffers.count > 1 {
+            pendingDuration -= Self.duration(of: pendingBuffers.removeFirst())
+        }
+    }
+
+    private static func duration(of buffer: AVAudioPCMBuffer) -> TimeInterval {
+        guard buffer.format.sampleRate > 0 else { return 0 }
+        return TimeInterval(buffer.frameLength) / buffer.format.sampleRate
     }
 
     private static func copy(_ buffer: AVAudioPCMBuffer) -> AVAudioPCMBuffer? {

--- a/Sources/Typeflux/Resources/en.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/en.lproj/Localizable.strings
@@ -143,6 +143,8 @@
 "settings.microphone.title" = "Microphone";
 "settings.microphone.subtitle" = "Pick the device used for dictation. Automatic follows the current macOS default input.";
 "settings.microphone.automatic" = "Automatic";
+"settings.instantVoiceInput.title" = "Speak Immediately (Experimental)";
+"settings.instantVoiceInput.subtitle" = "Keep the microphone ready so your first words are captured when you press the shortcut. The most recent half-second stays in memory and joins a recording only when you start dictation; otherwise it is continuously discarded. macOS will show the microphone as in use and battery use may increase.";
 "settings.mute.title" = "Mute During Recording";
 "settings.mute.subtitle" = "Temporarily mute the system output while recording to reduce feedback or system sounds leaking into the microphone.";
 "settings.permissions" = "Permissions";

--- a/Sources/Typeflux/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/ja.lproj/Localizable.strings
@@ -143,6 +143,8 @@
 "settings.microphone.title" = "マイク";
 "settings.microphone.subtitle" = "ディクテーションに使用するデバイスを選択します。自動は、現在の macOS デフォルト入力に従います。";
 "settings.microphone.automatic" = "自動";
+"settings.instantVoiceInput.title" = "すぐに話す（試験機能）";
+"settings.instantVoiceInput.subtitle" = "ショートカットを押した瞬間から冒頭を録音できるよう、マイクを準備状態に保ちます。直近約0.5秒の音声はメモリーだけに保持され、音声入力を開始したときに限り今回の録音へ加えられ、それ以外は上書きされ続けます。有効にすると macOS にマイク使用中と表示され、バッテリー消費が少し増える場合があります。";
 "settings.mute.title" = "録音中にミュートする";
 "settings.mute.subtitle" = "録音中にシステム出力を一時的にミュートして、マイクに漏れるフィードバックやシステム音を軽減します。";
 "settings.permissions" = "権限";

--- a/Sources/Typeflux/Resources/ko.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/ko.lproj/Localizable.strings
@@ -143,6 +143,8 @@
 "settings.microphone.title" = "마이크";
 "settings.microphone.subtitle" = "받아쓰기에 사용되는 장치를 선택하세요. 자동은 현재 macOS 기본 입력을 따릅니다.";
 "settings.microphone.automatic" = "자동";
+"settings.instantVoiceInput.title" = "바로 말하기(실험 기능)";
+"settings.instantVoiceInput.subtitle" = "단축키를 누르는 순간부터 첫말을 빠짐없이 녹음할 수 있도록 마이크를 준비 상태로 유지합니다. 최근 약 0.5초의 음성은 메모리에만 보관되며 음성 입력을 시작할 때만 이번 녹음에 포함되고, 그 외에는 계속 덮어씁니다. 켜면 macOS에 마이크 사용 중으로 표시되고 배터리 사용량이 조금 늘 수 있습니다.";
 "settings.mute.title" = "녹음 중 음소거";
 "settings.mute.subtitle" = "녹음하는 동안 일시적으로 시스템 출력을 음소거하여 피드백이나 시스템 사운드가 마이크에 새는 것을 줄입니다.";
 "settings.permissions" = "권한";

--- a/Sources/Typeflux/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/zh-Hans.lproj/Localizable.strings
@@ -135,6 +135,8 @@
 "settings.microphone.title" = "麦克风";
 "settings.microphone.subtitle" = "选择听写使用的输入设备。自动模式会跟随当前 macOS 默认输入设备。";
 "settings.microphone.automatic" = "自动";
+"settings.instantVoiceInput.title" = "按键即说（实验功能）";
+"settings.instantVoiceInput.subtitle" = "提前让麦克风保持就绪，按下快捷键时即可完整录下开头。最近约半秒音频只保留在内存中，仅在开始语音输入时并入本次录音，其他时候会持续覆盖。开启后 macOS 会显示麦克风正在使用，并可能略微增加耗电。";
 "settings.mute.title" = "录音时静音";
 "settings.mute.subtitle" = "录音期间临时静音系统输出，减少回声或系统声音串入麦克风。";
 "settings.permissions" = "权限";

--- a/Sources/Typeflux/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/zh-Hant.lproj/Localizable.strings
@@ -135,6 +135,8 @@
 "settings.microphone.title" = "麥克風";
 "settings.microphone.subtitle" = "選擇聽寫使用的輸入裝置。自動模式會跟隨目前 macOS 預設輸入裝置。";
 "settings.microphone.automatic" = "自動";
+"settings.instantVoiceInput.title" = "按鍵即說（實驗功能）";
+"settings.instantVoiceInput.subtitle" = "預先讓麥克風保持就緒，按下快捷鍵時即可完整錄下開頭。最近約半秒音訊只保留在記憶體中，僅在開始語音輸入時併入本次錄音，其他時間會持續覆寫。開啟後 macOS 會顯示麥克風正在使用，並可能稍微增加耗電。";
 "settings.mute.title" = "錄音時靜音";
 "settings.mute.subtitle" = "錄音期間暫時靜音系統輸出，減少回聲或系統聲音進入麥克風。";
 "settings.permissions" = "權限";

--- a/Sources/Typeflux/Settings/SettingsStore.swift
+++ b/Sources/Typeflux/Settings/SettingsStore.swift
@@ -10,6 +10,7 @@ extension Notification.Name {
     static let appearanceModeDidChange = Notification.Name("SettingsStore.appearanceModeDidChange")
     static let overlayStyleDidChange = Notification.Name("SettingsStore.overlayStyleDidChange")
     static let preferredMicrophoneDidChange = Notification.Name("SettingsStore.preferredMicrophoneDidChange")
+    static let instantVoiceInputDidChange = Notification.Name("SettingsStore.instantVoiceInputDidChange")
     static let agentConfigurationDidChange = Notification.Name("SettingsStore.agentConfigurationDidChange")
     static let localOptimizationDidEnable = Notification.Name("SettingsStore.localOptimizationDidEnable")
     static let analyticsSharingDidChange = Notification.Name("SettingsStore.analyticsSharingDidChange")
@@ -172,6 +173,15 @@ final class SettingsStore {
     var muteSystemOutputDuringRecording: Bool {
         get { defaults.object(forKey: "audio.recording.muteSystemOutput") as? Bool ?? false }
         set { defaults.set(newValue, forKey: "audio.recording.muteSystemOutput") }
+    }
+
+    var instantVoiceInputEnabled: Bool {
+        get { defaults.object(forKey: "audio.recording.instantVoiceInput") as? Bool ?? false }
+        set {
+            guard instantVoiceInputEnabled != newValue else { return }
+            defaults.set(newValue, forKey: "audio.recording.instantVoiceInput")
+            NotificationCenter.default.post(name: .instantVoiceInputDidChange, object: self)
+        }
     }
 
     var soundEffectsEnabled: Bool {

--- a/Sources/Typeflux/Settings/SettingsView.swift
+++ b/Sources/Typeflux/Settings/SettingsView.swift
@@ -2604,6 +2604,23 @@ struct StudioView: View {
                     Divider().overlay(StudioTheme.border.opacity(StudioTheme.Opacity.divider))
 
                     StudioSettingRow(
+                        title: L("settings.instantVoiceInput.title"),
+                        subtitle: L("settings.instantVoiceInput.subtitle")
+                    ) {
+                        Toggle(
+                            "",
+                            isOn: Binding(
+                                get: { viewModel.instantVoiceInputEnabled },
+                                set: viewModel.setInstantVoiceInputEnabled
+                            )
+                        )
+                        .labelsHidden()
+                        .toggleStyle(.switch)
+                    }
+
+                    Divider().overlay(StudioTheme.border.opacity(StudioTheme.Opacity.divider))
+
+                    StudioSettingRow(
                         title: L("settings.mute.title"),
                         subtitle: L("settings.mute.subtitle")
                     ) {

--- a/Sources/Typeflux/Settings/SettingsViewModel.swift
+++ b/Sources/Typeflux/Settings/SettingsViewModel.swift
@@ -104,6 +104,7 @@ final class StudioViewModel: ObservableObject {
     @Published var appLanguage: AppLanguage
     @Published var availableMicrophones: [AudioInputDevice] = []
     @Published var preferredMicrophoneID: String
+    @Published var instantVoiceInputEnabled: Bool
     @Published var muteSystemOutputDuringRecording: Bool
     @Published var soundEffectsEnabled: Bool
     @Published var preferredAPIServer = CloudServerPreferences.automaticValue
@@ -330,6 +331,7 @@ final class StudioViewModel: ObservableObject {
         overlayStyle = settingsStore.overlayStyle
         appLanguage = settingsStore.appLanguage
         preferredMicrophoneID = settingsStore.preferredMicrophoneID
+        instantVoiceInputEnabled = settingsStore.instantVoiceInputEnabled
         muteSystemOutputDuringRecording = settingsStore.muteSystemOutputDuringRecording
         soundEffectsEnabled = settingsStore.soundEffectsEnabled
         preferredAPIServer = CloudServerPreferences.shared.preferredAPIServer
@@ -1095,6 +1097,11 @@ final class StudioViewModel: ObservableObject {
     func setMuteSystemOutputDuringRecording(_ value: Bool) {
         muteSystemOutputDuringRecording = value
         settingsStore.muteSystemOutputDuringRecording = value
+    }
+
+    func setInstantVoiceInputEnabled(_ value: Bool) {
+        instantVoiceInputEnabled = value
+        settingsStore.instantVoiceInputEnabled = value
     }
 
     func setSoundEffectsEnabled(_ value: Bool) {

--- a/Tests/TypefluxTests/AVFoundationAudioRecorderTests.swift
+++ b/Tests/TypefluxTests/AVFoundationAudioRecorderTests.swift
@@ -66,6 +66,69 @@ final class AVFoundationAudioRecorderTests: XCTestCase {
         XCTAssertEqual(relay.firstBufferReceivedAt, receivedAt)
     }
 
+    func testRecordingStartupBufferRelayKeepsOnlyTheConfiguredPreRollTail() throws {
+        let format = try XCTUnwrap(AVAudioFormat(
+            commonFormat: .pcmFormatFloat32,
+            sampleRate: 16000,
+            channels: 1,
+            interleaved: false
+        ))
+        let relay = RecordingStartupAudioBufferRelay(maximumBufferedDuration: 0.25)
+        var amplitudes: [Float] = []
+
+        for amplitude: Float in [0.1, 0.2, 0.3, 0.4] {
+            relay.append(try makeTestBuffer(
+                format: format,
+                frameLength: 1600,
+                amplitude: amplitude
+            ))
+        }
+        relay.activate { buffer in
+            amplitudes.append(buffer.floatChannelData?[0][0] ?? 0)
+        }
+
+        XCTAssertEqual(amplitudes.count, 2)
+        XCTAssertEqual(amplitudes[0], 0.3, accuracy: 0.001)
+        XCTAssertEqual(amplitudes[1], 0.4, accuracy: 0.001)
+    }
+
+    func testRecordingStartupBufferRelaySignalsWhenInstantCaptureIsArmed() throws {
+        let format = try XCTUnwrap(AVAudioFormat(
+            commonFormat: .pcmFormatFloat32,
+            sampleRate: 16000,
+            channels: 1,
+            interleaved: false
+        ))
+        let relay = RecordingStartupAudioBufferRelay(maximumBufferedDuration: 0.5)
+
+        XCTAssertFalse(relay.waitForFirstBuffer(timeout: .milliseconds(0)))
+        relay.append(try makeTestBuffer(format: format, frameLength: 160))
+        XCTAssertTrue(relay.waitForFirstBuffer(timeout: .milliseconds(0)))
+    }
+
+    func testRecordingStartupBufferRelayDropsStalePreRollWhenWarmEngineStopped() throws {
+        let format = try XCTUnwrap(AVAudioFormat(
+            commonFormat: .pcmFormatFloat32,
+            sampleRate: 16000,
+            channels: 1,
+            interleaved: false
+        ))
+        let relay = RecordingStartupAudioBufferRelay(maximumBufferedDuration: 0.5)
+        let staleBuffer = try makeTestBuffer(format: format, frameLength: 160, amplitude: 0.1)
+        let freshBuffer = try makeTestBuffer(format: format, frameLength: 160, amplitude: 0.4)
+        var amplitudes: [Float] = []
+
+        relay.append(staleBuffer)
+        relay.discardBufferedAudio()
+        relay.append(freshBuffer)
+        relay.activate { buffer in
+            amplitudes.append(buffer.floatChannelData?[0][0] ?? 0)
+        }
+
+        XCTAssertEqual(amplitudes.count, 1)
+        XCTAssertEqual(amplitudes[0], 0.4, accuracy: 0.001)
+    }
+
     func testInputTapUsesLowLatencyBufferSize() {
         XCTAssertEqual(AVFoundationAudioRecorder.inputTapBufferSize, 512)
     }
@@ -170,6 +233,47 @@ final class AVFoundationAudioRecorderTests: XCTestCase {
         settingsStore.preferredMicrophoneID = "bluetooth-headset"
 
         XCTAssertEqual(recorder.preparedInputGenerationForTesting, initialGeneration + 1)
+    }
+
+    func testInstantVoiceInputChangeInvalidatesPreparedInputGeneration() throws {
+        let suiteName = "AVFoundationAudioRecorderTests-\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let settingsStore = SettingsStore(defaults: defaults)
+        let recorder = AVFoundationAudioRecorder(
+            settingsStore: settingsStore,
+            audioDeviceManager: MockAudioDeviceManager(defaultInputDeviceID: nil)
+        )
+        let initialGeneration = recorder.preparedInputGenerationForTesting
+
+        settingsStore.instantVoiceInputEnabled = true
+
+        XCTAssertEqual(recorder.preparedInputGenerationForTesting, initialGeneration + 1)
+    }
+
+    func testInstantVoiceInputUsesHalfSecondPreRoll() {
+        XCTAssertEqual(AVFoundationAudioRecorder.instantVoiceInputPreRollDuration, 0.5)
+    }
+
+    func testPreparedInputSuspendsAndRebuildsAcrossSleepLifecycle() throws {
+        let suiteName = "AVFoundationAudioRecorderTests-\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let recorder = AVFoundationAudioRecorder(
+            settingsStore: SettingsStore(defaults: defaults),
+            audioDeviceManager: MockAudioDeviceManager(defaultInputDeviceID: nil)
+        )
+        let initialGeneration = recorder.preparedInputGenerationForTesting
+
+        recorder.suspendPreparedInputForTesting()
+
+        XCTAssertTrue(recorder.preparedInputIsSuspendedForTesting)
+        XCTAssertEqual(recorder.preparedInputGenerationForTesting, initialGeneration + 1)
+
+        recorder.resumePreparedInputForTesting()
+
+        XCTAssertFalse(recorder.preparedInputIsSuspendedForTesting)
+        XCTAssertEqual(recorder.preparedInputGenerationForTesting, initialGeneration + 2)
     }
 
     func testValidateInputFormatAcceptsUsableMicrophoneFormat() throws {

--- a/Tests/TypefluxTests/LocalizationResourceTests.swift
+++ b/Tests/TypefluxTests/LocalizationResourceTests.swift
@@ -29,6 +29,31 @@ final class LocalizationResourceTests: XCTestCase {
         }
     }
 
+    func testInstantVoiceInputExplainsBenefitAndMicrophoneTradeoffInEveryLanguage() throws {
+        let keys = [
+            "settings.instantVoiceInput.title",
+            "settings.instantVoiceInput.subtitle"
+        ]
+
+        for language in AppLanguage.allCases {
+            let bundle = try localizationBundle(for: language)
+            for key in keys {
+                let localized = bundle.localizedString(forKey: key, value: nil, table: nil)
+                XCTAssertNotEqual(localized, key, "Missing localized value for \(key) in \(language.rawValue)")
+                XCTAssertFalse(localized.isEmpty)
+            }
+        }
+
+        let chineseBundle = try localizationBundle(for: .simplifiedChinese)
+        let chineseDetail = chineseBundle.localizedString(
+            forKey: "settings.instantVoiceInput.subtitle",
+            value: nil,
+            table: nil
+        )
+        XCTAssertTrue(chineseDetail.contains("麦克风正在使用"))
+        XCTAssertTrue(chineseDetail.contains("内存"))
+    }
+
     func testSidebarAccountCardStateCopyExistsForAllSupportedLanguages() throws {
         let keys = [
             "sidebar.accountCard.guest",

--- a/Tests/TypefluxTests/SettingsStoreAudioTests.swift
+++ b/Tests/TypefluxTests/SettingsStoreAudioTests.swift
@@ -1,0 +1,62 @@
+import Foundation
+@testable import Typeflux
+import XCTest
+
+@MainActor
+final class SettingsStoreAudioTests: XCTestCase {
+    func testInstantVoiceInputIsDisabledByDefault() throws {
+        let suiteName = "SettingsStoreAudioTests-\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        XCTAssertFalse(SettingsStore(defaults: defaults).instantVoiceInputEnabled)
+    }
+
+    func testInstantVoiceInputPersistsAndNotifiesOnlyWhenChanged() throws {
+        let suiteName = "SettingsStoreAudioTests-\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let store = SettingsStore(defaults: defaults)
+        var notificationCount = 0
+        let observer = NotificationCenter.default.addObserver(
+            forName: .instantVoiceInputDidChange,
+            object: store,
+            queue: nil
+        ) { _ in notificationCount += 1 }
+        defer { NotificationCenter.default.removeObserver(observer) }
+
+        store.instantVoiceInputEnabled = true
+        store.instantVoiceInputEnabled = true
+
+        XCTAssertTrue(store.instantVoiceInputEnabled)
+        XCTAssertEqual(notificationCount, 1)
+    }
+
+    func testInstantVoiceInputPersistsThroughSettingsViewModel() throws {
+        let suiteName = "SettingsStoreAudioTests-\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let store = SettingsStore(defaults: defaults)
+        let viewModel = StudioViewModel(
+            settingsStore: store,
+            historyStore: AudioSettingsHistoryStore(),
+            initialSection: .settings
+        )
+
+        viewModel.setInstantVoiceInputEnabled(true)
+
+        XCTAssertTrue(viewModel.instantVoiceInputEnabled)
+        XCTAssertTrue(store.instantVoiceInputEnabled)
+    }
+}
+
+private final class AudioSettingsHistoryStore: HistoryStore {
+    func save(record _: HistoryRecord) {}
+    func list() -> [HistoryRecord] { [] }
+    func list(limit _: Int, offset _: Int, searchQuery _: String?) -> [HistoryRecord] { [] }
+    func record(id _: UUID) -> HistoryRecord? { nil }
+    func delete(id _: UUID) {}
+    func purge(olderThanDays _: Int) {}
+    func clear() {}
+    func exportMarkdown() throws -> URL { URL(fileURLWithPath: "/tmp/typeflux-audio-settings-history.md") }
+}


### PR DESCRIPTION
## Summary

- add a default-off **Speak Immediately (Experimental)** switch to Audio settings, with localized copy that explains the benefit, half-second memory buffer, microphone indicator, and battery tradeoff
- arm the selected microphone in the background only when enabled and prepend the bounded in-memory tail when dictation starts
- invalidate and fully rebuild armed input across default/preferred microphone changes, Bluetooth reconfiguration, sleep, and lock; preserve the existing active-recording health checks and retry path
- avoid concurrent cold and warm engine starts, discard stale pre-roll when an engine stops, and include pre-roll in the reported audio duration

## Verification

- `swift test` (2476 XCTest + 8 Swift Testing passed)
- `swift test --sanitize=thread --filter 'AVFoundationAudioRecorderTests|SettingsStoreAudioTests'` (50 passed)
- focused audio/settings/localization suite after final changes (66 passed)
- `make coverage` (passed; total line coverage 39.03%)
- `git diff --check`

`make format` could not run because `swiftformat` is not installed in the environment. A settings screenshot was not captured in the headless runtime.

## Manual acceptance

- enable the switch and confirm macOS shows microphone use while Typeflux is idle
- say a short phrase while pressing the shortcut and verify the WAV includes the first word
- switch between built-in and Bluetooth microphones, then verify the next recording uses the new device
- lock/unlock and sleep/wake the Mac, then verify instant capture rearms
- disable the switch and confirm idle microphone use stops

Closes GUL-66
