### PR TITLE
GUL-74: align progress with processing stages

### DIFF
--- a/Sources/Typeflux/Overlay/OverlayController.swift
+++ b/Sources/Typeflux/Overlay/OverlayController.swift
@@ -606,7 +606,7 @@ final class OverlayController {
         if contentProcessingStartedElapsed == nil,
            let startedAt = processingProgressStartedAt {
             contentProcessingStartedElapsed = ProcessInfo.processInfo.systemUptime - startedAt
-            updateProcessingProgress()
+            model.processingProgress = ProcessingProgressTimeline.recognitionCompleteProgress
         }
         if model.statusText.isEmpty {
             model.statusText = L(Self.processingStatusLocalizationKey)
@@ -958,6 +958,9 @@ final class OverlayController {
         processingProgressStartedAt = ProcessInfo.processInfo.systemUptime
         contentProcessingStartedElapsed = contentProcessingAlreadyStarted ? 0 : nil
         processingProgressTimeline = ProcessingProgressTimeline(timeout: timeout)
+        model.processingProgress = contentProcessingAlreadyStarted
+            ? ProcessingProgressTimeline.recognitionCompleteProgress
+            : ProcessingProgressTimeline.initialProgress
         processingProgressTask = Task { [weak self] in
             while !Task.isCancelled {
                 try? await Task.sleep(for: Self.processingProgressRefreshInterval)

--- a/Sources/Typeflux/Overlay/ProcessingProgressTimeline.swift
+++ b/Sources/Typeflux/Overlay/ProcessingProgressTimeline.swift
@@ -1,18 +1,15 @@
 import Foundation
 
 struct ProcessingProgressTimeline {
-    static let initialStageProgress: CGFloat = 0.5
-    static let initialStageDuration: TimeInterval = 1.5
+    static let initialProgress: CGFloat = 0.5
+    static let recognitionCompleteProgress: CGFloat = 0.7
     static let maximumIncompleteProgress: CGFloat = 0.95
 
+    private static let recognitionResponseTime: TimeInterval = 0.45
     private let timeout: TimeInterval
 
     init(timeout: TimeInterval) {
         self.timeout = max(timeout, 0.001)
-    }
-
-    func progress(elapsed: TimeInterval) -> CGFloat {
-        progress(elapsed: elapsed, contentProcessingStartedAt: initialStageDuration)
     }
 
     func progress(
@@ -21,24 +18,16 @@ struct ProcessingProgressTimeline {
     ) -> CGFloat {
         let elapsed = min(max(elapsed, 0), timeout)
 
-        // Give transcription immediate visual momentum, then reserve the
-        // remaining progress for the slower content-processing phase.
-        if elapsed <= initialStageDuration {
-            let normalizedElapsed = elapsed / initialStageDuration
-            let easedProgress = 1 - pow(1 - normalizedElapsed, 3)
-            return CGFloat(easedProgress) * Self.initialStageProgress
-        }
-
         guard let contentProcessingStartedAt else {
-            return Self.initialStageProgress
+            return recognitionProgress(elapsed: elapsed)
         }
 
         let normalizedContentProcessingStart = min(
-            max(contentProcessingStartedAt, initialStageDuration),
+            max(contentProcessingStartedAt, 0),
             timeout
         )
         guard elapsed > normalizedContentProcessingStart else {
-            return Self.initialStageProgress
+            return Self.recognitionCompleteProgress
         }
 
         let remainingDuration = timeout - normalizedContentProcessingStart
@@ -47,11 +36,15 @@ struct ProcessingProgressTimeline {
             1
         )
         let easedProgress = log1p(9 * normalizedElapsed) / log(10)
-        let remainingProgress = Self.maximumIncompleteProgress - Self.initialStageProgress
-        return Self.initialStageProgress + CGFloat(easedProgress) * remainingProgress
+        let remainingProgress = Self.maximumIncompleteProgress - Self.recognitionCompleteProgress
+        return Self.recognitionCompleteProgress + CGFloat(easedProgress) * remainingProgress
     }
 
-    private var initialStageDuration: TimeInterval {
-        min(Self.initialStageDuration, timeout / 2)
+    private func recognitionProgress(elapsed: TimeInterval) -> CGFloat {
+        // Approach 70% asymptotically so recognition keeps moving without
+        // reaching its phase boundary before transcription actually finishes.
+        let easedProgress = 1 - exp(-elapsed / Self.recognitionResponseTime)
+        let recognitionProgress = Self.recognitionCompleteProgress - Self.initialProgress
+        return Self.initialProgress + CGFloat(easedProgress) * recognitionProgress
     }
 }

--- a/Tests/TypefluxTests/OverlayControllerTests.swift
+++ b/Tests/TypefluxTests/OverlayControllerTests.swift
@@ -91,28 +91,32 @@ final class OverlayControllerTests: XCTestCase {
 
         controller.showProcessing(timeout: 1)
         XCTAssertTrue(controller.isProcessingProgressActiveForTesting)
+        XCTAssertEqual(controller.processingProgressForTesting, 0.5)
 
         try await Task.sleep(for: .milliseconds(120))
 
-        XCTAssertGreaterThan(controller.processingProgressForTesting, 0)
+        XCTAssertGreaterThan(controller.processingProgressForTesting, 0.5)
+        XCTAssertLessThan(controller.processingProgressForTesting, 0.7)
         controller.showFailure(message: "Failed")
         XCTAssertFalse(controller.isProcessingProgressActiveForTesting)
         XCTAssertEqual(controller.processingProgressForTesting, 0)
     }
 
     @MainActor
-    func testProcessingProgressWaitsAtHalfUntilLLMPhase() async throws {
+    func testProcessingProgressMovesFromRecognitionIntoLLMPhase() async throws {
         let controller = OverlayController(appState: AppStateStore())
 
-        controller.showProcessing(timeout: 0.4)
-        try await Task.sleep(for: .milliseconds(260))
-
-        XCTAssertEqual(controller.processingProgressForTesting, 0.5, accuracy: 0.001)
-
-        controller.transitionToLLMPhase()
-        try await Task.sleep(for: .milliseconds(70))
+        controller.showProcessing(timeout: 1)
+        try await Task.sleep(for: .milliseconds(120))
 
         XCTAssertGreaterThan(controller.processingProgressForTesting, 0.5)
+        XCTAssertLessThan(controller.processingProgressForTesting, 0.7)
+
+        controller.transitionToLLMPhase()
+        XCTAssertEqual(controller.processingProgressForTesting, 0.7, accuracy: 0.001)
+        try await Task.sleep(for: .milliseconds(70))
+
+        XCTAssertGreaterThan(controller.processingProgressForTesting, 0.7)
     }
 
     @MainActor

--- a/Tests/TypefluxTests/ProcessingProgressTimelineTests.swift
+++ b/Tests/TypefluxTests/ProcessingProgressTimelineTests.swift
@@ -2,99 +2,94 @@
 import XCTest
 
 final class ProcessingProgressTimelineTests: XCTestCase {
-    func testProgressStartsAtZeroAndClampsNegativeElapsedTime() {
+    func testRecognitionStartsAtHalfAndClampsNegativeElapsedTime() {
         let timeline = ProcessingProgressTimeline(timeout: 120)
 
-        XCTAssertEqual(timeline.progress(elapsed: -1), 0)
-        XCTAssertEqual(timeline.progress(elapsed: 0), 0)
+        XCTAssertEqual(
+            timeline.progress(elapsed: -1, contentProcessingStartedAt: nil),
+            ProcessingProgressTimeline.initialProgress
+        )
+        XCTAssertEqual(
+            timeline.progress(elapsed: 0, contentProcessingStartedAt: nil),
+            ProcessingProgressTimeline.initialProgress
+        )
     }
 
-    func testProgressContinuouslyAdvancesAcrossEntireTimeout() {
+    func testRecognitionContinuouslyApproachesSeventyPercent() {
         let timeline = ProcessingProgressTimeline(timeout: 120)
-        let checkpoints = stride(from: 0.0, through: 120.0, by: 1.0)
-            .map(timeline.progress(elapsed:))
+        let checkpoints = stride(from: 0.0, through: 10.0, by: 0.1)
+            .map { timeline.progress(elapsed: $0, contentProcessingStartedAt: nil) }
+
+        for (earlier, later) in zip(checkpoints, checkpoints.dropFirst()) {
+            XCTAssertGreaterThan(later, earlier)
+        }
+        XCTAssertGreaterThan(checkpoints[5], 0.6)
+        XCTAssertLessThan(checkpoints.last!, ProcessingProgressTimeline.recognitionCompleteProgress)
+    }
+
+    func testContentProcessingStartsAtSeventyPercentAndContinuesForward() {
+        let timeline = ProcessingProgressTimeline(timeout: 120)
+
+        XCTAssertEqual(
+            timeline.progress(elapsed: 30, contentProcessingStartedAt: 30),
+            ProcessingProgressTimeline.recognitionCompleteProgress,
+            accuracy: 0.0001
+        )
+        XCTAssertGreaterThan(
+            timeline.progress(elapsed: 31, contentProcessingStartedAt: 30),
+            ProcessingProgressTimeline.recognitionCompleteProgress
+        )
+    }
+
+    func testContentProgressContinuouslyAdvancesAcrossRemainingTimeout() {
+        let timeline = ProcessingProgressTimeline(timeout: 120)
+        let checkpoints = stride(from: 30.0, through: 120.0, by: 1.0)
+            .map { timeline.progress(elapsed: $0, contentProcessingStartedAt: 30) }
 
         for (earlier, later) in zip(checkpoints, checkpoints.dropFirst()) {
             XCTAssertGreaterThan(later, earlier)
         }
     }
 
-    func testProgressQuicklyReachesHalfBeforeSlowerSecondStage() {
-        let timeline = ProcessingProgressTimeline(timeout: 120)
-
-        XCTAssertGreaterThan(timeline.progress(elapsed: 0.5), 0.3)
-        XCTAssertEqual(
-            timeline.progress(elapsed: ProcessingProgressTimeline.initialStageDuration),
-            ProcessingProgressTimeline.initialStageProgress,
-            accuracy: 0.0001
-        )
-        XCTAssertGreaterThan(
-            timeline.progress(elapsed: ProcessingProgressTimeline.initialStageDuration + 1),
-            ProcessingProgressTimeline.initialStageProgress
-        )
-    }
-
-    func testProgressWaitsAtHalfUntilContentProcessingStarts() {
+    func testIncompleteContentProgressNeverReachesCompletion() {
         let timeline = ProcessingProgressTimeline(timeout: 120)
 
         XCTAssertEqual(
-            timeline.progress(elapsed: 30, contentProcessingStartedAt: nil),
-            ProcessingProgressTimeline.initialStageProgress,
-            accuracy: 0.0001
-        )
-        XCTAssertEqual(
-            timeline.progress(elapsed: 30, contentProcessingStartedAt: 30),
-            ProcessingProgressTimeline.initialStageProgress,
-            accuracy: 0.0001
-        )
-        XCTAssertGreaterThan(
-            timeline.progress(elapsed: 31, contentProcessingStartedAt: 30),
-            ProcessingProgressTimeline.initialStageProgress
-        )
-    }
-
-    func testIncompleteProgressNeverReachesCompletion() {
-        let timeline = ProcessingProgressTimeline(timeout: 120)
-
-        XCTAssertEqual(
-            timeline.progress(elapsed: 120),
+            timeline.progress(elapsed: 120, contentProcessingStartedAt: 30),
             ProcessingProgressTimeline.maximumIncompleteProgress,
             accuracy: 0.0001
         )
         XCTAssertEqual(
-            timeline.progress(elapsed: 300),
+            timeline.progress(elapsed: 300, contentProcessingStartedAt: 30),
             ProcessingProgressTimeline.maximumIncompleteProgress,
             accuracy: 0.0001
         )
-        XCTAssertLessThan(timeline.progress(elapsed: 300), 1)
+        XCTAssertLessThan(
+            timeline.progress(elapsed: 300, contentProcessingStartedAt: 30),
+            1
+        )
     }
 
-    func testProgressSlowsDownWithoutStoppingNearTimeout() {
+    func testContentProgressSlowsDownWithoutStoppingNearTimeout() {
         let timeline = ProcessingProgressTimeline(timeout: 120)
-        let earlyGain = timeline.progress(elapsed: 1.5) - timeline.progress(elapsed: 0)
-        let lateGain = timeline.progress(elapsed: 120) - timeline.progress(elapsed: 90)
+        let earlyGain = timeline.progress(elapsed: 60, contentProcessingStartedAt: 30)
+            - timeline.progress(elapsed: 30, contentProcessingStartedAt: 30)
+        let lateGain = timeline.progress(elapsed: 120, contentProcessingStartedAt: 30)
+            - timeline.progress(elapsed: 90, contentProcessingStartedAt: 30)
 
         XCTAssertGreaterThan(earlyGain, lateGain)
         XCTAssertGreaterThan(lateGain, 0)
     }
 
-    func testShortTimeoutStillUsesBothStagesAndReachesIncompleteMaximum() {
-        let timeline = ProcessingProgressTimeline(timeout: 1)
+    func testNonPositiveTimeoutRemainsFinite() {
+        let timeline = ProcessingProgressTimeline(timeout: 0)
+        let progress = timeline.progress(elapsed: 1, contentProcessingStartedAt: 0)
 
-        XCTAssertEqual(timeline.progress(elapsed: 0.5), 0.5, accuracy: 0.0001)
-        XCTAssertGreaterThan(timeline.progress(elapsed: 0.75), 0.5)
+        XCTAssertTrue(progress.isFinite)
         XCTAssertEqual(
-            timeline.progress(elapsed: 1),
+            progress,
             ProcessingProgressTimeline.maximumIncompleteProgress,
             accuracy: 0.0001
         )
-    }
-
-    func testNonPositiveTimeoutRemainsFinite() {
-        let timeline = ProcessingProgressTimeline(timeout: 0)
-        let progress = timeline.progress(elapsed: 1)
-
-        XCTAssertTrue(progress.isFinite)
-        XCTAssertEqual(progress, ProcessingProgressTimeline.maximumIncompleteProgress, accuracy: 0.0001)
     }
 }


### PR DESCRIPTION
## Summary

- start the post-recording progress capsule directly at 50%
- keep ASR moving smoothly from 50% toward 70%, then align to 70% when recognition completes
- advance LLM processing from 70% to 95% with the timeout-aware slow curve and finish at 100%

## Testing

- `swift test --filter 'ProcessingProgressTimelineTests|OverlayControllerTests|WorkflowControllerProcessingTests'` (107 passed)
- `swift test --enable-code-coverage --filter 'ProcessingProgressTimelineTests|OverlayControllerTests'` (17 passed; timeline line coverage 100%)
- `git diff --check`

Closes GUL-74
