### PR TITLE
GUL-74: keep processing progress moving

### DIFF
--- a/Sources/Typeflux/Overlay/OverlayController.swift
+++ b/Sources/Typeflux/Overlay/OverlayController.swift
@@ -262,6 +262,7 @@ final class OverlayController {
     private static let autoDismissDelay: TimeInterval = 6.0
     private static let shadowGutter: CGFloat = 32
     private static let processingStatusLocalizationKey = "overlay.processing.thinking"
+    private static let processingProgressRefreshInterval: Duration = .milliseconds(50)
 
     static func noticeIsInteractive(dismissible: Bool) -> Bool {
         dismissible
@@ -269,6 +270,14 @@ final class OverlayController {
 
     var isShowingPassiveNotice: Bool {
         model.presentation == .notice && !model.noticeDismissible
+    }
+
+    var processingProgressForTesting: CGFloat {
+        model.processingProgress
+    }
+
+    var isProcessingProgressActiveForTesting: Bool {
+        processingProgressTask?.isCancelled == false
     }
 
     struct PersonaPickerItem: Identifiable, Equatable {
@@ -313,6 +322,9 @@ final class OverlayController {
     private var pendingFrameAnimationWorkItem: DispatchWorkItem?
     private var pendingPresentationWorkItem: DispatchWorkItem?
     private var recordingHintAutoHideWorkItem: DispatchWorkItem?
+    private var processingProgressTask: Task<Void, Never>?
+    private var processingProgressStartedAt: TimeInterval?
+    private var processingProgressTimeline: ProcessingProgressTimeline?
 
     init(appState: AppStateStore, settingsStore: SettingsStore) {
         self.appState = appState
@@ -347,6 +359,7 @@ final class OverlayController {
             pendingPresentationWorkItem,
             recordingHintAutoHideWorkItem
         ]
+        let progressTask = processingProgressTask
         let tap = eventTap
         let source = runLoopSource
         let fallbackGlobalMonitor = _fallbackGlobalMonitor
@@ -356,6 +369,7 @@ final class OverlayController {
         let systemKeyHandlerRef = pickerSystemKeyHandlerRef
 
         queuedWork.forEach { $0?.cancel() }
+        progressTask?.cancel()
         if let tap {
             CGEvent.tapEnable(tap: tap, enable: false)
             if let source {
@@ -421,6 +435,7 @@ final class OverlayController {
         }
         pendingPresentationWorkItem?.cancel()
         pendingPresentationWorkItem = nil
+        stopProcessingProgress()
         dismissWorkItem?.cancel()
         dismissWorkItem = nil
         cancelRecordingHintAutoHide()
@@ -480,6 +495,7 @@ final class OverlayController {
         }
         pendingPresentationWorkItem?.cancel()
         pendingPresentationWorkItem = nil
+        stopProcessingProgress()
         dismissWorkItem?.cancel()
         dismissWorkItem = nil
         cancelRecordingHintAutoHide()
@@ -512,23 +528,21 @@ final class OverlayController {
         refreshWindow()
     }
 
-    func showProcessing() {
+    func showProcessing(timeout: TimeInterval = 120) {
         if !Thread.isMainThread {
-            DispatchQueue.main.async { [weak self] in self?.showProcessing() }
+            DispatchQueue.main.async { [weak self] in self?.showProcessing(timeout: timeout) }
             return
         }
         cancelPendingPresentationTransition()
         dismissWorkItem?.cancel()
         dismissWorkItem = nil
         ensureWindow()
+        startProcessingProgress(timeout: timeout)
         if model.presentation.isRecordingPreview {
             model.recordingPreviewExpanded = false
             model.statusText = L(Self.processingStatusLocalizationKey)
             model.recordingHintText = ""
             cancelRecordingHintAutoHide()
-            model.processingProgress = 0
-            model.processingPhase = 1
-            model.processingEpoch += 1
             refreshWindow()
 
             let workItem = DispatchWorkItem { [weak self] in
@@ -550,15 +564,12 @@ final class OverlayController {
         model.detailText = ""
         model.recordingHintText = ""
         cancelRecordingHintAutoHide()
-        model.processingProgress = 0
-        model.processingPhase = 1
-        model.processingEpoch += 1
         refreshWindow()
     }
 
-    func showLLMProcessing() {
+    func showLLMProcessing(timeout: TimeInterval = 120) {
         if !Thread.isMainThread {
-            DispatchQueue.main.async { [weak self] in self?.showLLMProcessing() }
+            DispatchQueue.main.async { [weak self] in self?.showLLMProcessing(timeout: timeout) }
             return
         }
         cancelPendingPresentationTransition()
@@ -570,9 +581,7 @@ final class OverlayController {
         model.detailText = ""
         model.recordingHintText = ""
         cancelRecordingHintAutoHide()
-        model.processingProgress = 0
-        model.processingPhase = 1
-        model.processingEpoch += 1
+        startProcessingProgress(timeout: timeout)
         refreshWindow()
     }
 
@@ -590,15 +599,11 @@ final class OverlayController {
             model.statusText = L(Self.processingStatusLocalizationKey)
             model.detailText = ""
             model.recordingHintText = ""
-            model.processingProgress = 0
-            model.processingPhase = 1
-            model.processingEpoch += 1
             shouldRefresh = true
         }
         guard model.presentation.isProcessing else { return }
-        if model.processingPhase == 0 {
+        if model.statusText.isEmpty {
             model.statusText = L(Self.processingStatusLocalizationKey)
-            model.processingPhase = 1
             shouldRefresh = true
         }
         if shouldRefresh {
@@ -613,6 +618,7 @@ final class OverlayController {
         }
         cancelPendingPresentationTransition()
         dismissWorkItem?.cancel()
+        stopProcessingProgress()
         ensureWindow()
         model.presentation = .failure
         model.statusText = L("overlay.failure.title")
@@ -629,6 +635,7 @@ final class OverlayController {
         }
         cancelPendingPresentationTransition()
         dismissWorkItem?.cancel()
+        stopProcessingProgress()
         ensureWindow()
         model.presentation = .failure
         model.statusText = L("overlay.failure.title")
@@ -651,6 +658,7 @@ final class OverlayController {
         }
         cancelPendingPresentationTransition()
         dismissWorkItem?.cancel()
+        stopProcessingProgress()
         ensureWindow()
         model.presentation = .failure
         model.statusText = L("overlay.timeout.title")
@@ -685,6 +693,7 @@ final class OverlayController {
         }
         cancelPendingPresentationTransition()
         dismissWorkItem?.cancel()
+        stopProcessingProgress()
         ensureWindow()
         model.presentation = .failure
         model.statusText = title
@@ -749,6 +758,7 @@ final class OverlayController {
         }
         cancelPendingPresentationTransition()
         dismissWorkItem?.cancel()
+        stopProcessingProgress()
         model.noticeDismissible = true
         model.presentation = .notice
         model.statusText = L("overlay.notice.title")
@@ -764,6 +774,7 @@ final class OverlayController {
         }
         cancelPendingPresentationTransition()
         dismissWorkItem?.cancel()
+        stopProcessingProgress()
         model.noticeDismissible = false
         model.presentation = .notice
         model.statusText = L("overlay.notice.title")
@@ -781,6 +792,7 @@ final class OverlayController {
         }
         cancelPendingPresentationTransition()
         dismissWorkItem?.cancel()
+        stopProcessingProgress()
         ensureWindow()
         model.presentation = .resultDialog
         model.statusText = title
@@ -808,6 +820,7 @@ final class OverlayController {
 
         cancelPendingPresentationTransition()
         dismissWorkItem?.cancel()
+        stopProcessingProgress()
         ensureWindow()
         model.presentation = .personaPicker
         model.personaItems = items
@@ -839,6 +852,7 @@ final class OverlayController {
         cancelPendingPresentationTransition()
 
         if model.presentation.isProcessing {
+            stopProcessingProgress(resetProgress: false)
             model.processingProgress = 1
             dismiss(after: 0.18)
         } else if model.presentation == .notice || model.presentation == .resultDialog {
@@ -878,6 +892,7 @@ final class OverlayController {
             dismissWorkItem?.cancel()
             dismissWorkItem = nil
             cancelRecordingHintAutoHide()
+            stopProcessingProgress()
             window?.orderOut(nil)
             model.detailText = ""
             model.recordingHintText = ""
@@ -900,6 +915,7 @@ final class OverlayController {
             return
         }
         cancelPendingPresentationTransition()
+        stopProcessingProgress(resetProgress: false)
         if model.presentation == .failure, delay > 0 {
             return
         }
@@ -926,6 +942,40 @@ final class OverlayController {
         }
         recordingHintAutoHideWorkItem = workItem
         DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: workItem)
+    }
+
+    private func startProcessingProgress(timeout: TimeInterval) {
+        stopProcessingProgress()
+        processingProgressStartedAt = ProcessInfo.processInfo.systemUptime
+        processingProgressTimeline = ProcessingProgressTimeline(timeout: timeout)
+        processingProgressTask = Task { [weak self] in
+            while !Task.isCancelled {
+                try? await Task.sleep(for: Self.processingProgressRefreshInterval)
+                guard !Task.isCancelled else { return }
+                await MainActor.run { [weak self] in
+                    self?.updateProcessingProgress()
+                }
+            }
+        }
+    }
+
+    private func updateProcessingProgress() {
+        guard let startedAt = processingProgressStartedAt,
+              let timeline = processingProgressTimeline
+        else { return }
+
+        let elapsed = ProcessInfo.processInfo.systemUptime - startedAt
+        model.processingProgress = timeline.progress(elapsed: elapsed)
+    }
+
+    private func stopProcessingProgress(resetProgress: Bool = true) {
+        processingProgressTask?.cancel()
+        processingProgressTask = nil
+        processingProgressStartedAt = nil
+        processingProgressTimeline = nil
+        if resetProgress {
+            model.processingProgress = 0
+        }
     }
 
     private func cancelRecordingHintAutoHide() {
@@ -1445,8 +1495,6 @@ final class OverlayViewModel: ObservableObject {
     @Published var recordingPreviewExpanded: Bool = false
     @Published var level: Float = 0
     @Published var processingProgress: CGFloat = 0
-    @Published var processingEpoch: Int = 0
-    @Published var processingPhase: Int = 0
     @Published var personaItems: [OverlayController.PersonaPickerItem] = []
     @Published var personaSelectedIndex: Int = 0
     @Published var personaViewportHeight: CGFloat = 240
@@ -1673,9 +1721,7 @@ private struct OverlayView: View {
     private var processingCapsule: some View {
         ThinkingProgressCapsule(
             title: model.statusText.isEmpty ? L("overlay.processing.thinking") : model.statusText,
-            progress: model.processingProgress,
-            epoch: model.processingEpoch,
-            phase: model.processingPhase
+            progress: model.processingProgress
         )
     }
 
@@ -1683,9 +1729,7 @@ private struct OverlayView: View {
         ProcessingTranscriptCapsule(
             text: model.detailText,
             title: model.statusText.isEmpty ? L("overlay.processing.thinking") : model.statusText,
-            progress: model.processingProgress,
-            epoch: model.processingEpoch,
-            phase: model.processingPhase
+            progress: model.processingProgress
         )
         .fixedSize(horizontal: true, vertical: true)
     }
@@ -2445,9 +2489,6 @@ private struct LiveTranscriptPreviewText: View {
 private struct ThinkingProgressCapsule: View {
     let title: String
     let progress: CGFloat
-    let epoch: Int
-    let phase: Int
-    @State private var displayProgress: CGFloat = 0
 
     var body: some View {
         let capsuleShape = Capsule(style: .continuous)
@@ -2468,7 +2509,7 @@ private struct ThinkingProgressCapsule: View {
                     Color.clear
                     Rectangle()
                         .fill(Color.white.opacity(0.22))
-                        .frame(width: max(0, width * displayProgress))
+                        .frame(width: max(0, width * progress))
                 }
             }
             .mask(capsuleShape)
@@ -2484,34 +2525,7 @@ private struct ThinkingProgressCapsule: View {
         .compositingGroup()
         .shadow(color: Color.black.opacity(0.24), radius: 16, x: 0, y: 12)
         .environment(\.colorScheme, .dark)
-        .onAppear {
-            startProcessingPhase()
-        }
-        .onChange(of: epoch) { _ in
-            displayProgress = 0
-            startProcessingPhase()
-        }
-        .onChange(of: phase) { newPhase in
-            guard newPhase == 1, progress < 1 else { return }
-            withAnimation(.easeOut(duration: 2.0)) {
-                displayProgress = 0.85
-            }
-        }
-        .onChange(of: progress) { newValue in
-            if newValue >= 1 {
-                withAnimation(.easeOut(duration: 0.22)) {
-                    displayProgress = 1
-                }
-            }
-        }
-    }
-
-    private func startProcessingPhase() {
-        guard progress < 1 else { return }
-        let targetProgress: CGFloat = phase == 1 ? 0.85 : 0.5
-        withAnimation(.easeOut(duration: 1.5)) {
-            displayProgress = targetProgress
-        }
+        .animation(.linear(duration: 0.06), value: progress)
     }
 }
 
@@ -2519,9 +2533,6 @@ private struct ProcessingTranscriptCapsule: View {
     let text: String
     let title: String
     let progress: CGFloat
-    let epoch: Int
-    let phase: Int
-    @State private var displayProgress: CGFloat = 0
 
     var body: some View {
         let shape = RoundedRectangle(cornerRadius: 22, style: .continuous)
@@ -2548,26 +2559,7 @@ private struct ProcessingTranscriptCapsule: View {
         )
         .shadow(color: Color.black.opacity(0.24), radius: 18, x: 0, y: 12)
         .environment(\.colorScheme, .dark)
-        .onAppear {
-            startProcessingPhase()
-        }
-        .onChange(of: epoch) { _ in
-            displayProgress = 0
-            startProcessingPhase()
-        }
-        .onChange(of: phase) { newPhase in
-            guard newPhase == 1, progress < 1 else { return }
-            withAnimation(.easeOut(duration: 2.0)) {
-                displayProgress = 0.85
-            }
-        }
-        .onChange(of: progress) { newValue in
-            if newValue >= 1 {
-                withAnimation(.easeOut(duration: 0.22)) {
-                    displayProgress = 1
-                }
-            }
-        }
+        .animation(.linear(duration: 0.06), value: progress)
     }
 
     private var processingRow: some View {
@@ -2579,7 +2571,7 @@ private struct ProcessingTranscriptCapsule: View {
                     Color.white.opacity(0.08)
                     Rectangle()
                         .fill(Color.white.opacity(0.24))
-                        .frame(width: max(0, geo.size.width * displayProgress))
+                        .frame(width: max(0, geo.size.width * progress))
                 }
             }
             .mask(capsuleShape)
@@ -2598,13 +2590,6 @@ private struct ProcessingTranscriptCapsule: View {
         )
     }
 
-    private func startProcessingPhase() {
-        guard progress < 1 else { return }
-        let targetProgress: CGFloat = phase == 1 ? 0.85 : 0.5
-        withAnimation(.easeOut(duration: 1.5)) {
-            displayProgress = targetProgress
-        }
-    }
 }
 
 private struct OverlayCapsule<Content: View>: View {

--- a/Sources/Typeflux/Overlay/ProcessingProgressTimeline.swift
+++ b/Sources/Typeflux/Overlay/ProcessingProgressTimeline.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+struct ProcessingProgressTimeline {
+    static let maximumIncompleteProgress: CGFloat = 0.95
+
+    private let timeout: TimeInterval
+
+    init(timeout: TimeInterval) {
+        self.timeout = max(timeout, 0.001)
+    }
+
+    func progress(elapsed: TimeInterval) -> CGFloat {
+        let normalizedElapsed = min(max(elapsed, 0) / timeout, 1)
+        let easedProgress = log1p(9 * normalizedElapsed) / log(10)
+        return CGFloat(easedProgress) * Self.maximumIncompleteProgress
+    }
+}

--- a/Sources/Typeflux/Workflow/WorkflowController+Persona.swift
+++ b/Sources/Typeflux/Workflow/WorkflowController+Persona.swift
@@ -176,7 +176,8 @@ extension WorkflowController {
 
         cancelCurrentProcessing(resetUI: false, reason: L("workflow.cancel.newRecording"))
         let sessionID = beginProcessingSession()
-        startProcessingTimeout(sessionID: sessionID)
+        let timeoutSeconds = Self.processingTimeoutSeconds(recordingDurationSeconds: nil)
+        startProcessingTimeout(sessionID: sessionID, timeoutSeconds: timeoutSeconds)
 
         var record = HistoryRecord(
             date: Date(),
@@ -193,7 +194,7 @@ extension WorkflowController {
 
         Task { @MainActor in
             self.appState.setStatus(.processing)
-            self.overlayController.showLLMProcessing()
+            self.overlayController.showLLMProcessing(timeout: timeoutSeconds)
         }
 
         let shouldShowResultDialog = shouldPresentResultDialog(for: context.snapshot)

--- a/Sources/Typeflux/Workflow/WorkflowController+Processing.swift
+++ b/Sources/Typeflux/Workflow/WorkflowController+Processing.swift
@@ -534,12 +534,15 @@ extension WorkflowController {
             let personaPrompt = activePersonaProfile.map {
                 settingsStore.resolvedPersonaPrompt(for: $0)
             }
+            let processingTimeoutSeconds = Self.processingTimeoutSeconds(
+                recordingDurationSeconds: validatedAudioFile.duration
+            )
 
             NetworkDebugLogger.logMessage(selectionSnapshotLog(selectionSnapshot))
             if WorkflowOverlayPresentationPolicy.shouldShowProcessingAfterRecording() {
                 await MainActor.run {
                     self.appState.setStatus(.processing)
-                    self.overlayController.showProcessing()
+                    self.overlayController.showProcessing(timeout: processingTimeoutSeconds)
                 }
             }
 
@@ -576,7 +579,7 @@ extension WorkflowController {
 
             startProcessingTimeout(
                 sessionID: sessionID,
-                recordingDurationSeconds: validatedAudioFile.duration
+                timeoutSeconds: processingTimeoutSeconds
             )
             processingTask = Task { [weak self] in
                 guard let self else { return }

--- a/Sources/Typeflux/Workflow/WorkflowController.swift
+++ b/Sources/Typeflux/Workflow/WorkflowController.swift
@@ -419,15 +419,18 @@ final class WorkflowController {
         cancelCurrentProcessing(resetUI: false, reason: L("workflow.cancel.retry"))
 
         let sessionID = beginProcessingSession()
+        let timeoutSeconds = Self.processingTimeoutSeconds(
+            recordingDurationSeconds: record.recordingDurationSeconds
+        )
         startProcessingTimeout(
             sessionID: sessionID,
-            recordingDurationSeconds: record.recordingDurationSeconds
+            timeoutSeconds: timeoutSeconds
         )
         processingTask = Task { [weak self] in
             guard let self else { return }
             await MainActor.run {
                 self.appState.setStatus(.processing)
-                self.overlayController.showProcessing()
+                self.overlayController.showProcessing(timeout: timeoutSeconds)
             }
             await reprocess(record: record, sessionID: sessionID)
             cancelProcessingTimeout()
@@ -507,22 +510,26 @@ final class WorkflowController {
         }
     }
 
-    static func processingTimeoutNanoseconds(recordingDurationSeconds: TimeInterval?) -> UInt64 {
+    static func processingTimeoutSeconds(recordingDurationSeconds: TimeInterval?) -> TimeInterval {
         let recordingDuration = max(0, recordingDurationSeconds ?? 0)
-        let timeoutSeconds = max(
+        return max(
             minimumProcessingTimeoutSeconds,
             recordingDuration + processingTimeoutGraceSeconds
+        )
+    }
+
+    static func processingTimeoutNanoseconds(recordingDurationSeconds: TimeInterval?) -> UInt64 {
+        let timeoutSeconds = processingTimeoutSeconds(
+            recordingDurationSeconds: recordingDurationSeconds
         )
         return UInt64(timeoutSeconds * 1_000_000_000)
     }
 
     func startProcessingTimeout(
         sessionID: UUID,
-        recordingDurationSeconds: TimeInterval? = nil
+        timeoutSeconds: TimeInterval
     ) {
-        let timeoutNanoseconds = Self.processingTimeoutNanoseconds(
-            recordingDurationSeconds: recordingDurationSeconds
-        )
+        let timeoutNanoseconds = UInt64(max(0, timeoutSeconds) * 1_000_000_000)
         processingTimeoutTask?.cancel()
         processingTimeoutTask = Task { [weak self] in
             try? await Task.sleep(nanoseconds: timeoutNanoseconds)

--- a/Tests/TypefluxTests/OverlayControllerTests.swift
+++ b/Tests/TypefluxTests/OverlayControllerTests.swift
@@ -84,4 +84,30 @@ final class OverlayControllerTests: XCTestCase {
         XCTAssertFalse(OverlayController.noticeIsInteractive(dismissible: false))
         XCTAssertTrue(OverlayController.noticeIsInteractive(dismissible: true))
     }
+
+    @MainActor
+    func testProcessingProgressAdvancesUntilPresentationStops() async throws {
+        let controller = OverlayController(appState: AppStateStore())
+
+        controller.showProcessing(timeout: 1)
+        XCTAssertTrue(controller.isProcessingProgressActiveForTesting)
+
+        try await Task.sleep(for: .milliseconds(120))
+
+        XCTAssertGreaterThan(controller.processingProgressForTesting, 0)
+        controller.showFailure(message: "Failed")
+        XCTAssertFalse(controller.isProcessingProgressActiveForTesting)
+        XCTAssertEqual(controller.processingProgressForTesting, 0)
+    }
+
+    @MainActor
+    func testSuccessfulProcessingStopsTimelineAndCompletesProgress() {
+        let controller = OverlayController(appState: AppStateStore())
+
+        controller.showProcessing(timeout: 1)
+        controller.dismissSoon()
+
+        XCTAssertFalse(controller.isProcessingProgressActiveForTesting)
+        XCTAssertEqual(controller.processingProgressForTesting, 1)
+    }
 }

--- a/Tests/TypefluxTests/ProcessingProgressTimelineTests.swift
+++ b/Tests/TypefluxTests/ProcessingProgressTimelineTests.swift
@@ -1,0 +1,54 @@
+@testable import Typeflux
+import XCTest
+
+final class ProcessingProgressTimelineTests: XCTestCase {
+    func testProgressStartsAtZeroAndClampsNegativeElapsedTime() {
+        let timeline = ProcessingProgressTimeline(timeout: 120)
+
+        XCTAssertEqual(timeline.progress(elapsed: -1), 0)
+        XCTAssertEqual(timeline.progress(elapsed: 0), 0)
+    }
+
+    func testProgressContinuouslyAdvancesAcrossEntireTimeout() {
+        let timeline = ProcessingProgressTimeline(timeout: 120)
+        let checkpoints = stride(from: 0.0, through: 120.0, by: 1.0)
+            .map(timeline.progress(elapsed:))
+
+        for (earlier, later) in zip(checkpoints, checkpoints.dropFirst()) {
+            XCTAssertGreaterThan(later, earlier)
+        }
+    }
+
+    func testIncompleteProgressNeverReachesCompletion() {
+        let timeline = ProcessingProgressTimeline(timeout: 120)
+
+        XCTAssertEqual(
+            timeline.progress(elapsed: 120),
+            ProcessingProgressTimeline.maximumIncompleteProgress,
+            accuracy: 0.0001
+        )
+        XCTAssertEqual(
+            timeline.progress(elapsed: 300),
+            ProcessingProgressTimeline.maximumIncompleteProgress,
+            accuracy: 0.0001
+        )
+        XCTAssertLessThan(timeline.progress(elapsed: 300), 1)
+    }
+
+    func testProgressSlowsDownWithoutStoppingNearTimeout() {
+        let timeline = ProcessingProgressTimeline(timeout: 120)
+        let earlyGain = timeline.progress(elapsed: 30) - timeline.progress(elapsed: 0)
+        let lateGain = timeline.progress(elapsed: 120) - timeline.progress(elapsed: 90)
+
+        XCTAssertGreaterThan(earlyGain, lateGain)
+        XCTAssertGreaterThan(lateGain, 0)
+    }
+
+    func testNonPositiveTimeoutRemainsFinite() {
+        let timeline = ProcessingProgressTimeline(timeout: 0)
+        let progress = timeline.progress(elapsed: 1)
+
+        XCTAssertTrue(progress.isFinite)
+        XCTAssertEqual(progress, ProcessingProgressTimeline.maximumIncompleteProgress, accuracy: 0.0001)
+    }
+}

--- a/Tests/TypefluxTests/WorkflowControllerProcessingTests.swift
+++ b/Tests/TypefluxTests/WorkflowControllerProcessingTests.swift
@@ -584,6 +584,14 @@ final class WorkflowControllerProcessingTests: XCTestCase {
 
     func testProcessingTimeoutUsesMinimumForShortOrMissingRecordings() {
         XCTAssertEqual(
+            WorkflowController.processingTimeoutSeconds(recordingDurationSeconds: nil),
+            120
+        )
+        XCTAssertEqual(
+            WorkflowController.processingTimeoutSeconds(recordingDurationSeconds: 30),
+            120
+        )
+        XCTAssertEqual(
             WorkflowController.processingTimeoutNanoseconds(recordingDurationSeconds: nil),
             120_000_000_000
         )


### PR DESCRIPTION
## Summary

- drive the thinking capsule with the same timeout used by the processing workflow
- use a continuously advancing, front-loaded progress curve capped at 95% until completion
- share progress across transcription and LLM phases and stop timers on completion, cancellation, or presentation changes
- add progress-curve and overlay lifecycle tests

## Tests

- `swift test --filter 'OverlayControllerTests|ProcessingProgressTimelineTests|WorkflowControllerProcessingTests'` (104 passed)
- targeted coverage: `ProcessingProgressTimeline.swift` 100% line coverage
- full `swift test`: 2,485 passed; 8 existing Persona localization assertions failed in `SettingsStorePersonaTests` and `SettingsViewModelPersonaTests` (unrelated files, reproducible in isolation)

Closes GUL-74
