### PR TITLE
GUL-66: simplify instant input copy

### DIFF
--- a/Sources/Typeflux/Resources/en.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/en.lproj/Localizable.strings
@@ -144,7 +144,7 @@
 "settings.microphone.subtitle" = "Pick the device used for dictation. Automatic follows the current macOS default input.";
 "settings.microphone.automatic" = "Automatic";
 "settings.instantVoiceInput.title" = "Speak Immediately";
-"settings.instantVoiceInput.subtitle" = "Make your next dictations start faster so the first words aren't missed. After each use, the microphone stays ready for 15 minutes and macOS shows it as in use.";
+"settings.instantVoiceInput.subtitle" = "Press the shortcut and start speaking right away, with less chance of missing the beginning. The microphone stays on for 15 minutes after use.";
 "settings.mute.title" = "Mute During Recording";
 "settings.mute.subtitle" = "Temporarily mute the system output while recording to reduce feedback or system sounds leaking into the microphone.";
 "settings.permissions" = "Permissions";

--- a/Sources/Typeflux/Resources/en.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/en.lproj/Localizable.strings
@@ -144,7 +144,7 @@
 "settings.microphone.subtitle" = "Pick the device used for dictation. Automatic follows the current macOS default input.";
 "settings.microphone.automatic" = "Automatic";
 "settings.instantVoiceInput.title" = "Speak Immediately";
-"settings.instantVoiceInput.subtitle" = "Press the shortcut and start speaking right away, with less chance of missing the beginning. The microphone stays on for 15 minutes after use.";
+"settings.instantVoiceInput.subtitle" = "Shortens microphone startup time, so you can speak as soon as you press the shortcut without missing anything. The microphone stays on for 15 minutes after use.";
 "settings.mute.title" = "Mute During Recording";
 "settings.mute.subtitle" = "Temporarily mute the system output while recording to reduce feedback or system sounds leaking into the microphone.";
 "settings.permissions" = "Permissions";

--- a/Sources/Typeflux/Resources/en.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/en.lproj/Localizable.strings
@@ -144,7 +144,7 @@
 "settings.microphone.subtitle" = "Pick the device used for dictation. Automatic follows the current macOS default input.";
 "settings.microphone.automatic" = "Automatic";
 "settings.instantVoiceInput.title" = "Speak Immediately";
-"settings.instantVoiceInput.subtitle" = "The first dictation starts normally. After each dictation, the microphone stays ready for up to 15 minutes so your next first words are captured; each use resets the timer, and the microphone is released after the idle period. The most recent half-second cycles only in memory and joins a recording only when you start dictation. While ready, macOS will show the microphone as in use and battery use may increase.";
+"settings.instantVoiceInput.subtitle" = "Make your next dictations start faster so the first words aren't missed. After each use, the microphone stays ready for 15 minutes and macOS shows it as in use.";
 "settings.mute.title" = "Mute During Recording";
 "settings.mute.subtitle" = "Temporarily mute the system output while recording to reduce feedback or system sounds leaking into the microphone.";
 "settings.permissions" = "Permissions";

--- a/Sources/Typeflux/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/ja.lproj/Localizable.strings
@@ -144,7 +144,7 @@
 "settings.microphone.subtitle" = "ディクテーションに使用するデバイスを選択します。自動は、現在の macOS デフォルト入力に従います。";
 "settings.microphone.automatic" = "自動";
 "settings.instantVoiceInput.title" = "すぐに話す";
-"settings.instantVoiceInput.subtitle" = "次回の音声入力をすばやく開始し、話し始めを逃しません。使用後はマイクが15分間準備状態になり、その間 macOS にマイク使用中と表示されます。";
+"settings.instantVoiceInput.subtitle" = "ショートカットを押したらすぐに話せるため、話し始めを逃しにくくなります。使用後はマイクが15分間オンになります。";
 "settings.mute.title" = "録音中にミュートする";
 "settings.mute.subtitle" = "録音中にシステム出力を一時的にミュートして、マイクに漏れるフィードバックやシステム音を軽減します。";
 "settings.permissions" = "権限";

--- a/Sources/Typeflux/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/ja.lproj/Localizable.strings
@@ -144,7 +144,7 @@
 "settings.microphone.subtitle" = "ディクテーションに使用するデバイスを選択します。自動は、現在の macOS デフォルト入力に従います。";
 "settings.microphone.automatic" = "自動";
 "settings.instantVoiceInput.title" = "すぐに話す";
