### PR TITLE
GUL-74: smooth two-stage processing progress

### DIFF
--- a/Sources/Typeflux/Overlay/OverlayController.swift
+++ b/Sources/Typeflux/Overlay/OverlayController.swift
@@ -324,6 +324,7 @@ final class OverlayController {
     private var recordingHintAutoHideWorkItem: DispatchWorkItem?
     private var processingProgressTask: Task<Void, Never>?
     private var processingProgressStartedAt: TimeInterval?
+    private var contentProcessingStartedElapsed: TimeInterval?
     private var processingProgressTimeline: ProcessingProgressTimeline?
 
     init(appState: AppStateStore, settingsStore: SettingsStore) {
@@ -581,7 +582,7 @@ final class OverlayController {
         model.detailText = ""
         model.recordingHintText = ""
         cancelRecordingHintAutoHide()
-        startProcessingProgress(timeout: timeout)
+        startProcessingProgress(timeout: timeout, contentProcessingAlreadyStarted: true)
         refreshWindow()
     }
 
@@ -602,6 +603,11 @@ final class OverlayController {
             shouldRefresh = true
         }
         guard model.presentation.isProcessing else { return }
+        if contentProcessingStartedElapsed == nil,
+           let startedAt = processingProgressStartedAt {
+            contentProcessingStartedElapsed = ProcessInfo.processInfo.systemUptime - startedAt
+            updateProcessingProgress()
+        }
         if model.statusText.isEmpty {
             model.statusText = L(Self.processingStatusLocalizationKey)
             shouldRefresh = true
@@ -944,9 +950,13 @@ final class OverlayController {
         DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: workItem)
     }
 
-    private func startProcessingProgress(timeout: TimeInterval) {
+    private func startProcessingProgress(
+        timeout: TimeInterval,
+        contentProcessingAlreadyStarted: Bool = false
+    ) {
         stopProcessingProgress()
         processingProgressStartedAt = ProcessInfo.processInfo.systemUptime
+        contentProcessingStartedElapsed = contentProcessingAlreadyStarted ? 0 : nil
         processingProgressTimeline = ProcessingProgressTimeline(timeout: timeout)
         processingProgressTask = Task { [weak self] in
             while !Task.isCancelled {
@@ -965,13 +975,17 @@ final class OverlayController {
         else { return }
 
         let elapsed = ProcessInfo.processInfo.systemUptime - startedAt
-        model.processingProgress = timeline.progress(elapsed: elapsed)
+        model.processingProgress = timeline.progress(
+            elapsed: elapsed,
+            contentProcessingStartedAt: contentProcessingStartedElapsed
+        )
     }
 
     private func stopProcessingProgress(resetProgress: Bool = true) {
         processingProgressTask?.cancel()
         processingProgressTask = nil
         processingProgressStartedAt = nil
+        contentProcessingStartedElapsed = nil
         processingProgressTimeline = nil
         if resetProgress {
             model.processingProgress = 0

--- a/Sources/Typeflux/Overlay/ProcessingProgressTimeline.swift
+++ b/Sources/Typeflux/Overlay/ProcessingProgressTimeline.swift
@@ -1,6 +1,8 @@
 import Foundation
 
 struct ProcessingProgressTimeline {
+    static let initialStageProgress: CGFloat = 0.5
+    static let initialStageDuration: TimeInterval = 1.5
     static let maximumIncompleteProgress: CGFloat = 0.95
 
     private let timeout: TimeInterval
@@ -10,8 +12,46 @@ struct ProcessingProgressTimeline {
     }
 
     func progress(elapsed: TimeInterval) -> CGFloat {
-        let normalizedElapsed = min(max(elapsed, 0) / timeout, 1)
+        progress(elapsed: elapsed, contentProcessingStartedAt: initialStageDuration)
+    }
+
+    func progress(
+        elapsed: TimeInterval,
+        contentProcessingStartedAt: TimeInterval?
+    ) -> CGFloat {
+        let elapsed = min(max(elapsed, 0), timeout)
+
+        // Give transcription immediate visual momentum, then reserve the
+        // remaining progress for the slower content-processing phase.
+        if elapsed <= initialStageDuration {
+            let normalizedElapsed = elapsed / initialStageDuration
+            let easedProgress = 1 - pow(1 - normalizedElapsed, 3)
+            return CGFloat(easedProgress) * Self.initialStageProgress
+        }
+
+        guard let contentProcessingStartedAt else {
+            return Self.initialStageProgress
+        }
+
+        let normalizedContentProcessingStart = min(
+            max(contentProcessingStartedAt, initialStageDuration),
+            timeout
+        )
+        guard elapsed > normalizedContentProcessingStart else {
+            return Self.initialStageProgress
+        }
+
+        let remainingDuration = timeout - normalizedContentProcessingStart
+        let normalizedElapsed = min(
+            (elapsed - normalizedContentProcessingStart) / remainingDuration,
+            1
+        )
         let easedProgress = log1p(9 * normalizedElapsed) / log(10)
-        return CGFloat(easedProgress) * Self.maximumIncompleteProgress
+        let remainingProgress = Self.maximumIncompleteProgress - Self.initialStageProgress
+        return Self.initialStageProgress + CGFloat(easedProgress) * remainingProgress
+    }
+
+    private var initialStageDuration: TimeInterval {
+        min(Self.initialStageDuration, timeout / 2)
     }
 }

--- a/Tests/TypefluxTests/OverlayControllerTests.swift
+++ b/Tests/TypefluxTests/OverlayControllerTests.swift
@@ -101,6 +101,21 @@ final class OverlayControllerTests: XCTestCase {
     }
 
     @MainActor
+    func testProcessingProgressWaitsAtHalfUntilLLMPhase() async throws {
+        let controller = OverlayController(appState: AppStateStore())
+
+        controller.showProcessing(timeout: 0.4)
+        try await Task.sleep(for: .milliseconds(260))
+
+        XCTAssertEqual(controller.processingProgressForTesting, 0.5, accuracy: 0.001)
+
+        controller.transitionToLLMPhase()
+        try await Task.sleep(for: .milliseconds(70))
+
+        XCTAssertGreaterThan(controller.processingProgressForTesting, 0.5)
+    }
+
+    @MainActor
     func testSuccessfulProcessingStopsTimelineAndCompletesProgress() {
         let controller = OverlayController(appState: AppStateStore())
 

--- a/Tests/TypefluxTests/ProcessingProgressTimelineTests.swift
+++ b/Tests/TypefluxTests/ProcessingProgressTimelineTests.swift
@@ -19,6 +19,40 @@ final class ProcessingProgressTimelineTests: XCTestCase {
         }
     }
 
+    func testProgressQuicklyReachesHalfBeforeSlowerSecondStage() {
+        let timeline = ProcessingProgressTimeline(timeout: 120)
+
+        XCTAssertGreaterThan(timeline.progress(elapsed: 0.5), 0.3)
+        XCTAssertEqual(
+            timeline.progress(elapsed: ProcessingProgressTimeline.initialStageDuration),
+            ProcessingProgressTimeline.initialStageProgress,
+            accuracy: 0.0001
+        )
+        XCTAssertGreaterThan(
+            timeline.progress(elapsed: ProcessingProgressTimeline.initialStageDuration + 1),
+            ProcessingProgressTimeline.initialStageProgress
+        )
+    }
+
+    func testProgressWaitsAtHalfUntilContentProcessingStarts() {
+        let timeline = ProcessingProgressTimeline(timeout: 120)
+
+        XCTAssertEqual(
+            timeline.progress(elapsed: 30, contentProcessingStartedAt: nil),
+            ProcessingProgressTimeline.initialStageProgress,
+            accuracy: 0.0001
+        )
+        XCTAssertEqual(
+            timeline.progress(elapsed: 30, contentProcessingStartedAt: 30),
+            ProcessingProgressTimeline.initialStageProgress,
+            accuracy: 0.0001
+        )
+        XCTAssertGreaterThan(
+            timeline.progress(elapsed: 31, contentProcessingStartedAt: 30),
+            ProcessingProgressTimeline.initialStageProgress
+        )
+    }
+
     func testIncompleteProgressNeverReachesCompletion() {
         let timeline = ProcessingProgressTimeline(timeout: 120)
 
@@ -37,11 +71,23 @@ final class ProcessingProgressTimelineTests: XCTestCase {
 
     func testProgressSlowsDownWithoutStoppingNearTimeout() {
         let timeline = ProcessingProgressTimeline(timeout: 120)
-        let earlyGain = timeline.progress(elapsed: 30) - timeline.progress(elapsed: 0)
+        let earlyGain = timeline.progress(elapsed: 1.5) - timeline.progress(elapsed: 0)
         let lateGain = timeline.progress(elapsed: 120) - timeline.progress(elapsed: 90)
 
         XCTAssertGreaterThan(earlyGain, lateGain)
         XCTAssertGreaterThan(lateGain, 0)
+    }
+
+    func testShortTimeoutStillUsesBothStagesAndReachesIncompleteMaximum() {
+        let timeline = ProcessingProgressTimeline(timeout: 1)
+
+        XCTAssertEqual(timeline.progress(elapsed: 0.5), 0.5, accuracy: 0.0001)
+        XCTAssertGreaterThan(timeline.progress(elapsed: 0.75), 0.5)
+        XCTAssertEqual(
+            timeline.progress(elapsed: 1),
+            ProcessingProgressTimeline.maximumIncompleteProgress,
+            accuracy: 0.0001
+        )
     }
 
     func testNonPositiveTimeoutRemainsFinite() {


### PR DESCRIPTION
## Summary

- animate speech recognition quickly to 50%, then hold there until content processing begins
- continue from 50% to 95% with the timeout-aware deceleration curve once the LLM/content phase starts
- keep direct LLM processing smooth and cover normal, delayed-phase, and compressed short-timeout timelines

## Testing

- `swift test --filter 'ProcessingProgressTimelineTests|OverlayControllerTests|WorkflowControllerProcessingTests'` (108 passed)
- `swift test --enable-code-coverage --filter 'ProcessingProgressTimelineTests|OverlayControllerTests'` (18 passed; timeline line coverage 100%)
- `git diff --check`

Closes GUL-74
