### PR TITLE
GUL-67: Improve exhausted free quota prompt

### DIFF
--- a/Sources/Typeflux/Networking/TypefluxCloudBillingError.swift
+++ b/Sources/Typeflux/Networking/TypefluxCloudBillingError.swift
@@ -6,6 +6,11 @@ struct TypefluxCloudBillingError: LocalizedError, Equatable {
         case quotaExceeded
     }
 
+    enum PrimaryAction: Equatable {
+        case openAccount
+        case openPlans
+    }
+
     let reason: Reason
     let serverMessage: String?
 
@@ -37,7 +42,7 @@ struct TypefluxCloudBillingError: LocalizedError, Equatable {
         case .quotaExceeded:
             return hasPaidSubscription
                 ? L("cloud.billing.quotaExceeded.title")
-                : L("cloud.billing.subscriptionRequired.title")
+                : L("cloud.billing.freePlanQuotaExceeded.title")
         }
     }
 
@@ -51,7 +56,7 @@ struct TypefluxCloudBillingError: LocalizedError, Equatable {
         case .quotaExceeded:
             return hasPaidSubscription
                 ? L("cloud.billing.quotaExceeded.body")
-                : L("cloud.billing.subscriptionRequired.body")
+                : L("cloud.billing.freePlanQuotaExceeded.body")
         }
     }
 