-"settings.instantVoiceInput.subtitle" = "ショートカットを押したらすぐに話せるため、話し始めを逃しにくくなります。使用後はマイクが15分間オンになります。";
+"settings.instantVoiceInput.subtitle" = "マイクの起動時間を短縮し、ショートカットを押したらすぐに話せます。話した内容を最初から漏らさず記録します。使用後はマイクが15分間オンになります。";
 "settings.mute.title" = "録音中にミュートする";
 "settings.mute.subtitle" = "録音中にシステム出力を一時的にミュートして、マイクに漏れるフィードバックやシステム音を軽減します。";
 "settings.permissions" = "権限";

--- a/Sources/Typeflux/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/ja.lproj/Localizable.strings
@@ -144,7 +144,7 @@
 "settings.microphone.subtitle" = "ディクテーションに使用するデバイスを選択します。自動は、現在の macOS デフォルト入力に従います。";
 "settings.microphone.automatic" = "自動";
 "settings.instantVoiceInput.title" = "すぐに話す";
-"settings.instantVoiceInput.subtitle" = "最初の音声入力は通常どおり起動します。音声入力の終了後、マイクは最長15分間準備状態を保ち、その間の次回入力では冒頭から録音できます。使用するたびに時間が延長され、操作がなければ自動的に解放されます。直近約0.5秒の音声はメモリー内だけで循環し、音声入力を開始したときだけ録音に加えられます。準備中は macOS にマイク使用中と表示され、バッテリー消費が少し増える場合があります。";
+"settings.instantVoiceInput.subtitle" = "次回の音声入力をすばやく開始し、話し始めを逃しません。使用後はマイクが15分間準備状態になり、その間 macOS にマイク使用中と表示されます。";
 "settings.mute.title" = "録音中にミュートする";
 "settings.mute.subtitle" = "録音中にシステム出力を一時的にミュートして、マイクに漏れるフィードバックやシステム音を軽減します。";
 "settings.permissions" = "権限";

--- a/Sources/Typeflux/Resources/ko.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/ko.lproj/Localizable.strings
@@ -144,7 +144,7 @@
 "settings.microphone.subtitle" = "받아쓰기에 사용되는 장치를 선택하세요. 자동은 현재 macOS 기본 입력을 따릅니다.";
 "settings.microphone.automatic" = "자동";
 "settings.instantVoiceInput.title" = "바로 말하기";
-"settings.instantVoiceInput.subtitle" = "첫 음성 입력은 평소처럼 시작됩니다. 음성 입력이 끝나면 마이크가 최대 15분 동안 준비 상태를 유지해 다음 입력의 첫말부터 녹음합니다. 사용할 때마다 시간이 다시 시작되며, 유휴 시간이 지나면 마이크가 자동으로 해제됩니다. 최근 약 0.5초의 음성은 메모리에서만 순환하며 음성 입력을 시작할 때만 녹음에 포함됩니다. 준비 상태에서는 macOS에 마이크 사용 중으로 표시되고 배터리 사용량이 조금 늘 수 있습니다.";
+"settings.instantVoiceInput.subtitle" = "다음 음성 입력을 더 빠르게 시작해 첫말을 놓치지 않습니다. 사용 후 마이크는 15분 동안 준비 상태를 유지하며, 이때 macOS에 마이크 사용 중으로 표시됩니다.";
 "settings.mute.title" = "녹음 중 음소거";
 "settings.mute.subtitle" = "녹음하는 동안 일시적으로 시스템 출력을 음소거하여 피드백이나 시스템 사운드가 마이크에 새는 것을 줄입니다.";
 "settings.permissions" = "권한";

--- a/Sources/Typeflux/Resources/ko.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/ko.lproj/Localizable.strings
@@ -144,7 +144,7 @@
 "settings.microphone.subtitle" = "받아쓰기에 사용되는 장치를 선택하세요. 자동은 현재 macOS 기본 입력을 따릅니다.";
 "settings.microphone.automatic" = "자동";
 "settings.instantVoiceInput.title" = "바로 말하기";
-"settings.instantVoiceInput.subtitle" = "다음 음성 입력을 더 빠르게 시작해 첫말을 놓치지 않습니다. 사용 후 마이크는 15분 동안 준비 상태를 유지하며, 이때 macOS에 마이크 사용 중으로 표시됩니다.";
+"settings.instantVoiceInput.subtitle" = "단축키를 누른 즉시 말할 수 있어 첫말을 놓칠 가능성이 줄어듭니다. 사용 후 마이크는 15분 동안 켜진 상태를 유지합니다.";
 "settings.mute.title" = "녹음 중 음소거";
 "settings.mute.subtitle" = "녹음하는 동안 일시적으로 시스템 출력을 음소거하여 피드백이나 시스템 사운드가 마이크에 새는 것을 줄입니다.";
 "settings.permissions" = "권한";

