### PR TITLE
GUL-74: keep LLM progress visibly moving

### DIFF
--- a/Sources/Typeflux/Overlay/ProcessingProgressTimeline.swift
+++ b/Sources/Typeflux/Overlay/ProcessingProgressTimeline.swift
@@ -6,6 +6,7 @@ struct ProcessingProgressTimeline {
     static let maximumIncompleteProgress: CGFloat = 0.95
 
     private static let recognitionResponseTime: TimeInterval = 0.45
+    private static let contentResponseTime: TimeInterval = 3
     private let timeout: TimeInterval
 
     init(timeout: TimeInterval) {
@@ -31,11 +32,12 @@ struct ProcessingProgressTimeline {
         }
 
         let remainingDuration = timeout - normalizedContentProcessingStart
-        let normalizedElapsed = min(
-            (elapsed - normalizedContentProcessingStart) / remainingDuration,
-            1
-        )
-        let easedProgress = log1p(9 * normalizedElapsed) / log(10)
+        let contentElapsed = elapsed - normalizedContentProcessingStart
+        // Drive the visible response on a human-scale curve instead of spreading
+        // it across the much longer hard timeout, then normalize at the deadline.
+        let responseAtTimeout = 1 - exp(-remainingDuration / Self.contentResponseTime)
+        let responseAtElapsed = 1 - exp(-contentElapsed / Self.contentResponseTime)
+        let easedProgress = min(responseAtElapsed / responseAtTimeout, 1)
         let remainingProgress = Self.maximumIncompleteProgress - Self.recognitionCompleteProgress
         return Self.recognitionCompleteProgress + CGFloat(easedProgress) * remainingProgress
     }

--- a/Tests/TypefluxTests/OverlayControllerTests.swift
+++ b/Tests/TypefluxTests/OverlayControllerTests.swift
@@ -120,6 +120,24 @@ final class OverlayControllerTests: XCTestCase {
     }
 
     @MainActor
+    func testLLMProgressMovesByVisibleAmountWithinFirstSecond() async throws {
+        let controller = OverlayController(appState: AppStateStore())
+
+        controller.showProcessing(timeout: 120)
+        controller.transitionToLLMPhase()
+        for _ in 0 ..< 20 {
+            if controller.processingProgressForTesting >= 0.738 { break }
+            try await Task.sleep(for: .milliseconds(50))
+        }
+
+        XCTAssertGreaterThanOrEqual(controller.processingProgressForTesting, 0.738)
+        XCTAssertLessThan(
+            controller.processingProgressForTesting,
+            ProcessingProgressTimeline.maximumIncompleteProgress
+        )
+    }
+
+    @MainActor
     func testSuccessfulProcessingStopsTimelineAndCompletesProgress() {
         let controller = OverlayController(appState: AppStateStore())
 

--- a/Tests/TypefluxTests/ProcessingProgressCapsuleRenderingTests.swift
+++ b/Tests/TypefluxTests/ProcessingProgressCapsuleRenderingTests.swift
@@ -45,6 +45,52 @@ final class ProcessingProgressCapsuleRenderingTests: XCTestCase {
         }
     }
 
+    @MainActor
+    func testThinkingCapsuleVisiblyMovesDuringFirstFiveSecondsOfLLMProcessing() throws {
+        let progress = typicalLLMProgressCheckpoints()
+
+        for style in OverlayStyle.allCases {
+            let images = try progress.map { value in
+                try render(
+                    ThinkingProgressCapsule(title: "Thinking", progress: value)
+                        .environment(\.overlayStyle, style)
+                        .frame(width: 132, height: 35),
+                    size: CGSize(width: 132, height: 35)
+                )
+            }
+
+            assertStageImagesDiffer(images, context: "\(style.rawValue) first five seconds")
+        }
+    }
+
+    @MainActor
+    func testTranscriptCapsuleVisiblyMovesDuringFirstFiveSecondsOfLLMProcessing() throws {
+        let progress = typicalLLMProgressCheckpoints()
+
+        for style in OverlayStyle.allCases {
+            let images = try progress.map { value in
+                try render(
+                    ProcessingTranscriptCapsule(
+                        text: "A stable transcript preview",
+                        title: "Thinking",
+                        progress: value
+                    )
+                    .environment(\.overlayStyle, style),
+                    size: CGSize(width: 360, height: 127)
+                )
+            }
+
+            assertStageImagesDiffer(images, context: "\(style.rawValue) first five seconds")
+        }
+    }
+
+    private func typicalLLMProgressCheckpoints() -> [CGFloat] {
+        let timeline = ProcessingProgressTimeline(timeout: 120)
+        return [30.0, 31.0, 33.0, 35.0].map {
+            timeline.progress(elapsed: $0, contentProcessingStartedAt: 30)
+        }
+    }
+
     private func assertIncreasingBrightness(
         _ images: [NSBitmapImageRep],
         stages: [CGFloat],

--- a/Tests/TypefluxTests/ProcessingProgressTimelineTests.swift
+++ b/Tests/TypefluxTests/ProcessingProgressTimelineTests.swift
@@ -41,6 +41,30 @@ final class ProcessingProgressTimelineTests: XCTestCase {
         )
     }
 
+    func testContentProgressMovesVisiblyDuringTypicalResponseTime() {
+        let timeline = ProcessingProgressTimeline(timeout: 120)
+        let progressAfterOneSecond = timeline.progress(
+            elapsed: 31,
+            contentProcessingStartedAt: 30
+        )
+        let progressAfterThreeSeconds = timeline.progress(
+            elapsed: 33,
+            contentProcessingStartedAt: 30
+        )
+        let progressAfterFiveSeconds = timeline.progress(
+            elapsed: 35,
+            contentProcessingStartedAt: 30
+        )
+
+        XCTAssertGreaterThanOrEqual(progressAfterOneSecond, 0.77)
+        XCTAssertGreaterThanOrEqual(progressAfterThreeSeconds, 0.85)
+        XCTAssertGreaterThanOrEqual(progressAfterFiveSeconds, 0.9)
+        XCTAssertLessThan(
+            progressAfterFiveSeconds,
+            ProcessingProgressTimeline.maximumIncompleteProgress
+        )
+    }
+
     func testContentProgressContinuouslyAdvancesAcrossRemainingTimeout() {
         let timeline = ProcessingProgressTimeline(timeout: 120)
         let checkpoints = stride(from: 30.0, through: 120.0, by: 1.0)


### PR DESCRIPTION
## Summary

- decouple perceptible LLM progress from the 120-second hard processing timeout
- move from 70% to roughly 77% / 85% / 90% after 1 / 3 / 5 seconds, then ease toward 95%
- add controller and real SwiftUI bitmap-rendering regressions for visible first-five-second movement

## Root cause

The previous curve spread the whole 70%–95% range across the remaining hard timeout. With the 120-second minimum, a typical several-second LLM request moved only a few pixels before completion.

## Verification

- relevant Overlay, timeline, UI rendering, and Workflow tests: 113 passed
- focused coverage run: 23 passed; `ProcessingProgressTimeline.swift` line coverage 100%
- `git diff --check`

Closes GUL-74