@@ -60,16 +65,24 @@ struct TypefluxCloudBillingError: LocalizedError, Equatable {
     }
 
     func primaryActionTitle(hasPaidSubscription: Bool, billingEnabled: Bool = true) -> String {
-        if !billingEnabled {
+        if primaryAction(hasPaidSubscription: hasPaidSubscription, billingEnabled: billingEnabled) == .openAccount {
             return L("cloud.billing.action.openAccount")
         }
         switch reason {
         case .subscriptionRequired:
             return L("cloud.billing.action.subscribe")
         case .quotaExceeded:
-            return hasPaidSubscription
-                ? L("cloud.billing.action.openAccount")
-                : L("cloud.billing.action.subscribe")
+            return L("cloud.billing.action.upgradePlan")
+        }
+    }
+
+    func primaryAction(hasPaidSubscription: Bool, billingEnabled: Bool = true) -> PrimaryAction {
+        guard billingEnabled else { return .openAccount }
+        switch reason {
+        case .subscriptionRequired:
+            return .openPlans
+        case .quotaExceeded:
+            return hasPaidSubscription ? .openAccount : .openPlans
         }
     }
 

--- a/Sources/Typeflux/Resources/en.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/en.lproj/Localizable.strings
@@ -1231,10 +1231,13 @@
 "cloud.billing.subscriptionRequired.body" = "This Cloud feature is not included in your current plan. Subscribe to keep using Typeflux Cloud.";
 "cloud.billing.quotaExceeded.title" = "Typeflux Cloud credits used up";
 "cloud.billing.quotaExceeded.body" = "Your Cloud quota or credits are currently unavailable. Open Account to review your subscription or billing.";
+"cloud.billing.freePlanQuotaExceeded.title" = "Free Cloud credits used up";
+"cloud.billing.freePlanQuotaExceeded.body" = "Your free Cloud credits have been used up for this period. Upgrade your plan to keep using Typeflux Cloud, or switch to another model.";
 "cloud.billing.freeQuotaExceeded.title" = "Free Cloud credits used up";
 "cloud.billing.freeQuotaExceeded.body" = "Your free Cloud credits have been used up for this period. Open Account to review usage or switch to another model.";
 "cloud.billing.action.openAccount" = "Open Account";
 "cloud.billing.action.subscribe" = "Subscribe";
+"cloud.billing.action.upgradePlan" = "Upgrade Plan";
 "cloud.billing.action.switchModel" = "Switch Model";
 
 "auth.account.provider" = "Login Method";

--- a/Sources/Typeflux/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/ja.lproj/Localizable.strings
@@ -1216,10 +1216,13 @@
 "cloud.billing.subscriptionRequired.body" = "このクラウド機能は現在のプランに含まれていません。購読すると Typeflux Cloud を引き続き利用できます。";
 "cloud.billing.quotaExceeded.title" = "Typeflux Cloud の利用枠が不足しています";
 "cloud.billing.quotaExceeded.body" = "クラウドの利用枠またはクレジットが現在利用できません。アカウント画面で購読または請求を確認してください。";
+"cloud.billing.freePlanQuotaExceeded.title" = "無料のクラウドクレジットを使い切りました";
+"cloud.billing.freePlanQuotaExceeded.body" = "この期間の無料クラウドクレジットを使い切りました。プランをアップグレードして Typeflux Cloud を引き続き利用するか、別のモデルに切り替えてください。";
 "cloud.billing.freeQuotaExceeded.title" = "無料のクラウドクレジットを使い切りました";
 "cloud.billing.freeQuotaExceeded.body" = "この期間の無料クラウドクレジットを使い切りました。アカウントで使用量を確認するか、別のモデルに切り替えてください。";
 "cloud.billing.action.openAccount" = "アカウントを開く";
 "cloud.billing.action.subscribe" = "購読する";
+"cloud.billing.action.upgradePlan" = "プランをアップグレード";
 "cloud.billing.action.switchModel" = "別のモデルに切り替え";
 
 "auth.account.provider" = "ログイン方法";

--- a/Sources/Typeflux/Resources/ko.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/ko.lproj/Localizable.strings
@@ -1216,10 +1216,13 @@
 "cloud.billing.subscriptionRequired.body" = "현재 요금제에는 이 클라우드 기능이 포함되어 있지 않습니다. 구독하면 Typeflux Cloud를 계속 사용할 수 있습니다.";
 "cloud.billing.quotaExceeded.title" = "Typeflux Cloud 한도를 사용할 수 없습니다";
 "cloud.billing.quotaExceeded.body" = "현재 클라우드 한도 또는 크레딧을 사용할 수 없습니다. 계정 화면에서 구독 또는 결제를 확인해 주세요.";
+"cloud.billing.freePlanQuotaExceeded.title" = "무료 클라우드 크레딧을 모두 사용했습니다";
+"cloud.billing.freePlanQuotaExceeded.body" = "이번 기간의 무료 클라우드 크레딧을 모두 사용했습니다. 요금제를 업그레이드하여 Typeflux Cloud를 계속 사용하거나 다른 모델로 전환하세요.";
 "cloud.billing.freeQuotaExceeded.title" = "무료 클라우드 크레딧을 모두 사용했습니다";
 "cloud.billing.freeQuotaExceeded.body" = "이번 기간의 무료 클라우드 크레딧을 모두 사용했습니다. 계정에서 사용량을 확인하거나 다른 모델로 전환하세요.";
 "cloud.billing.action.openAccount" = "계정 열기";
 "cloud.billing.action.subscribe" = "구독하기";
+"cloud.billing.action.upgradePlan" = "요금제 업그레이드";
 "cloud.billing.action.switchModel" = "다른 모델로 전환";
 
 "auth.account.provider" = "로그인 방법";

--- a/Sources/Typeflux/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/zh-Hans.lproj/Localizable.strings
@@ -1231,10 +1231,13 @@
 "cloud.billing.subscriptionRequired.body" = "当前套餐暂不包含这项云端功能。开通会员后即可继续使用 Typeflux Cloud。";
 "cloud.billing.quotaExceeded.title" = "Typeflux Cloud 额度暂不可用";
 "cloud.billing.quotaExceeded.body" = "当前云端额度或余额不足。请前往账号页处理订阅或账单。";
+"cloud.billing.freePlanQuotaExceeded.title" = "免费云端额度已用完";
+"cloud.billing.freePlanQuotaExceeded.body" = "本周期的免费云端额度已用完。升级会员后即可继续使用 Typeflux Cloud，也可以切换其他模型。";
 "cloud.billing.freeQuotaExceeded.title" = "免费云端额度已用完";
 "cloud.billing.freeQuotaExceeded.body" = "当前周期的免费云端额度已用完。你可以前往账号页查看用量，或切换其他模型。";
 "cloud.billing.action.openAccount" = "打开账号";
 "cloud.billing.action.subscribe" = "订阅会员";
+"cloud.billing.action.upgradePlan" = "升级套餐";
 "cloud.billing.action.switchModel" = "切换其他模型";
 
 "auth.account.provider" = "登录方式";

--- a/Sources/Typeflux/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/zh-Hant.lproj/Localizable.strings
@@ -1227,10 +1227,13 @@
 "cloud.billing.subscriptionRequired.body" = "目前方案暫不包含這項雲端功能。開通會員後即可繼續使用 Typeflux Cloud。";
 "cloud.billing.quotaExceeded.title" = "Typeflux Cloud 額度暫不可用";
 "cloud.billing.quotaExceeded.body" = "目前雲端額度或餘額不足。請前往帳號頁處理訂閱或帳單。";
+"cloud.billing.freePlanQuotaExceeded.title" = "免費雲端額度已用完";
+"cloud.billing.freePlanQuotaExceeded.body" = "本週期的免費雲端額度已用完。升級會員後即可繼續使用 Typeflux Cloud，也可以切換其他模型。";
 "cloud.billing.freeQuotaExceeded.title" = "免費雲端額度已用完";
 "cloud.billing.freeQuotaExceeded.body" = "目前週期的免費雲端額度已用完。你可以前往帳號頁查看用量，或切換其他模型。";
 "cloud.billing.action.openAccount" = "開啟帳號";
 "cloud.billing.action.subscribe" = "訂閱會員";
+"cloud.billing.action.upgradePlan" = "升級方案";
 "cloud.billing.action.switchModel" = "切換其他模型";
 
 "auth.account.provider" = "登入方式";

--- a/Sources/Typeflux/Workflow/WorkflowController.swift
+++ b/Sources/Typeflux/Workflow/WorkflowController.swift
@@ -1513,6 +1513,11 @@ final class WorkflowController {
             self.shouldPreserveLLMConfigurationNotice = true
             self.soundEffectPlayer.play(.tip)
 
+            let primaryAction = error.primaryAction(
+                hasPaidSubscription: hasPaidSubscription,
+                billingEnabled: billingEnabled
+            )
+
             let actions: [OverlayFailureAction] = [
                 OverlayFailureAction(
                     title: error.primaryActionTitle(
@@ -1523,11 +1528,39 @@ final class WorkflowController {
                     trailingSystemImage: "arrow.up.right",
                     handler: { [weak self] in
                         guard let self else { return }
-                        SettingsWindowController.shared.show(
-                            settingsStore: settingsStore,
-                            historyStore: historyStore,
-                            initialSection: .account
-                        )
+                        switch primaryAction {
+                        case .openAccount:
+                            SettingsWindowController.shared.show(
+                                settingsStore: settingsStore,
+                                historyStore: historyStore,
+                                initialSection: .account
+                            )
+                        case .openPlans:
+                            Task { @MainActor [weak self] in
+                                guard let self else { return }
+                                do {
+                                    let url = try await AccountBillingFlow.destination(
+                                        for: .subscribe,
+                                        requestBillingPageToken: {
+                                            try await AuthState.shared.requestBillingPageToken()
+                                        },
+                                        createPortalSession: {
+                                            try await AuthState.shared.createBillingPortalSession()
+                                        }
+                                    )
+                                    NSWorkspace.shared.open(url)
+                                } catch {
+                                    self.logger.error(
+                                        "Failed to open Typeflux Cloud plans: \(error.localizedDescription, privacy: .public)"
+                                    )
+                                    SettingsWindowController.shared.show(
+                                        settingsStore: self.settingsStore,
+                                        historyStore: self.historyStore,
+                                        initialSection: .account
+                                    )
+                                }
+                            }
+                        }
                     }
                 ),
                 OverlayFailureAction(

--- a/Tests/TypefluxTests/TypefluxCloudServerErrorMessageTests.swift
+++ b/Tests/TypefluxTests/TypefluxCloudServerErrorMessageTests.swift
@@ -105,7 +105,11 @@ final class TypefluxCloudServerErrorMessageTests: XCTestCase {
                 subscriptionRequired.title(hasPaidSubscription: false),
                 "Typeflux Cloud needs a subscription"
             )
-            XCTAssertEqual(quotaExceeded.title(hasPaidSubscription: false), "Typeflux Cloud needs a subscription")
+            XCTAssertEqual(quotaExceeded.title(hasPaidSubscription: false), "Free Cloud credits used up")
+            XCTAssertEqual(
+                quotaExceeded.message(hasPaidSubscription: false),
+                "Your free Cloud credits have been used up for this period. Upgrade your plan to keep using Typeflux Cloud, or switch to another model."
+            )
             XCTAssertEqual(quotaExceeded.title(hasPaidSubscription: true), "Typeflux Cloud credits used up")
             XCTAssertEqual(
                 subscriptionRequired.primaryActionTitle,
@@ -113,11 +117,23 @@ final class TypefluxCloudServerErrorMessageTests: XCTestCase {
             )
             XCTAssertEqual(
                 quotaExceeded.primaryActionTitle,
-                "Subscribe"
+                "Upgrade Plan"
             )
             XCTAssertEqual(
                 quotaExceeded.primaryActionTitle(hasPaidSubscription: true),
                 "Open Account"
+            )
+            XCTAssertEqual(
+                subscriptionRequired.primaryAction(hasPaidSubscription: false),
+                .openPlans
+            )
+            XCTAssertEqual(
+                quotaExceeded.primaryAction(hasPaidSubscription: false),
+                .openPlans
+            )
+            XCTAssertEqual(
+                quotaExceeded.primaryAction(hasPaidSubscription: true),
+                .openAccount
             )
         }
     }
@@ -133,6 +149,10 @@ final class TypefluxCloudServerErrorMessageTests: XCTestCase {
             XCTAssertEqual(
                 error.primaryActionTitle(hasPaidSubscription: false, billingEnabled: false),
                 "Open Account"
+            )
+            XCTAssertEqual(
+                error.primaryAction(hasPaidSubscription: false, billingEnabled: false),
+                .openAccount
             )
             XCTAssertFalse(
                 error.message(hasPaidSubscription: false, billingEnabled: false).localizedCaseInsensitiveContains(


### PR DESCRIPTION
## Summary

- show an accurate free-credit exhaustion message instead of saying a subscription is missing
- send free users directly to the authenticated plans page from the upgrade action
- preserve account and model-switch fallbacks for paid or billing-disabled states
- add localized copy and unit coverage for billing prompt actions

## Tests

- `swift test --filter TypefluxCloudServerErrorMessageTests` (12 tests)
- `swift test` (2494 tests)

Closes GUL-67