--- a/Sources/Typeflux/Resources/ko.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/ko.lproj/Localizable.strings
@@ -144,7 +144,7 @@
 "settings.microphone.subtitle" = "받아쓰기에 사용되는 장치를 선택하세요. 자동은 현재 macOS 기본 입력을 따릅니다.";
 "settings.microphone.automatic" = "자동";
 "settings.instantVoiceInput.title" = "바로 말하기";
-"settings.instantVoiceInput.subtitle" = "단축키를 누른 즉시 말할 수 있어 첫말을 놓칠 가능성이 줄어듭니다. 사용 후 마이크는 15분 동안 켜진 상태를 유지합니다.";
+"settings.instantVoiceInput.subtitle" = "마이크 시작 시간을 줄여 단축키를 누르자마자 말해도 모든 내용을 빠짐없이 녹음합니다. 사용 후 마이크는 15분 동안 켜진 상태를 유지합니다.";
 "settings.mute.title" = "녹음 중 음소거";
 "settings.mute.subtitle" = "녹음하는 동안 일시적으로 시스템 출력을 음소거하여 피드백이나 시스템 사운드가 마이크에 새는 것을 줄입니다.";
 "settings.permissions" = "권한";

--- a/Sources/Typeflux/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/zh-Hans.lproj/Localizable.strings
@@ -136,7 +136,7 @@
 "settings.microphone.subtitle" = "选择听写使用的输入设备。自动模式会跟随当前 macOS 默认输入设备。";
 "settings.microphone.automatic" = "自动";
 "settings.instantVoiceInput.title" = "按键即说";
-"settings.instantVoiceInput.subtitle" = "首次使用为正常启动。每次语音输入结束后，麦克风会保持就绪最多 15 分钟；期间再次使用可完整录下开头，每次使用都会重新计时，空闲超时后自动释放。最近约半秒音频只在内存中循环覆盖，仅在开始语音输入时并入本次录音。保持就绪期间，macOS 会显示麦克风正在使用，并可能略微增加耗电。";
+"settings.instantVoiceInput.subtitle" = "让接下来的语音输入启动更快，避免漏掉开头。每次使用后，麦克风会保持就绪 15 分钟，期间 macOS 会显示麦克风正在使用。";
 "settings.mute.title" = "录音时静音";
 "settings.mute.subtitle" = "录音期间临时静音系统输出，减少回声或系统声音串入麦克风。";
 "settings.permissions" = "权限";

--- a/Sources/Typeflux/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/zh-Hans.lproj/Localizable.strings
@@ -136,7 +136,7 @@
 "settings.microphone.subtitle" = "选择听写使用的输入设备。自动模式会跟随当前 macOS 默认输入设备。";
 "settings.microphone.automatic" = "自动";
 "settings.instantVoiceInput.title" = "按键即说";
-"settings.instantVoiceInput.subtitle" = "按下快捷键就能直接说话，不易漏掉开头。使用后麦克风会保持启用 15 分钟。";
+"settings.instantVoiceInput.subtitle" = "缩短麦克风启动耗时，按下快捷键就能直接说话，不漏任何内容。使用后麦克风会保持启用 15 分钟。";
 "settings.mute.title" = "录音时静音";
 "settings.mute.subtitle" = "录音期间临时静音系统输出，减少回声或系统声音串入麦克风。";
 "settings.permissions" = "权限";

--- a/Sources/Typeflux/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/zh-Hans.lproj/Localizable.strings
@@ -136,7 +136,7 @@
 "settings.microphone.subtitle" = "选择听写使用的输入设备。自动模式会跟随当前 macOS 默认输入设备。";
 "settings.microphone.automatic" = "自动";
 "settings.instantVoiceInput.title" = "按键即说";
-"settings.instantVoiceInput.subtitle" = "让接下来的语音输入启动更快，避免漏掉开头。每次使用后，麦克风会保持就绪 15 分钟，期间 macOS 会显示麦克风正在使用。";
+"settings.instantVoiceInput.subtitle" = "按下快捷键就能直接说话，不易漏掉开头。使用后麦克风会保持启用 15 分钟。";
 "settings.mute.title" = "录音时静音";
 "settings.mute.subtitle" = "录音期间临时静音系统输出，减少回声或系统声音串入麦克风。";
 "settings.permissions" = "权限";

