### PR TITLE
GUL-66: release instant input after idle timeout

### DIFF
--- a/Sources/Typeflux/Audio/AVFoundationAudioRecorder.swift
+++ b/Sources/Typeflux/Audio/AVFoundationAudioRecorder.swift
@@ -7,6 +7,7 @@ import TypefluxAudioSafety
 final class AVFoundationAudioRecorder: AudioRecorder {
     static let inputTapBufferSize: AVAudioFrameCount = 512
     static let instantVoiceInputPreRollDuration: TimeInterval = 0.5
+    static let instantVoiceInputIdleTimeout: TimeInterval = 15 * 60
     private static let outputMuteDelayWithStartCue: Duration = .milliseconds(1225)
     private static let outputMuteDelayWithoutStartCue: Duration = .milliseconds(180)
     private static let silentInputRecoveryDelay: DispatchTimeInterval = .seconds(1)
@@ -39,6 +40,7 @@ final class AVFoundationAudioRecorder: AudioRecorder {
     private let audioDeviceManager: AudioDeviceManaging
     private let outputMuter: SystemAudioOutputMuting
     private let sleep: @Sendable (Duration) async -> Void
+    private let configuredInstantVoiceInputIdleTimeout: TimeInterval
     private let writeCoordinator = AudioBufferWriteCoordinator()
     private let configurationRecoveryQueue = DispatchQueue(label: "typeflux.audio.configuration-recovery")
     private let inputPreparationQueue = DispatchQueue(label: "typeflux.audio.input-preparation", qos: .userInitiated)
@@ -72,6 +74,9 @@ final class AVFoundationAudioRecorder: AudioRecorder {
     private var preparedInputIsSuspended = false
     private var preparedMicrophoneObserver: NSObjectProtocol?
     private var instantVoiceInputObserver: NSObjectProtocol?
+    private var instantVoiceInputWarmWindowIsActive = false
+    private var instantVoiceInputWarmWindowGeneration: UInt64 = 0
+    private var instantVoiceInputIdleReleaseWorkItem: DispatchWorkItem?
     private var preparedEngineConfigurationObserver: NSObjectProtocol?
     private var preparedDefaultInputDeviceChangeObservation: AudioInputDeviceChangeObservation?
     private var workspaceObservers: [NSObjectProtocol] = []
@@ -81,6 +86,7 @@ final class AVFoundationAudioRecorder: AudioRecorder {
         audioDeviceManager: AudioDeviceManaging = AudioDeviceManager(),
         outputMuter: SystemAudioOutputMuting = SystemAudioOutputMuter(),
         makeAudioEngine: @escaping () -> AVAudioEngine = { AVAudioEngine() },
+        instantVoiceInputIdleTimeout: TimeInterval = AVFoundationAudioRecorder.instantVoiceInputIdleTimeout,
         sleep: @escaping @Sendable (Duration) async -> Void = { duration in
             try? await Task.sleep(for: duration)
         }
@@ -90,12 +96,14 @@ final class AVFoundationAudioRecorder: AudioRecorder {
         self.outputMuter = outputMuter
         self.makeAudioEngine = makeAudioEngine
         engine = makeAudioEngine()
+        configuredInstantVoiceInputIdleTimeout = instantVoiceInputIdleTimeout
         self.sleep = sleep
         observePreparedInputLifecycle()
         schedulePreparedInputEngineBuild()
     }
 
     deinit {
+        cancelInstantVoiceInputIdleRelease()
         removeInputChangeObservers()
         removePreparedInputLifecycleObservers()
         discardPreparedInputEngine()
@@ -246,7 +254,11 @@ final class AVFoundationAudioRecorder: AudioRecorder {
         muteTask?.cancel()
         muteTask = nil
         outputMuter.endMutedSession()
-        schedulePreparedInputEngineBuild()
+        if settingsStore.instantVoiceInputEnabled {
+            beginInstantVoiceInputWarmWindow()
+        } else {
+            schedulePreparedInputEngineBuild()
+        }
 
         return AudioFile(fileURL: fileURL, duration: duration, startupTiming: startupTiming)
     }
@@ -401,6 +413,17 @@ final class AVFoundationAudioRecorder: AudioRecorder {
         guard waitForPendingPreparedInputBuild() else {
             throw RecorderError.inputStartupTimedOut
         }
+        preparedInputLock.lock()
+        // A recording consumes the current warm window. Cancelling its idle
+        // release here prevents the timeout from invalidating the device
+        // generation while this prepared engine is moving into an active
+        // session. A successful stop opens a fresh full-length window.
+        instantVoiceInputWarmWindowIsActive = false
+        instantVoiceInputWarmWindowGeneration &+= 1
+        instantVoiceInputIdleReleaseWorkItem?.cancel()
+        instantVoiceInputIdleReleaseWorkItem = nil
+        preparedInputLock.unlock()
+
         let currentSignature = try currentPreparedInputSignature()
         var cachedInput: PreparedInputEngine?
         var staleInput: PreparedInputEngine?
@@ -506,7 +529,7 @@ final class AVFoundationAudioRecorder: AudioRecorder {
 
         do {
             let signature = try currentPreparedInputSignature()
-            let instantVoiceInputEnabled = settingsStore.instantVoiceInputEnabled
+            let instantVoiceInputEnabled = shouldArmInstantVoiceInput()
             let preparedInput = try buildPreparedInputEngine(
                 signature: signature,
                 includesInstantPreRoll: instantVoiceInputEnabled
@@ -526,10 +549,12 @@ final class AVFoundationAudioRecorder: AudioRecorder {
                 }
             }
             preparedInputLock.lock()
+            let shouldArmNow = settingsStore.instantVoiceInputEnabled
+                && instantVoiceInputWarmWindowIsActive
             let canStore = preparedInputEngine == nil
                 && preparedInputGeneration == signature.generation
                 && !preparedInputIsSuspended
-                && settingsStore.instantVoiceInputEnabled == instantVoiceInputEnabled
+                && shouldArmNow == instantVoiceInputEnabled
             if canStore {
                 preparedInputEngine = preparedInput
             }
@@ -596,6 +621,7 @@ final class AVFoundationAudioRecorder: AudioRecorder {
             object: settingsStore,
             queue: nil
         ) { [weak self] _ in
+            self?.cancelInstantVoiceInputWarmWindowIfDisabled()
             self?.invalidatePreparedInputEngine(reason: "instant voice input setting changed")
         }
         preparedEngineConfigurationObserver = NotificationCenter.default.addObserver(
@@ -680,6 +706,7 @@ final class AVFoundationAudioRecorder: AudioRecorder {
     }
 
     private func suspendPreparedInputEngine(reason: String) {
+        cancelInstantVoiceInputIdleRelease()
         preparedInputLock.lock()
         guard !preparedInputIsSuspended else {
             preparedInputLock.unlock()
@@ -720,6 +747,77 @@ final class AVFoundationAudioRecorder: AudioRecorder {
         if let staleInput {
             disposePreparedInputEngine(staleInput)
         }
+    }
+
+    private func shouldArmInstantVoiceInput() -> Bool {
+        preparedInputLock.lock()
+        defer { preparedInputLock.unlock() }
+        return settingsStore.instantVoiceInputEnabled && instantVoiceInputWarmWindowIsActive
+    }
+
+    private func beginInstantVoiceInputWarmWindow() {
+        guard settingsStore.instantVoiceInputEnabled else {
+            schedulePreparedInputEngineBuild()
+            return
+        }
+
+        preparedInputLock.lock()
+        instantVoiceInputWarmWindowIsActive = true
+        instantVoiceInputWarmWindowGeneration &+= 1
+        let generation = instantVoiceInputWarmWindowGeneration
+        instantVoiceInputIdleReleaseWorkItem?.cancel()
+        let workItem = DispatchWorkItem { [weak self] in
+            self?.expireInstantVoiceInputWarmWindow(generation: generation)
+        }
+        instantVoiceInputIdleReleaseWorkItem = workItem
+        preparedInputLock.unlock()
+
+        inputPreparationQueue.asyncAfter(
+            deadline: .now() + configuredInstantVoiceInputIdleTimeout,
+            execute: workItem
+        )
+        schedulePreparedInputEngineBuild()
+    }
+
+    private func cancelInstantVoiceInputWarmWindowIfDisabled() {
+        guard !settingsStore.instantVoiceInputEnabled else { return }
+        cancelInstantVoiceInputIdleRelease()
+    }
+
+    private func cancelInstantVoiceInputIdleRelease() {
+        preparedInputLock.lock()
+        instantVoiceInputWarmWindowGeneration &+= 1
+        instantVoiceInputWarmWindowIsActive = false
+        instantVoiceInputIdleReleaseWorkItem?.cancel()
+        instantVoiceInputIdleReleaseWorkItem = nil
+        preparedInputLock.unlock()
+    }
+
+    private func expireInstantVoiceInputWarmWindow(generation: UInt64) {
+        preparedInputLock.lock()
+        guard instantVoiceInputWarmWindowGeneration == generation,
+              instantVoiceInputWarmWindowIsActive
+        else {
+            preparedInputLock.unlock()
+            return
+        }
+        instantVoiceInputWarmWindowIsActive = false
+        instantVoiceInputIdleReleaseWorkItem = nil
+        preparedInputGeneration &+= 1
+        let staleInput = preparedInputEngine
+        preparedInputEngine = nil
+        if preparedInputBuildIsPending {
+            preparedInputBuildNeedsRetry = true
+        }
+        preparedInputLock.unlock()
+
+        if let staleInput {
+            disposePreparedInputEngine(staleInput)
+        }
+        NetworkDebugLogger.logMessage(
+            "[Audio Recorder] Released instant voice input after the idle timeout."
+        )
+        schedulePreparedInputEngineBuild()
     }
 
     private func disposePreparedInputEngine(_ preparedInput: PreparedInputEngine) {
@@ -1077,6 +1175,16 @@ final class AVFoundationAudioRecorder: AudioRecorder {
             preparedInputLock.lock()
             defer { preparedInputLock.unlock() }
             return preparedInputIsSuspended
+        }
+
+        var instantVoiceInputWarmWindowIsActiveForTesting: Bool {
+            preparedInputLock.lock()
+            defer { preparedInputLock.unlock() }
+            return instantVoiceInputWarmWindowIsActive
+        }
+
+        func beginInstantVoiceInputWarmWindowForTesting() {
+            beginInstantVoiceInputWarmWindow()
         }
 
         func suspendPreparedInputForTesting() {

--- a/Sources/Typeflux/Resources/en.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/en.lproj/Localizable.strings
@@ -143,8 +143,8 @@
 "settings.microphone.title" = "Microphone";
 "settings.microphone.subtitle" = "Pick the device used for dictation. Automatic follows the current macOS default input.";
 "settings.microphone.automatic" = "Automatic";
-"settings.instantVoiceInput.title" = "Speak Immediately (Experimental)";
-"settings.instantVoiceInput.subtitle" = "Keep the microphone ready so your first words are captured when you press the shortcut. The most recent half-second stays in memory and joins a recording only when you start dictation; otherwise it is continuously discarded. macOS will show the microphone as in use and battery use may increase.";
+"settings.instantVoiceInput.title" = "Speak Immediately";
+"settings.instantVoiceInput.subtitle" = "The first dictation starts normally. After each dictation, the microphone stays ready for up to 15 minutes so your next first words are captured; each use resets the timer, and the microphone is released after the idle period. The most recent half-second cycles only in memory and joins a recording only when you start dictation. While ready, macOS will show the microphone as in use and battery use may increase.";
 "settings.mute.title" = "Mute During Recording";
 "settings.mute.subtitle" = "Temporarily mute the system output while recording to reduce feedback or system sounds leaking into the microphone.";
 "settings.permissions" = "Permissions";

--- a/Sources/Typeflux/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/ja.lproj/Localizable.strings
@@ -143,8 +143,8 @@
 "settings.microphone.title" = "マイク";
 "settings.microphone.subtitle" = "ディクテーションに使用するデバイスを選択します。自動は、現在の macOS デフォルト入力に従います。";
 "settings.microphone.automatic" = "自動";
-"settings.instantVoiceInput.title" = "すぐに話す（試験機能）";
-"settings.instantVoiceInput.subtitle" = "ショートカットを押した瞬間から冒頭を録音できるよう、マイクを準備状態に保ちます。直近約0.5秒の音声はメモリーだけに保持され、音声入力を開始したときに限り今回の録音へ加えられ、それ以外は上書きされ続けます。有効にすると macOS にマイク使用中と表示され、バッテリー消費が少し増える場合があります。";
+"settings.instantVoiceInput.title" = "すぐに話す";
+"settings.instantVoiceInput.subtitle" = "最初の音声入力は通常どおり起動します。音声入力の終了後、マイクは最長15分間準備状態を保ち、その間の次回入力では冒頭から録音できます。使用するたびに時間が延長され、操作がなければ自動的に解放されます。直近約0.5秒の音声はメモリー内だけで循環し、音声入力を開始したときだけ録音に加えられます。準備中は macOS にマイク使用中と表示され、バッテリー消費が少し増える場合があります。";
 "settings.mute.title" = "録音中にミュートする";
 "settings.mute.subtitle" = "録音中にシステム出力を一時的にミュートして、マイクに漏れるフィードバックやシステム音を軽減します。";
 "settings.permissions" = "権限";

--- a/Sources/Typeflux/Resources/ko.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/ko.lproj/Localizable.strings
@@ -143,8 +143,8 @@
 "settings.microphone.title" = "마이크";
 "settings.microphone.subtitle" = "받아쓰기에 사용되는 장치를 선택하세요. 자동은 현재 macOS 기본 입력을 따릅니다.";
 "settings.microphone.automatic" = "자동";
-"settings.instantVoiceInput.title" = "바로 말하기(실험 기능)";
-"settings.instantVoiceInput.subtitle" = "단축키를 누르는 순간부터 첫말을 빠짐없이 녹음할 수 있도록 마이크를 준비 상태로 유지합니다. 최근 약 0.5초의 음성은 메모리에만 보관되며 음성 입력을 시작할 때만 이번 녹음에 포함되고, 그 외에는 계속 덮어씁니다. 켜면 macOS에 마이크 사용 중으로 표시되고 배터리 사용량이 조금 늘 수 있습니다.";
+"settings.instantVoiceInput.title" = "바로 말하기";
+"settings.instantVoiceInput.subtitle" = "첫 음성 입력은 평소처럼 시작됩니다. 음성 입력이 끝나면 마이크가 최대 15분 동안 준비 상태를 유지해 다음 입력의 첫말부터 녹음합니다. 사용할 때마다 시간이 다시 시작되며, 유휴 시간이 지나면 마이크가 자동으로 해제됩니다. 최근 약 0.5초의 음성은 메모리에서만 순환하며 음성 입력을 시작할 때만 녹음에 포함됩니다. 준비 상태에서는 macOS에 마이크 사용 중으로 표시되고 배터리 사용량이 조금 늘 수 있습니다.";
 "settings.mute.title" = "녹음 중 음소거";
 "settings.mute.subtitle" = "녹음하는 동안 일시적으로 시스템 출력을 음소거하여 피드백이나 시스템 사운드가 마이크에 새는 것을 줄입니다.";
 "settings.permissions" = "권한";

--- a/Sources/Typeflux/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/zh-Hans.lproj/Localizable.strings
@@ -135,8 +135,8 @@
 "settings.microphone.title" = "麦克风";
 "settings.microphone.subtitle" = "选择听写使用的输入设备。自动模式会跟随当前 macOS 默认输入设备。";
 "settings.microphone.automatic" = "自动";
-"settings.instantVoiceInput.title" = "按键即说（实验功能）";
-"settings.instantVoiceInput.subtitle" = "提前让麦克风保持就绪，按下快捷键时即可完整录下开头。最近约半秒音频只保留在内存中，仅在开始语音输入时并入本次录音，其他时候会持续覆盖。开启后 macOS 会显示麦克风正在使用，并可能略微增加耗电。";
+"settings.instantVoiceInput.title" = "按键即说";
+"settings.instantVoiceInput.subtitle" = "首次使用为正常启动。每次语音输入结束后，麦克风会保持就绪最多 15 分钟；期间再次使用可完整录下开头，每次使用都会重新计时，空闲超时后自动释放。最近约半秒音频只在内存中循环覆盖，仅在开始语音输入时并入本次录音。保持就绪期间，macOS 会显示麦克风正在使用，并可能略微增加耗电。";
 "settings.mute.title" = "录音时静音";
 "settings.mute.subtitle" = "录音期间临时静音系统输出，减少回声或系统声音串入麦克风。";
 "settings.permissions" = "权限";

--- a/Sources/Typeflux/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/zh-Hant.lproj/Localizable.strings
@@ -135,8 +135,8 @@
 "settings.microphone.title" = "麥克風";
 "settings.microphone.subtitle" = "選擇聽寫使用的輸入裝置。自動模式會跟隨目前 macOS 預設輸入裝置。";
 "settings.microphone.automatic" = "自動";
-"settings.instantVoiceInput.title" = "按鍵即說（實驗功能）";
-"settings.instantVoiceInput.subtitle" = "預先讓麥克風保持就緒，按下快捷鍵時即可完整錄下開頭。最近約半秒音訊只保留在記憶體中，僅在開始語音輸入時併入本次錄音，其他時間會持續覆寫。開啟後 macOS 會顯示麥克風正在使用，並可能稍微增加耗電。";
+"settings.instantVoiceInput.title" = "按鍵即說";
+"settings.instantVoiceInput.subtitle" = "首次使用為正常啟動。每次語音輸入結束後，麥克風會保持就緒最多 15 分鐘；期間再次使用可完整錄下開頭，每次使用都會重新計時，閒置逾時後自動釋放。最近約半秒音訊只在記憶體中循環覆寫，僅在開始語音輸入時併入本次錄音。麥克風保持就緒期間，macOS 會顯示正在使用，並可能稍微增加耗電。";
 "settings.mute.title" = "錄音時靜音";
 "settings.mute.subtitle" = "錄音期間暫時靜音系統輸出，減少回聲或系統聲音進入麥克風。";
 "settings.permissions" = "權限";

--- a/Sources/Typeflux/Settings/SettingsView.swift
+++ b/Sources/Typeflux/Settings/SettingsView.swift
@@ -2321,7 +2321,8 @@ struct StudioView: View {
 
                     StudioSettingRow(
                         title: L("settings.instantVoiceInput.title"),
-                        subtitle: L("settings.instantVoiceInput.subtitle")
+                        subtitle: L("settings.instantVoiceInput.subtitle"),
+                        badge: "Beta"
                     ) {
                         Toggle(
                             "",

--- a/Tests/TypefluxTests/AVFoundationAudioRecorderTests.swift
+++ b/Tests/TypefluxTests/AVFoundationAudioRecorderTests.swift
@@ -255,6 +255,64 @@ final class AVFoundationAudioRecorderTests: XCTestCase {
         XCTAssertEqual(AVFoundationAudioRecorder.instantVoiceInputPreRollDuration, 0.5)
     }
 
+    func testInstantVoiceInputUsesFifteenMinuteIdleWindow() {
+        XCTAssertEqual(AVFoundationAudioRecorder.instantVoiceInputIdleTimeout, 15 * 60)
+    }
+
+    func testInstantVoiceInputWarmWindowExpiresAfterIdleTimeout() throws {
+        let suiteName = "AVFoundationAudioRecorderTests-\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let settingsStore = SettingsStore(defaults: defaults)
+        settingsStore.instantVoiceInputEnabled = true
+        let recorder = AVFoundationAudioRecorder(
+            settingsStore: settingsStore,
+            audioDeviceManager: MockAudioDeviceManager(defaultInputDeviceID: nil),
+            instantVoiceInputIdleTimeout: 0.05
+        )
+
+        recorder.beginInstantVoiceInputWarmWindowForTesting()
+
+        XCTAssertTrue(recorder.instantVoiceInputWarmWindowIsActiveForTesting)
+        let released = expectation(description: "Instant voice input is released after being idle")
+        DispatchQueue.global().asyncAfter(deadline: .now() + 0.15) {
+            XCTAssertFalse(recorder.instantVoiceInputWarmWindowIsActiveForTesting)
+            released.fulfill()
+        }
+        wait(for: [released], timeout: 1)
+    }
+
+    func testInstantVoiceInputStartsColdUntilARecordingCompletes() throws {
+        let suiteName = "AVFoundationAudioRecorderTests-\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let settingsStore = SettingsStore(defaults: defaults)
+        settingsStore.instantVoiceInputEnabled = true
+        let recorder = AVFoundationAudioRecorder(
+            settingsStore: settingsStore,
+            audioDeviceManager: MockAudioDeviceManager(defaultInputDeviceID: nil)
+        )
+
+        XCTAssertFalse(recorder.instantVoiceInputWarmWindowIsActiveForTesting)
+    }
+
+    func testDisablingInstantVoiceInputCancelsActiveWarmWindow() throws {
+        let suiteName = "AVFoundationAudioRecorderTests-\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let settingsStore = SettingsStore(defaults: defaults)
+        settingsStore.instantVoiceInputEnabled = true
+        let recorder = AVFoundationAudioRecorder(
+            settingsStore: settingsStore,
+            audioDeviceManager: MockAudioDeviceManager(defaultInputDeviceID: nil)
+        )
+        recorder.beginInstantVoiceInputWarmWindowForTesting()
+
+        settingsStore.instantVoiceInputEnabled = false
+
+        XCTAssertFalse(recorder.instantVoiceInputWarmWindowIsActiveForTesting)
+    }
+
     func testPreparedInputSuspendsAndRebuildsAcrossSleepLifecycle() throws {
         let suiteName = "AVFoundationAudioRecorderTests-\(UUID().uuidString)"
         let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))

--- a/Tests/TypefluxTests/LocalizationResourceTests.swift
+++ b/Tests/TypefluxTests/LocalizationResourceTests.swift
@@ -45,11 +45,19 @@ final class LocalizationResourceTests: XCTestCase {
         }
 
         let chineseBundle = try localizationBundle(for: .simplifiedChinese)
+        let chineseTitle = chineseBundle.localizedString(
+            forKey: "settings.instantVoiceInput.title",
+            value: nil,
+            table: nil
+        )
         let chineseDetail = chineseBundle.localizedString(
             forKey: "settings.instantVoiceInput.subtitle",
             value: nil,
             table: nil
         )
+        XCTAssertEqual(chineseTitle, "按键即说")
+        XCTAssertTrue(chineseDetail.contains("15 分钟"))
+        XCTAssertTrue(chineseDetail.contains("自动释放"))
         XCTAssertTrue(chineseDetail.contains("麦克风正在使用"))
         XCTAssertTrue(chineseDetail.contains("内存"))
     }


### PR DESCRIPTION
## Summary

- change Speak Immediately from always-armed capture to a 15-minute sliding warm window after each completed dictation
- keep the first dictation cold, automatically release the active microphone after inactivity, and preserve the stopped prepared-engine fast path
- consume and reset the warm-window timer safely when a prepared engine moves into a recording session
- retain microphone generation invalidation for default/preferred device changes, Bluetooth reconfiguration, sleep, and lock
- present the feature with the existing `Beta` setting-row badge and update all five localizations to explain the warm window and microphone indicator

## Verification

- `swift test --filter 'AVFoundationAudioRecorderTests|LocalizationResourceTests'` (68 tests)
- `swift test` (2486 XCTest + 8 Swift Testing tests)
- `make coverage` (39.68% repository line coverage)
- `git diff --check`
- `make format` could not run because `swiftformat` is not installed in the environment

## Manual QA

The execution environment has no interactive audio device/UI session. Before release, verify on a physical Mac that the microphone indicator disappears after the idle timeout and that built-in/Bluetooth microphone switching rebuilds the warm input correctly. The settings change reuses the existing Beta badge component; no screenshot is available from the headless environment.
