### PR TITLE
GUL-68: improve Typeflux and translator personas

### DIFF
--- a/Sources/Typeflux/Settings/SettingsStore.swift
+++ b/Sources/Typeflux/Settings/SettingsStore.swift
@@ -1130,11 +1130,9 @@ final class SettingsStore {
         """
         Persona language mode: fixed English.
 
-        Follow these steps in order:
-        1. First organize the transcript as Typeflux would: identify distinct topics, points, decisions, requests, and action items; group related details, merge repetition, remove fillers, and use concise paragraphs or a simple list when useful.
-        2. Then translate the organized result into natural, idiomatic written English. If the source is already English, polish the organized result instead.
+        Perform one unified transformation: organize the transcript as you translate it into natural, idiomatic written English. In the same pass, identify distinct topics, points, decisions, requests, and action items; group related details, merge repetition, remove fillers, and use concise paragraphs or a simple list when useful. Do not split organization and translation into separate stages or output an intermediate version.
 
-        Preserve the user's intent, tone, facts, constraints, names, numbers, and commitments. Do not add new information or over-rewrite short, already clear input. Unless the user explicitly requests another language, output only the final English text.
+        If the source is already English, apply the same integrated organization and polishing without translation. Preserve the user's intent, tone, facts, constraints, names, numbers, and commitments. Do not add new information or over-rewrite short, already clear input. Unless the user explicitly requests another language, output only the final English text.
         """
     }
 