--- a/Sources/Typeflux/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/zh-Hant.lproj/Localizable.strings
@@ -136,7 +136,7 @@
 "settings.microphone.subtitle" = "選擇聽寫使用的輸入裝置。自動模式會跟隨目前 macOS 預設輸入裝置。";
 "settings.microphone.automatic" = "自動";
 "settings.instantVoiceInput.title" = "按鍵即說";
-"settings.instantVoiceInput.subtitle" = "讓接下來的語音輸入啟動更快，避免漏掉開頭。每次使用後，麥克風會保持就緒 15 分鐘，期間 macOS 會顯示麥克風正在使用。";
+"settings.instantVoiceInput.subtitle" = "按下快速鍵就能直接說話，不易漏掉開頭。使用後麥克風會保持啟用 15 分鐘。";
 "settings.mute.title" = "錄音時靜音";
 "settings.mute.subtitle" = "錄音期間暫時靜音系統輸出，減少回聲或系統聲音進入麥克風。";
 "settings.permissions" = "權限";

--- a/Sources/Typeflux/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/zh-Hant.lproj/Localizable.strings
@@ -136,7 +136,7 @@
 "settings.microphone.subtitle" = "選擇聽寫使用的輸入裝置。自動模式會跟隨目前 macOS 預設輸入裝置。";
 "settings.microphone.automatic" = "自動";
 "settings.instantVoiceInput.title" = "按鍵即說";
-"settings.instantVoiceInput.subtitle" = "按下快速鍵就能直接說話，不易漏掉開頭。使用後麥克風會保持啟用 15 分鐘。";
+"settings.instantVoiceInput.subtitle" = "縮短麥克風啟動時間，按下快速鍵就能直接說話，不漏掉任何內容。使用後麥克風會保持啟用 15 分鐘。";
 "settings.mute.title" = "錄音時靜音";
 "settings.mute.subtitle" = "錄音期間暫時靜音系統輸出，減少回聲或系統聲音進入麥克風。";
 "settings.permissions" = "權限";

--- a/Sources/Typeflux/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/zh-Hant.lproj/Localizable.strings
@@ -136,7 +136,7 @@
 "settings.microphone.subtitle" = "選擇聽寫使用的輸入裝置。自動模式會跟隨目前 macOS 預設輸入裝置。";
 "settings.microphone.automatic" = "自動";
 "settings.instantVoiceInput.title" = "按鍵即說";
-"settings.instantVoiceInput.subtitle" = "首次使用為正常啟動。每次語音輸入結束後，麥克風會保持就緒最多 15 分鐘；期間再次使用可完整錄下開頭，每次使用都會重新計時，閒置逾時後自動釋放。最近約半秒音訊只在記憶體中循環覆寫，僅在開始語音輸入時併入本次錄音。麥克風保持就緒期間，macOS 會顯示正在使用，並可能稍微增加耗電。";
+"settings.instantVoiceInput.subtitle" = "讓接下來的語音輸入啟動更快，避免漏掉開頭。每次使用後，麥克風會保持就緒 15 分鐘，期間 macOS 會顯示麥克風正在使用。";
 "settings.mute.title" = "錄音時靜音";
 "settings.mute.subtitle" = "錄音期間暫時靜音系統輸出，減少回聲或系統聲音進入麥克風。";
 "settings.permissions" = "權限";

--- a/Tests/TypefluxTests/LocalizationResourceTests.swift
+++ b/Tests/TypefluxTests/LocalizationResourceTests.swift
@@ -56,10 +56,13 @@ final class LocalizationResourceTests: XCTestCase {
             table: nil
         )
         XCTAssertEqual(chineseTitle, "按键即说")
+        XCTAssertLessThanOrEqual(chineseDetail.count, 70)
+        XCTAssertTrue(chineseDetail.contains("启动更快"))
+        XCTAssertTrue(chineseDetail.contains("避免漏掉开头"))
         XCTAssertTrue(chineseDetail.contains("15 分钟"))
-        XCTAssertTrue(chineseDetail.contains("自动释放"))
         XCTAssertTrue(chineseDetail.contains("麦克风正在使用"))
-        XCTAssertTrue(chineseDetail.contains("内存"))
+        XCTAssertFalse(chineseDetail.contains("内存"))
+        XCTAssertFalse(chineseDetail.contains("冷启动"))
     }
 
     func testSidebarAccountCardStateCopyExistsForAllSupportedLanguages() throws {

--- a/Tests/TypefluxTests/LocalizationResourceTests.swift
+++ b/Tests/TypefluxTests/LocalizationResourceTests.swift
@@ -34,6 +34,13 @@ final class LocalizationResourceTests: XCTestCase {
             "settings.instantVoiceInput.title",
             "settings.instantVoiceInput.subtitle"
         ]
+        let expectedSubtitles: [AppLanguage: String] = [
+            .english: "Shortens microphone startup time, so you can speak as soon as you press the shortcut without missing anything. The microphone stays on for 15 minutes after use.",
+            .simplifiedChinese: "缩短麦克风启动耗时，按下快捷键就能直接说话，不漏任何内容。使用后麦克风会保持启用 15 分钟。",
+            .traditionalChinese: "縮短麥克風啟動時間，按下快速鍵就能直接說話，不漏掉任何內容。使用後麥克風會保持啟用 15 分鐘。",
+            .japanese: "マイクの起動時間を短縮し、ショートカットを押したらすぐに話せます。話した内容を最初から漏らさず記録します。使用後はマイクが15分間オンになります。",
+            .korean: "마이크 시작 시간을 줄여 단축키를 누르자마자 말해도 모든 내용을 빠짐없이 녹음합니다. 사용 후 마이크는 15분 동안 켜진 상태를 유지합니다."
+        ]
 
         for language in AppLanguage.allCases {
             let bundle = try localizationBundle(for: language)
@@ -42,6 +49,13 @@ final class LocalizationResourceTests: XCTestCase {
                 XCTAssertNotEqual(localized, key, "Missing localized value for \(key) in \(language.rawValue)")
                 XCTAssertFalse(localized.isEmpty)
             }
+
+            let subtitle = bundle.localizedString(
+                forKey: "settings.instantVoiceInput.subtitle",
+                value: nil,
+                table: nil
+            )
+            XCTAssertEqual(subtitle, try XCTUnwrap(expectedSubtitles[language]))
         }
 
         let chineseBundle = try localizationBundle(for: .simplifiedChinese)
@@ -50,20 +64,7 @@ final class LocalizationResourceTests: XCTestCase {
             value: nil,
             table: nil
         )
-        let chineseDetail = chineseBundle.localizedString(
-            forKey: "settings.instantVoiceInput.subtitle",
-            value: nil,
-            table: nil
-        )
         XCTAssertEqual(chineseTitle, "按键即说")
-        XCTAssertLessThanOrEqual(chineseDetail.count, 45)
-        XCTAssertTrue(chineseDetail.contains("按下快捷键"))
-        XCTAssertTrue(chineseDetail.contains("不易漏掉开头"))
-        XCTAssertTrue(chineseDetail.contains("15 分钟"))
-        XCTAssertTrue(chineseDetail.contains("麦克风会保持启用"))
-        XCTAssertFalse(chineseDetail.contains("内存"))
-        XCTAssertFalse(chineseDetail.contains("冷启动"))
-        XCTAssertFalse(chineseDetail.contains("macOS"))
     }
 
     func testSidebarAccountCardStateCopyExistsForAllSupportedLanguages() throws {

--- a/Tests/TypefluxTests/LocalizationResourceTests.swift
+++ b/Tests/TypefluxTests/LocalizationResourceTests.swift
@@ -56,13 +56,14 @@ final class LocalizationResourceTests: XCTestCase {
             table: nil
         )
         XCTAssertEqual(chineseTitle, "按键即说")
-        XCTAssertLessThanOrEqual(chineseDetail.count, 70)
-        XCTAssertTrue(chineseDetail.contains("启动更快"))
-        XCTAssertTrue(chineseDetail.contains("避免漏掉开头"))
+        XCTAssertLessThanOrEqual(chineseDetail.count, 45)
+        XCTAssertTrue(chineseDetail.contains("按下快捷键"))
+        XCTAssertTrue(chineseDetail.contains("不易漏掉开头"))
         XCTAssertTrue(chineseDetail.contains("15 分钟"))
-        XCTAssertTrue(chineseDetail.contains("麦克风正在使用"))
+        XCTAssertTrue(chineseDetail.contains("麦克风会保持启用"))
         XCTAssertFalse(chineseDetail.contains("内存"))
         XCTAssertFalse(chineseDetail.contains("冷启动"))
+        XCTAssertFalse(chineseDetail.contains("macOS"))
     }
 
     func testSidebarAccountCardStateCopyExistsForAllSupportedLanguages() throws {


### PR DESCRIPTION
## Summary

- simplify the Instant Voice Input description around the user benefit and visible microphone trade-off
- remove implementation details such as cold start, timer resets, and the in-memory pre-roll buffer
- keep the copy contract aligned across all five supported locales

## Tests

- `swift test --filter LocalizationResourceTests` (15 tests passed)
- `swift test` (2492/2500 passed; 8 unrelated persona localization tests fail on the current base)

Issue: GUL-66