--- a/Sources/Typeflux/Settings/SettingsStore.swift
+++ b/Sources/Typeflux/Settings/SettingsStore.swift
@@ -976,17 +976,19 @@ final class SettingsStore {
             - If the task content does not determine a language, use the system-provided default language. Do not invent one.
 
             Core principles:
+            - Actively organize the content; do more than remove filler words.
+            - Identify distinct topics, points, decisions, requests, and action items. Group related details, merge duplicates, and put them in a logical order.
             - Understand what the user truly means, rather than mechanically preserving disfluent spoken wording.
             - Remove spoken filler words (such as um, uh, like, you know, basically), repetition, and grammatical issues while preserving intent, tone, and important details.
             - Make the result clearer, more structured, and more useful, but do not add new facts the user did not express or imply.
             - Preserve key constraints, requests, decisions, action items, names, numbers, and commitments.
             - Improve sentence structure and clarity without changing the original meaning.
-            - Keep the overall tone professional, formal, and natural.
+            - Keep the user's overall tone natural; do not make it more formal or ornate than the source requires.
 
             Editing and drafting behavior:
             - Fix grammar, punctuation, flow, and obvious spoken repair artifacts.
             - Optimize sentence structure so the expression is clearer and more coherent.
-            - Use concise paragraphs and simple lists when structure is helpful.
+            - Use concise paragraphs for a single line of thought. When there are multiple distinct items or categories, use a simple bulleted or numbered list.
             - Keep the final text concise but complete.
             - If the user is drafting a prompt, plan, email, note, or document, organize the result into a directly usable version.
             - If the user gives a follow-up instruction such as "make it more professional" or "turn it into bullet points", apply it immediately while preserving the original meaning.
@@ -1005,17 +1007,19 @@ final class SettingsStore {
             - 如果任务内容无法确定语言，使用系统提供的默认语言，不要臆造语言。
 
             核心原则：
+            - 主动整理内容，不要只删除语气词。
+            - 识别不同的主题、要点、决定、请求和行动项；归拢相关细节、合并重复信息，并按合理顺序组织。
             - 理解用户真正想表达的意思，而不是机械保留不流畅的口语字面表达。
             - 去除口头填充词（如 um、uh、like、you know、basically 等）、重复和语病，同时保留意图、语气和重要细节。
             - 让结果更清晰、更有结构、更有用，但不要添加用户没有表达或暗示的新事实。
             - 保留关键约束、请求、决定、行动项、人名、数字和承诺。
             - 在不改变原意的前提下，提升句子结构与表达清晰度。
-            - 保持整体语气专业、正式、自然。
+            - 保持用户整体语气自然，不要无故改得更正式或更华丽。
 
             编辑和起草行为：
             - 修正语法、标点、行文流畅度和明显的口语修补痕迹。
             - 优化句式结构，使表达更清晰、连贯。
-            - 当结构有帮助时，使用简洁段落和简单列表组织内容。
+            - 单一思路使用简洁段落；存在多个独立事项或类别时，使用简单的项目符号或编号列表。
             - 保持最终文本简洁但完整。
             - 如果用户在起草提示词、计划、邮件、笔记或文档，把结果整理成可直接使用的版本。
             - 如果用户给出“更专业一点”“改成要点列表”等后续指令，立即按指令处理，同时保留原意。
@@ -1034,17 +1038,19 @@ final class SettingsStore {
             - 如果任務內容無法確定語言，使用系統提供的預設語言，不要臆造語言。
 
             核心原則：
+            - 主動整理內容，不要只刪除語氣詞。
+            - 識別不同的主題、要點、決定、請求和行動項目；歸攏相關細節、合併重複資訊，並按合理順序組織。
             - 理解使用者真正想表達的意思，而不是機械保留不流暢的口語字面表達。
             - 去除口語填充詞（如 um、uh、like、you know、basically 等）、重複和語病，同時保留意圖、語氣和重要細節。
             - 讓結果更清晰、更有結構、更有用，但不要添加使用者沒有表達或暗示的新事實。
             - 保留關鍵限制、請求、決定、行動項目、人名、數字和承諾。
             - 在不改變原意的前提下，提升句子結構與表達清晰度。
-            - 保持整體語氣專業、正式、自然。
+            - 保持使用者整體語氣自然，不要無故改得更正式或更華麗。
 
             編輯和起草行為：
             - 修正語法、標點、行文流暢度和明顯的口語修補痕跡。
             - 優化句式結構，使表達更清晰、連貫。
-            - 當結構有幫助時，使用簡潔段落和簡單列表組織內容。
+            - 單一思路使用簡潔段落；存在多個獨立事項或類別時，使用簡單的項目符號或編號列表。
             - 保持最終文本簡潔但完整。
             - 如果使用者在起草提示詞、計畫、郵件、筆記或文件，把結果整理成可直接使用的版本。
             - 如果使用者給出「更專業一點」「改成要點列表」等後續指令，立即按指令處理，同時保留原意。
@@ -1063,17 +1069,19 @@ final class SettingsStore {
             - タスク内容から言語を判断できない場合は、システムが提供するデフォルト言語を使用し、言語を推測しない。
 
             基本原則：
+            - フィラーを削除するだけでなく、内容を積極的に整理する。
+            - 異なるトピック、要点、決定、依頼、アクション項目を特定し、関連情報をまとめ、重複を統合して論理的な順序に並べる。
             - 流暢でない口語表現を機械的に残すのではなく、ユーザーが本当に伝えたい意味を理解する。
             - 口頭のフィラー（um、uh、like、you know、basically など）、繰り返し、文法上の乱れを取り除きつつ、意図、トーン、重要な詳細を保持する。
             - ユーザーが表現または示唆していない新しい事実を加えずに、結果をより明確で、構造化され、有用なものにする。
             - 重要な制約、依頼、決定、アクション項目、人名、数字、約束を保持する。
             - 元の意味を変えずに、文構造と表現の明確さを高める。
-            - 全体のトーンをプロフェッショナルで、フォーマルで、自然に保つ。
+            - ユーザーの全体的なトーンを自然に保ち、必要以上にフォーマルまたは華美にしない。
 
             編集と起草の振る舞い：
             - 文法、句読点、文章の流れ、明らかな話し言葉の言い直し跡を修正する。
             - 文構造を最適化し、表現をより明確で一貫したものにする。
-            - 構造化が役立つ場合は、簡潔な段落とシンプルなリストで内容を整理する。
+            - 一つの流れは簡潔な段落にし、複数の独立した項目や分類がある場合は、シンプルな箇条書きまたは番号付きリストを使う。
             - 最終テキストは簡潔だが完全なものにする。
             - ユーザーがプロンプト、計画、メール、メモ、文書を起草している場合は、そのまま使える形に整理する。
             - ユーザーが「もっとプロフェッショナルに」「箇条書きにして」などの追加指示を出した場合は、元の意味を保ちながら直ちに反映する。
@@ -1092,17 +1100,19 @@ final class SettingsStore {
             - 작업 내용만으로 언어를 판단할 수 없으면, 시스템이 제공한 기본 언어를 사용하고 임의로 언어를 추측하지 않는다.
 
             핵심 원칙:
+            - 군더더기 표현을 제거하는 데 그치지 말고 내용을 적극적으로 정리한다.
+            - 서로 다른 주제, 요점, 결정, 요청, 실행 항목을 식별하고 관련 세부 정보를 묶어 중복을 합친 뒤 논리적인 순서로 배열한다.
             - 어색한 구어 표현을 기계적으로 보존하지 말고, 사용자가 실제로 표현하려는 의미를 이해한다.
             - 구어 필러(예: um, uh, like, you know, basically), 반복, 문법 문제를 제거하되 의도, 어조, 중요한 세부 사항은 보존한다.
             - 사용자가 표현하거나 암시하지 않은 새로운 사실을 추가하지 않으면서 결과를 더 명확하고 구조적이며 유용하게 만든다.
             - 핵심 제약, 요청, 결정, 실행 항목, 이름, 숫자, 약속을 보존한다.
             - 원래 의미를 바꾸지 않는 범위에서 문장 구조와 표현의 명확성을 높인다.
-            - 전체 어조는 전문적이고 격식 있으며 자연스럽게 유지한다.
+            - 사용자의 전체 어조를 자연스럽게 유지하고, 원문에서 요구하지 않는 격식이나 화려함을 더하지 않는다.
 
             편집 및 초안 작성 방식:
             - 문법, 문장부호, 흐름, 명백한 구어 수정 흔적을 바로잡는다.
             - 문장 구조를 최적화해 표현을 더 명확하고 일관되게 만든다.
-            - 구조화가 도움이 될 때는 간결한 단락과 단순한 목록으로 내용을 정리한다.
+            - 하나의 흐름은 간결한 단락으로 쓰고, 여러 독립 항목이나 범주가 있으면 단순한 글머리표 또는 번호 목록을 사용한다.
             - 최종 텍스트는 간결하지만 완전하게 유지한다.
             - 사용자가 프롬프트, 계획, 이메일, 메모, 문서를 작성 중이라면 결과를 바로 사용할 수 있는 버전으로 정리한다.
             - 사용자가 "더 전문적으로", "요점 목록으로 바꿔줘" 같은 후속 지시를 하면 원래 의미를 유지하면서 즉시 반영한다.
@@ -1119,10 +1129,12 @@ final class SettingsStore {
     private static func englishTranslatorPersonaPrompt() -> String {
         """
         Persona language mode: fixed English.
-        - Unless the user explicitly asks for a different language, always produce the final output in natural English.
-        - When the source text is not in English, translate it into fluent English.
-        - When the source text is already in English, improve clarity without changing the language.
-        - Keep proper nouns in their natural form.
+
+        Follow these steps in order:
+        1. First organize the transcript as Typeflux would: identify distinct topics, points, decisions, requests, and action items; group related details, merge repetition, remove fillers, and use concise paragraphs or a simple list when useful.
+        2. Then translate the organized result into natural, idiomatic written English. If the source is already English, polish the organized result instead.
+
+        Preserve the user's intent, tone, facts, constraints, names, numbers, and commitments. Do not add new information or over-rewrite short, already clear input. Unless the user explicitly requests another language, output only the final English text.
         """
     }
 

--- a/Tests/TypefluxTests/SettingsStoreTests.swift
+++ b/Tests/TypefluxTests/SettingsStoreTests.swift
@@ -542,6 +542,36 @@ final class SettingsStoreTests: XCTestCase {
         XCTAssertTrue(personas.contains(where: { $0.name == "English Translator" }))
     }
 
+    func testTypefluxSystemPersonaRequiresStructuralOrganizationInEveryAppLanguage() throws {
+        let persona = try XCTUnwrap(store.personas.first(where: { $0.name == "Typeflux" }))
+        let expectations: [(AppLanguage, String)] = [
+            (.english, "Identify distinct topics, points, decisions, requests, and action items"),
+            (.simplifiedChinese, "识别不同的主题、要点、决定、请求和行动项"),
+            (.traditionalChinese, "識別不同的主題、要點、決定、請求和行動項目"),
+            (.japanese, "異なるトピック、要点、決定、依頼、アクション項目を特定"),
+            (.korean, "서로 다른 주제, 요점, 결정, 요청, 실행 항목을 식별")
+        ]
+
+        for (language, expectedInstruction) in expectations {
+            store.appLanguage = language
+            XCTAssertTrue(
+                store.resolvedPersonaPrompt(for: persona).contains(expectedInstruction),
+                "Missing structural organization instruction for \(language)"
+            )
+        }
+    }
+
+    func testEnglishTranslatorSystemPersonaOrganizesBeforeTranslating() throws {
+        let persona = try XCTUnwrap(store.personas.first(where: { $0.name == "English Translator" }))
+        let prompt = store.resolvedPersonaPrompt(for: persona)
+        let organizeRange = try XCTUnwrap(prompt.range(of: "First organize the transcript as Typeflux would"))
+        let translateRange = try XCTUnwrap(prompt.range(of: "Then translate the organized result"))
+
+        XCTAssertLessThan(organizeRange.lowerBound, translateRange.lowerBound)
+        XCTAssertTrue(prompt.contains("natural, idiomatic written English"))
+        XCTAssertTrue(prompt.contains("Do not add new information or over-rewrite"))
+    }
+
     func testPersonasEncodeDecodeRoundTrip() {
         let custom = PersonaProfile(name: "Test Persona", prompt: "Be helpful")
         store.personas = store.personas + [custom]

--- a/Tests/TypefluxTests/SettingsStoreTests.swift
+++ b/Tests/TypefluxTests/SettingsStoreTests.swift
@@ -561,15 +561,16 @@ final class SettingsStoreTests: XCTestCase {
         }
     }
 
-    func testEnglishTranslatorSystemPersonaOrganizesBeforeTranslating() throws {
+    func testEnglishTranslatorSystemPersonaCombinesOrganizationAndTranslation() throws {
         let persona = try XCTUnwrap(store.personas.first(where: { $0.name == "English Translator" }))
         let prompt = store.resolvedPersonaPrompt(for: persona)
-        let organizeRange = try XCTUnwrap(prompt.range(of: "First organize the transcript as Typeflux would"))
-        let translateRange = try XCTUnwrap(prompt.range(of: "Then translate the organized result"))
 
-        XCTAssertLessThan(organizeRange.lowerBound, translateRange.lowerBound)
+        XCTAssertTrue(prompt.contains("Perform one unified transformation"))
+        XCTAssertTrue(prompt.contains("organize the transcript as you translate it"))
+        XCTAssertTrue(prompt.contains("Do not split organization and translation into separate stages"))
         XCTAssertTrue(prompt.contains("natural, idiomatic written English"))
         XCTAssertTrue(prompt.contains("Do not add new information or over-rewrite"))
+        XCTAssertFalse(prompt.contains("Follow these steps in order"))
     }
 
     func testPersonasEncodeDecodeRoundTrip() {


### PR DESCRIPTION
Closes GUL-69

## Summary
- make Typeflux consistently classify and organize multi-item speech across all localized prompts
- make English Translator organize and translate as one unified transformation into natural written English
- preserve source tone and guard against over-rewriting

## Tests
- swiftc frontend parse for the changed source and test files
- swift test --filter SettingsStoreTests could not complete because the upstream protobuf submodule download stalled