### PR TITLE
GUL-75: improve text insertion delivery verification

### DIFF
--- a/Sources/Typeflux/Resources/en.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/en.lproj/Localizable.strings
@@ -378,6 +378,7 @@
 
 "workflow.apply.inserted" = "Applied to the active app.";
 "workflow.apply.presentedInDialog" = "Direct insertion was unavailable, so the result was shown in a dialog.";
+"workflow.apply.copiedToClipboard" = "Direct insertion was unavailable, so the result was copied to the clipboard.";
 "workflow.cancel.stopping" = "Cancelled while stopping.";
 "workflow.cancel.retry" = "Cancelled due to retry.";
 "workflow.cancel.newRecording" = "Cancelled by a new recording.";
@@ -396,6 +397,7 @@
 "workflow.transcription.noSpeech" = "No clear speech detected. Transcription cancelled.";
 "workflow.transcription.serverUnavailableNotice" = "Unable to connect to the server. Your recording was saved in History for retry.";
 "workflow.result.copyTitle" = "Copy Result";
+"workflow.result.insertionFailedCopied" = "Text couldn't be inserted. It has been copied; press ⌘V to paste.";
 "workflow.ask.answerTitle" = "Ask Anything";
 "workflow.ask.questionSectionTitle" = "Your Question";
 "workflow.ask.answerSectionTitle" = "Answer";

--- a/Sources/Typeflux/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/ja.lproj/Localizable.strings
@@ -374,6 +374,7 @@
 
 "workflow.apply.inserted" = "アクティブなアプリに適用されます。";
 "workflow.apply.presentedInDialog" = "直接挿入は利用できないため、結果はダイアログに表示されました。";
+"workflow.apply.copiedToClipboard" = "直接挿入できなかったため、結果をクリップボードにコピーしました。";
 "workflow.cancel.stopping" = "停止中にキャンセルされました。";
 "workflow.cancel.retry" = "再試行のためキャンセルされました。";
 "workflow.cancel.newRecording" = "新規録音によりキャンセルされました。";
@@ -392,6 +393,7 @@
 "workflow.transcription.noSpeech" = "明瞭な音声が検出されませんでした。転写はキャンセルされました。";
 "workflow.transcription.serverUnavailableNotice" = "サーバーに接続できません。録音は履歴に保存され、後で再試行できます。";
 "workflow.result.copyTitle" = "コピー結果";
+"workflow.result.insertionFailedCopied" = "テキストを挿入できなかったためコピーしました。⌘V で貼り付けできます。";
 "workflow.ask.answerTitle" = "何でも聞いてください";
 "workflow.ask.questionSectionTitle" = "あなたの質問";
 "workflow.ask.answerSectionTitle" = "答え";

--- a/Sources/Typeflux/Resources/ko.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/ko.lproj/Localizable.strings
@@ -374,6 +374,7 @@
 
 "workflow.apply.inserted" = "활성 앱에 적용됩니다.";
 "workflow.apply.presentedInDialog" = "직접 삽입이 불가능하여 결과가 대화상자에 표시되었습니다.";
+"workflow.apply.copiedToClipboard" = "직접 삽입하지 못해 결과를 클립보드에 복사했습니다.";
 "workflow.cancel.stopping" = "정차 중 취소되었습니다.";
 "workflow.cancel.retry" = "재시도 때문에 취소되었습니다.";
 "workflow.cancel.newRecording" = "새 녹음으로 인해 취소되었습니다.";
@@ -392,6 +393,7 @@
 "workflow.transcription.noSpeech" = "명확한 음성이 감지되지 않았습니다. 스크립트 작성이 취소되었습니다.";
 "workflow.transcription.serverUnavailableNotice" = "서버에 연결할 수 없습니다. 녹음은 기록에 저장되어 나중에 다시 시도할 수 있습니다.";
 "workflow.result.copyTitle" = "결과 복사";
+"workflow.result.insertionFailedCopied" = "텍스트를 삽입하지 못해 복사했습니다. ⌘V로 붙여넣으세요.";
 "workflow.ask.answerTitle" = "무엇이든 물어보세요";
 "workflow.ask.questionSectionTitle" = "질문";
 "workflow.ask.answerSectionTitle" = "답변";

--- a/Sources/Typeflux/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/zh-Hans.lproj/Localizable.strings
@@ -378,6 +378,7 @@
 
 "workflow.apply.inserted" = "已应用到当前活动应用。";
 "workflow.apply.presentedInDialog" = "由于无法直接插入，结果已显示在提示框中。";
+"workflow.apply.copiedToClipboard" = "由于无法直接插入，结果已复制到剪贴板。";
 "workflow.cancel.stopping" = "停止应用时已取消。";
 "workflow.cancel.retry" = "由于重试已取消。";
 "workflow.cancel.newRecording" = "已被新的录音任务取消。";
@@ -396,6 +397,7 @@
 "workflow.transcription.noSpeech" = "未检测到清晰语音，本次转写已取消。";
 "workflow.transcription.serverUnavailableNotice" = "暂时无法连接服务器，录音已保存在历史记录中，可稍后重试。";
 "workflow.result.copyTitle" = "复制结果";
+"workflow.result.insertionFailedCopied" = "未能插入文本，内容已复制，可按 ⌘V 粘贴。";
 "workflow.ask.answerTitle" = "随便问";
 "workflow.ask.questionSectionTitle" = "你的问题";
 "workflow.ask.answerSectionTitle" = "回答";

--- a/Sources/Typeflux/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/zh-Hant.lproj/Localizable.strings
@@ -376,6 +376,7 @@
 
 "workflow.apply.inserted" = "已套用到目前活動應用。";
 "workflow.apply.presentedInDialog" = "因無法直接插入，結果已顯示在提示框中。";
+"workflow.apply.copiedToClipboard" = "因無法直接插入，結果已複製到剪貼簿。";
 "workflow.cancel.stopping" = "停止應用時已取消。";
 "workflow.cancel.retry" = "因重試已取消。";
 "workflow.cancel.newRecording" = "已被新的錄音任務取消。";
@@ -394,6 +395,7 @@
 "workflow.transcription.noSpeech" = "未偵測到清晰語音，本次轉寫已取消。";
 "workflow.transcription.serverUnavailableNotice" = "暫時無法連線至伺服器，錄音已儲存在歷史記錄中，可稍後重試。";
 "workflow.result.copyTitle" = "複製結果";
+"workflow.result.insertionFailedCopied" = "未能插入文字，內容已複製，可按 ⌘V 貼上。";
 "workflow.ask.answerTitle" = "隨便問";
 "workflow.ask.questionSectionTitle" = "你的問題";
 "workflow.ask.answerSectionTitle" = "回答";

--- a/Sources/Typeflux/TextInjection/AXTextInjector+Paste.swift
+++ b/Sources/Typeflux/TextInjection/AXTextInjector+Paste.swift
@@ -53,8 +53,9 @@ extension AXTextInjector {
         }
 
         var contextRestored = false
-        let beforeSnapshot = readCurrentInputTextSnapshot()
         let currentFocusedElement = focusedElement()
+        let beforeSnapshot = readCurrentInputTextSnapshot()
+        let focusedElementWasStableDuringSnapshot = focusedElementMatches(currentFocusedElement)
         let currentTargetCapability = currentFocusedElement
             .map(targetCapability(element:)) ?? .opaque
         NetworkDebugLogger.logMessage(
@@ -66,6 +67,7 @@ extension AXTextInjector {
             beforeSnapshot: \(snapshotSummary(beforeSnapshot))
             activeSelectionContext: \(selectionContextSummary(activeSelectionContext()))
             currentTargetCapability: \(String(describing: currentTargetCapability))
+            focusedElementWasStableDuringSnapshot: \(focusedElementWasStableDuringSnapshot)
             """
         )
 
@@ -79,6 +81,7 @@ extension AXTextInjector {
             }
 
             if let currentFocusedElement,
+               focusedElementWasStableDuringSnapshot,
                currentTargetCapability == .writable,
                try insertTextViaAX(
                    text,
@@ -167,22 +170,24 @@ extension AXTextInjector {
             text as CFTypeRef
         )
         if replaceSelectedText == .success {
+            let targetProcessID = processID(of: element) ?? beforeSnapshot.processID
             let verification = verifyAXWriteApplied(
                 insertedText: text,
                 replaceSelection: replaceSelection,
-                targetProcessID: frontmostProcessID(),
+                targetProcessID: targetProcessID,
                 beforeSnapshot: beforeSnapshot
             )
-            switch verification {
-            case .success:
+            if Self.successfulAXWriteIsCommitted(verification: verification) {
+                if verification == .indeterminate {
+                    NetworkDebugLogger.logMessage(
+                        "[Text Injection] AX write accepted; read-back unavailable, treating AX acknowledgement as committed"
+                    )
+                } else if case let .failure(reason) = verification {
+                    NetworkDebugLogger.logMessage(
+                        "[Text Injection] AX write accepted before read-back lost target: \(reason)"
+                    )
+                }
                 return true
-            case .indeterminate:
-                NetworkDebugLogger.logMessage(
-                    "[Text Injection] AX write accepted; read-back unavailable, treating AX acknowledgement as committed"
-                )
-                return true
-            case .failure:
-                break
             }
             let afterSnapshot = readCurrentInputTextSnapshot()
             logger.debug(
@@ -207,7 +212,7 @@ extension AXTextInjector {
         targetProcessID: pid_t?,
         beforeSnapshot: CurrentInputTextSnapshot
     ) -> PasteVerificationResult {
-        var lastFailure: PasteVerificationResult?
+        var lastReadback: PasteVerificationResult = .indeterminate
         for attempt in 0 ..< Self.axWriteVerificationAttempts {
             usleep(Self.axWriteVerificationPollIntervalMicroseconds)
             let afterSnapshot = readCurrentInputTextSnapshot()
@@ -230,14 +235,12 @@ extension AXTextInjector {
             switch verification {
             case .success:
                 return .success
-            case .failure:
-                lastFailure = verification
-            case .indeterminate:
-                continue
+            case .failure, .indeterminate:
+                lastReadback = verification
             }
         }
 
-        return lastFailure ?? .indeterminate
+        return lastReadback
     }
 
     func setTextViaPaste(
@@ -274,7 +277,15 @@ extension AXTextInjector {
             targetProcessID: targetPID
         )
 
+        let targetElement = focusedElement()
         let initialSnapshot = readCurrentInputTextSnapshot()
+        guard focusedElementMatches(targetElement) else {
+            throw NSError(
+                domain: "AXTextInjector",
+                code: 14,
+                userInfo: [NSLocalizedDescriptionKey: "Focused target changed before paste dispatch"]
+            )
+        }
         let beforeSnapshot = initialSnapshot.isEditable ? initialSnapshot : nil
         let allowClipboardSelectionFallback =
             Self.shouldAllowClipboardSelectionReplacementWithoutAXBaseline(
@@ -374,7 +385,8 @@ extension AXTextInjector {
             targetPID: targetPID,
             beforeSnapshot: beforeSnapshot,
             previousSnapshot: previousSnapshot,
-            deliveryProbe: deliveryProbe
+            deliveryProbe: deliveryProbe,
+            targetElement: targetElement
         )
     }
 
@@ -384,11 +396,23 @@ extension AXTextInjector {
         targetPID: pid_t?,
         beforeSnapshot: CurrentInputTextSnapshot?,
         previousSnapshot: PasteboardSnapshot,
-        deliveryProbe: PasteboardDeliveryProbe
+        deliveryProbe: PasteboardDeliveryProbe,
+        targetElement: AXUIElement?
     ) throws {
-        var lastFailureReason: String?
+        var lastReadback: PasteVerificationResult = .indeterminate
+        var targetStableThroughout = true
         for attempt in 0 ..< Self.pasteVerificationAttempts {
-            waitForPasteEvidence(microseconds: Self.pasteVerificationPollIntervalMicroseconds)
+            let payloadWasAlreadyObserved = deliveryProbe.wasRequestedAfterDispatch
+            let remainedStable = waitForPasteEvidence(
+                microseconds: Self.pasteVerificationPollIntervalMicroseconds,
+                targetProcessID: targetPID,
+                targetElement: targetElement,
+                deliveryProbe: deliveryProbe,
+                stopWhenPayloadRequested: !payloadWasAlreadyObserved
+            )
+            if !remainedStable {
+                targetStableThroughout = false
+            }
             let afterSnapshot = readCurrentInputTextSnapshot()
             let verification = Self.evaluatePasteVerification(
                 insertedText: text,
@@ -397,6 +421,7 @@ extension AXTextInjector {
                 before: beforeSnapshot,
                 after: afterSnapshot
             )
+            lastReadback = verification
             NetworkDebugLogger.logMessage(
                 """
                 [Text Injection] paste verification attempt \(attempt + 1)
@@ -408,27 +433,59 @@ extension AXTextInjector {
 
             switch verification {
             case .success:
-                restorePasteboardAfterPaste(
-                    previousSnapshot,
-                    delayNanoseconds: Self.verifiedPasteRestoreDelayNanoseconds
-                )
-                return
+                if targetStableThroughout {
+                    restorePasteboardAfterPaste(
+                        previousSnapshot,
+                        delayNanoseconds: Self.verifiedPasteRestoreDelayNanoseconds
+                    )
+                    return
+                }
             case let .failure(reason):
-                lastFailureReason = reason
                 logger.debug(
                     "paste verification failed on attempt \(attempt + 1, privacy: .public): \(reason, privacy: .public)"
                 )
             case .indeterminate:
+                if targetStableThroughout, deliveryProbe.wasRequestedAfterDispatch {
+                    restorePasteboardAfterPaste(
+                        previousSnapshot,
+                        delayNanoseconds: Self.verifiedPasteRestoreDelayNanoseconds
+                    )
+                    return
+                }
                 logger.debug("paste verification indeterminate on attempt \(attempt + 1, privacy: .public)")
             }
         }
 
-        if let lastFailureReason {
+        let currentPID = frontmostProcessID()
+        if let targetPID, currentPID != targetPID {
+            targetStableThroughout = false
+        }
+        if !focusedElementMatches(targetElement) {
+            targetStableThroughout = false
+        }
+        let finalVerification = Self.finalPasteVerification(
+            lastReadback: lastReadback,
+            payloadRequestedAfterDispatch: deliveryProbe.wasRequestedAfterDispatch,
+            payloadRequestedBeforeDispatch: deliveryProbe.wasRequestedBeforeDispatch,
+            targetStableThroughout: targetStableThroughout
+        )
+
+        switch finalVerification {
+        case .success:
+            NetworkDebugLogger.logMessage(
+                "[Text Injection] paste committed via verified readback or post-dispatch payload request"
+            )
+            restorePasteboardAfterPaste(
+                previousSnapshot,
+                delayNanoseconds: Self.verifiedPasteRestoreDelayNanoseconds
+            )
+            return
+        case let .failure(reason):
             let finalSnapshot = readCurrentInputTextSnapshot()
             NetworkDebugLogger.logMessage(
                 """
                 [Text Injection] paste verification exhausted
-                lastFailureReason: \(lastFailureReason)
+                failureReason: \(reason)
                 finalSnapshot: \(snapshotSummary(finalSnapshot))
                 """
             )
@@ -437,43 +494,44 @@ extension AXTextInjector {
                 code: 2,
                 userInfo: [
                     NSLocalizedDescriptionKey:
-                        "Paste insertion could not be verified: \(lastFailureReason)"
+                        "Paste insertion could not be verified: \(reason)"
                 ]
             )
+        case .indeterminate:
+            preconditionFailure("finalPasteVerification must return a terminal result")
         }
-
-        let currentPID = frontmostProcessID()
-        if deliveryProbe.wasRequestedAfterDispatch,
-           targetPID == nil || currentPID == targetPID {
-            NetworkDebugLogger.logMessage(
-                "[Text Injection] paste committed via post-dispatch pasteboard payload request"
-            )
-            restorePasteboardAfterPaste(
-                previousSnapshot,
-                delayNanoseconds: Self.verifiedPasteRestoreDelayNanoseconds
-            )
-            return
-        }
-
-        let reason = deliveryProbe.wasRequestedBeforeDispatch
-            ? "pasteboard-request-contaminated-before-dispatch"
-            : "pasteboard-payload-not-requested"
-        throw NSError(
-            domain: "AXTextInjector",
-            code: 2,
-            userInfo: [NSLocalizedDescriptionKey: "Paste insertion could not be verified: \(reason)"]
-        )
     }
 
-    private func waitForPasteEvidence(microseconds: useconds_t) {
-        let deadline = Date().addingTimeInterval(Double(microseconds) / 1_000_000)
-        if Thread.isMainThread {
-            while Date() < deadline {
-                _ = RunLoop.current.run(mode: .default, before: deadline)
+    private func waitForPasteEvidence(
+        microseconds: useconds_t,
+        targetProcessID: pid_t?,
+        targetElement: AXUIElement?,
+        deliveryProbe: PasteboardDeliveryProbe,
+        stopWhenPayloadRequested: Bool
+    ) -> Bool {
+        func targetIsStable() -> Bool {
+            if let targetProcessID, frontmostProcessID() != targetProcessID {
+                return false
             }
-        } else {
-            usleep(microseconds)
+            return focusedElementMatches(targetElement)
         }
+
+        let deadline = Date().addingTimeInterval(Double(microseconds) / 1_000_000)
+        let pollInterval: TimeInterval = 0.01
+        while Date() < deadline {
+            guard targetIsStable() else { return false }
+            if stopWhenPayloadRequested, deliveryProbe.wasRequestedAfterDispatch {
+                return true
+            }
+
+            if Thread.isMainThread {
+                let nextPoll = min(deadline, Date().addingTimeInterval(pollInterval))
+                _ = RunLoop.current.run(mode: .default, before: nextPoll)
+            } else {
+                usleep(useconds_t(pollInterval * 1_000_000))
+            }
+        }
+        return targetIsStable()
     }
 
     static func evaluatePasteVerification(
@@ -514,9 +572,17 @@ extension AXTextInjector {
             }
 
             if let beforeText = before?.text {
-                let normalizedBeforeText = beforeText.trimmingCharacters(in: .whitespacesAndNewlines)
-                if normalizedBeforeText == normalizedAfterText {
+                if beforeText == afterText {
                     if !after.isFocusedTarget || before?.isFocusedTarget == false {
+                        return .indeterminate
+                    }
+                    if !replaceSelection,
+                       before?.textSource == "ax-value",
+                       after.textSource == "ax-value",
+                       (
+                           normalizedAfterText.isEmpty
+                               || browserAutomationKind(for: before?.bundleIdentifier) != nil
+                       ) {
                         return .indeterminate
                     }
                     return .failure("input-text-unchanged")

--- a/Sources/Typeflux/TextInjection/AXTextInjector+Paste.swift
+++ b/Sources/Typeflux/TextInjection/AXTextInjector+Paste.swift
@@ -54,6 +54,9 @@ extension AXTextInjector {
 
         var contextRestored = false
         let beforeSnapshot = readCurrentInputTextSnapshot()
+        let currentFocusedElement = focusedElement()
+        let currentTargetCapability = currentFocusedElement
+            .map(targetCapability(element:)) ?? .opaque
         NetworkDebugLogger.logMessage(
             """
             [Text Injection] start
@@ -62,8 +65,33 @@ extension AXTextInjector {
             textPreview: \(String(text.trimmingCharacters(in: .whitespacesAndNewlines).prefix(120)))
             beforeSnapshot: \(snapshotSummary(beforeSnapshot))
             activeSelectionContext: \(selectionContextSummary(activeSelectionContext()))
+            currentTargetCapability: \(String(describing: currentTargetCapability))
             """
         )
+
+        if !replaceSelection {
+            if currentTargetCapability == .notWritable {
+                throw NSError(
+                    domain: "AXTextInjector",
+                    code: 13,
+                    userInfo: [NSLocalizedDescriptionKey: "Focused target is not writable"]
+                )
+            }
+
+            if let currentFocusedElement,
+               currentTargetCapability == .writable,
+               try insertTextViaAX(
+                   text,
+                   into: currentFocusedElement,
+                   replaceSelection: false,
+                   selectionRange: beforeSnapshot.selectedRange,
+                   beforeSnapshot: beforeSnapshot
+               ) {
+                NetworkDebugLogger.logMessage("[Text Injection] insert completed via focused AX path")
+                lastInjectionMethod = .ax
+                return
+            }
+        }
 
         if replaceSelection, let context = activeSelectionContext() {
             NetworkDebugLogger.logMessage(
@@ -91,7 +119,7 @@ extension AXTextInjector {
             )
         }
 
-        if let element = focusedElement(),
+        if replaceSelection, let element = currentFocusedElement,
            try insertTextViaAX(
                text,
                into: element,
@@ -127,37 +155,47 @@ extension AXTextInjector {
         selectionRange: CFRange?,
         beforeSnapshot: CurrentInputTextSnapshot
     ) throws -> Bool {
-        if replaceSelection {
-            if let selectionRange {
-                _ = setSelectedTextRange(selectionRange, on: element)
-            }
-            let replaceSelectedText = AXUIElementSetAttributeValue(
-                element,
-                kAXSelectedTextAttribute as CFString,
-                text as CFTypeRef
+        guard isAttributeSettable(kAXSelectedTextAttribute as CFString, on: element) else {
+            return false
+        }
+        if let selectionRange {
+            _ = setSelectedTextRange(selectionRange, on: element)
+        }
+        let replaceSelectedText = AXUIElementSetAttributeValue(
+            element,
+            kAXSelectedTextAttribute as CFString,
+            text as CFTypeRef
+        )
+        if replaceSelectedText == .success {
+            let verification = verifyAXWriteApplied(
+                insertedText: text,
+                replaceSelection: replaceSelection,
+                targetProcessID: frontmostProcessID(),
+                beforeSnapshot: beforeSnapshot
             )
-            if replaceSelectedText == .success {
-                if verifyAXWriteApplied(
-                    insertedText: text,
-                    replaceSelection: true,
-                    targetProcessID: frontmostProcessID(),
-                    beforeSnapshot: beforeSnapshot
-                ) {
-                    return true
-                }
-                let afterSnapshot = readCurrentInputTextSnapshot()
-                logger.debug(
-                    "AX selected text write reported success but could not be verified; falling back"
-                )
+            switch verification {
+            case .success:
+                return true
+            case .indeterminate:
                 NetworkDebugLogger.logMessage(
-                    """
-                    [Text Injection] AX write verification failed
-                    replaceSelection: \(replaceSelection)
-                    beforeSnapshot: \(snapshotSummary(beforeSnapshot))
-                    afterSnapshot: \(snapshotSummary(afterSnapshot))
-                    """
+                    "[Text Injection] AX write accepted; read-back unavailable, treating AX acknowledgement as committed"
                 )
+                return true
+            case .failure:
+                break
             }
+            let afterSnapshot = readCurrentInputTextSnapshot()
+            logger.debug(
+                "AX selected text write reported success but verification failed; falling back"
+            )
+            NetworkDebugLogger.logMessage(
+                """
+                [Text Injection] AX write verification failed
+                replaceSelection: \(replaceSelection)
+                beforeSnapshot: \(snapshotSummary(beforeSnapshot))
+                afterSnapshot: \(snapshotSummary(afterSnapshot))
+                """
+            )
         }
 
         return false
@@ -168,7 +206,8 @@ extension AXTextInjector {
         replaceSelection: Bool,
         targetProcessID: pid_t?,
         beforeSnapshot: CurrentInputTextSnapshot
-    ) -> Bool {
+    ) -> PasteVerificationResult {
+        var lastFailure: PasteVerificationResult?
         for attempt in 0 ..< Self.axWriteVerificationAttempts {
             usleep(Self.axWriteVerificationPollIntervalMicroseconds)
             let afterSnapshot = readCurrentInputTextSnapshot()
@@ -190,15 +229,15 @@ extension AXTextInjector {
 
             switch verification {
             case .success:
-                return true
+                return .success
             case .failure:
-                return false
+                lastFailure = verification
             case .indeterminate:
                 continue
             }
         }
 
-        return false
+        return lastFailure ?? .indeterminate
     }
 
     func setTextViaPaste(
@@ -276,8 +315,12 @@ extension AXTextInjector {
             )
         }
 
+        let deliveryProbe = PasteboardDeliveryProbe(text: text)
+        let pasteboardItem = NSPasteboardItem()
+        pasteboardItem.setDataProvider(deliveryProbe, forTypes: [.string])
         pasteboard.clearContents()
-        pasteboard.setString(text, forType: .string)
+        pasteboard.writeObjects([pasteboardItem])
+        activePasteboardDeliveryProbe = deliveryProbe
 
         let source = CGEventSource(stateID: .combinedSessionState)
         let vDown = CGEvent(keyboardEventSource: source, virtualKey: 0x09, keyDown: true)
@@ -285,6 +328,7 @@ extension AXTextInjector {
         let vUp = CGEvent(keyboardEventSource: source, virtualKey: 0x09, keyDown: false)
         vUp?.flags = .maskCommand
 
+        deliveryProbe.markDispatched()
         switch dispatchMethod {
         case .postToPid:
             if let targetPID {
@@ -329,7 +373,8 @@ extension AXTextInjector {
             replaceSelection: replaceSelection,
             targetPID: targetPID,
             beforeSnapshot: beforeSnapshot,
-            previousSnapshot: previousSnapshot
+            previousSnapshot: previousSnapshot,
+            deliveryProbe: deliveryProbe
         )
     }
 
@@ -338,11 +383,12 @@ extension AXTextInjector {
         replaceSelection: Bool,
         targetPID: pid_t?,
         beforeSnapshot: CurrentInputTextSnapshot?,
-        previousSnapshot: PasteboardSnapshot
+        previousSnapshot: PasteboardSnapshot,
+        deliveryProbe: PasteboardDeliveryProbe
     ) throws {
         var lastFailureReason: String?
         for attempt in 0 ..< Self.pasteVerificationAttempts {
-            usleep(Self.pasteVerificationPollIntervalMicroseconds)
+            waitForPasteEvidence(microseconds: Self.pasteVerificationPollIntervalMicroseconds)
             let afterSnapshot = readCurrentInputTextSnapshot()
             let verification = Self.evaluatePasteVerification(
                 insertedText: text,
@@ -377,11 +423,6 @@ extension AXTextInjector {
             }
         }
 
-        restorePasteboardAfterPaste(
-            previousSnapshot,
-            delayNanoseconds: Self.unverifiedPasteRestoreDelayNanoseconds
-        )
-
         if let lastFailureReason {
             let finalSnapshot = readCurrentInputTextSnapshot()
             NetworkDebugLogger.logMessage(
@@ -399,6 +440,39 @@ extension AXTextInjector {
                         "Paste insertion could not be verified: \(lastFailureReason)"
                 ]
             )
+        }
+
+        let currentPID = frontmostProcessID()
+        if deliveryProbe.wasRequestedAfterDispatch,
+           targetPID == nil || currentPID == targetPID {
+            NetworkDebugLogger.logMessage(
+                "[Text Injection] paste committed via post-dispatch pasteboard payload request"
+            )
+            restorePasteboardAfterPaste(
+                previousSnapshot,
+                delayNanoseconds: Self.verifiedPasteRestoreDelayNanoseconds
+            )
+            return
+        }
+
+        let reason = deliveryProbe.wasRequestedBeforeDispatch
+            ? "pasteboard-request-contaminated-before-dispatch"
+            : "pasteboard-payload-not-requested"
+        throw NSError(
+            domain: "AXTextInjector",
+            code: 2,
+            userInfo: [NSLocalizedDescriptionKey: "Paste insertion could not be verified: \(reason)"]
+        )
+    }
+
+    private func waitForPasteEvidence(microseconds: useconds_t) {
+        let deadline = Date().addingTimeInterval(Double(microseconds) / 1_000_000)
+        if Thread.isMainThread {
+            while Date() < deadline {
+                _ = RunLoop.current.run(mode: .default, before: deadline)
+            }
+        } else {
+            usleep(microseconds)
         }
     }
 
@@ -422,16 +496,26 @@ extension AXTextInjector {
         if let afterText = after.text {
             let normalizedAfterText = afterText.trimmingCharacters(in: .whitespacesAndNewlines)
 
-            if !normalizedInsertedText.isEmpty, normalizedAfterText.contains(normalizedInsertedText) {
+            if let beforeText = before?.text,
+               let beforeRange = before?.selectedRange,
+               let expectedText = replacingUTF16Range(
+                   in: beforeText,
+                   range: beforeRange,
+                   with: insertedText
+               ),
+               afterText == expectedText {
+                return .success
+            }
+
+            if before?.text == nil,
+               !normalizedInsertedText.isEmpty,
+               normalizedAfterText.contains(normalizedInsertedText) {
                 return .success
             }
 
             if let beforeText = before?.text {
                 let normalizedBeforeText = beforeText.trimmingCharacters(in: .whitespacesAndNewlines)
                 if normalizedBeforeText == normalizedAfterText {
-                    if !replaceSelection {
-                        return .indeterminate
-                    }
                     if !after.isFocusedTarget || before?.isFocusedTarget == false {
                         return .indeterminate
                     }
@@ -539,6 +623,7 @@ extension AXTextInjector {
     }
 
     func restorePasteboard(_ snapshot: PasteboardSnapshot, to pasteboard: NSPasteboard) {
+        activePasteboardDeliveryProbe = nil
         pasteboard.clearContents()
 
         guard !snapshot.items.isEmpty else { return }

--- a/Sources/Typeflux/TextInjection/AXTextInjector+Selection.swift
+++ b/Sources/Typeflux/TextInjection/AXTextInjector+Selection.swift
@@ -171,6 +171,18 @@ extension AXTextInjector {
         return status == .success && settable.boolValue
     }
 
+    func processID(of element: AXUIElement) -> pid_t? {
+        var processID: pid_t = 0
+        guard AXUIElementGetPid(element, &processID) == .success else { return nil }
+        return processID
+    }
+
+    func focusedElementMatches(_ expected: AXUIElement?) -> Bool {
+        guard let expected else { return true }
+        guard let current = focusedElement() else { return false }
+        return CFEqual(expected, current)
+    }
+
     func isLikelyEditable(element: AXUIElement) -> Bool {
         targetCapability(element: element) == .writable
     }

--- a/Sources/Typeflux/TextInjection/AXTextInjector+Selection.swift
+++ b/Sources/Typeflux/TextInjection/AXTextInjector+Selection.swift
@@ -172,27 +172,21 @@ extension AXTextInjector {
     }
 
     func isLikelyEditable(element: AXUIElement) -> Bool {
+        targetCapability(element: element) == .writable
+    }
+
+    func targetCapability(element: AXUIElement) -> TextTargetCapability {
         let role = copyStringAttribute(kAXRoleAttribute as String, from: element)
         let selectedRange = copySelectedTextRange(from: element)
-
-        if Self.nativeEditableRoles.contains(role ?? "") {
-            return true
-        }
-
-        if let role, Self.nonEditableFalsePositiveRoles.contains(role) {
-            return false
-        }
-
         let hasSettableTextAttributes =
             isAttributeSettable(kAXSelectedTextRangeAttribute as CFString, on: element)
                 || isAttributeSettable(kAXValueAttribute as CFString, on: element)
                 || isAttributeSettable(kAXSelectedTextAttribute as CFString, on: element)
-
-        if Self.genericEditableRoles.contains(role ?? "") {
-            return selectedRange != nil || hasSettableTextAttributes
-        }
-
-        return selectedRange != nil && hasSettableTextAttributes
+        return Self.targetCapability(
+            role: role,
+            hasSelectedRange: selectedRange != nil,
+            hasSettableTextAttributes: hasSettableTextAttributes
+        )
     }
 
     func systemFocusedElement() -> AXUIElement? {

--- a/Sources/Typeflux/TextInjection/AXTextInjector.swift
+++ b/Sources/Typeflux/TextInjection/AXTextInjector.swift
@@ -348,6 +348,49 @@ final class AXTextInjector: TextInjector {
         case indeterminate
     }
 
+    static func finalPasteVerification(
+        lastReadback: PasteVerificationResult,
+        payloadRequestedAfterDispatch: Bool,
+        payloadRequestedBeforeDispatch: Bool,
+        targetStableThroughout: Bool
+    ) -> PasteVerificationResult {
+        guard targetStableThroughout else {
+            return .failure("focused-target-changed")
+        }
+
+        switch lastReadback {
+        case .success:
+            return .success
+        case .failure:
+            return lastReadback
+        case .indeterminate:
+            break
+        }
+
+        if payloadRequestedAfterDispatch {
+            return .success
+        }
+
+        return .failure(
+            payloadRequestedBeforeDispatch
+                ? "pasteboard-request-contaminated-before-dispatch"
+                : "pasteboard-payload-not-requested"
+        )
+    }
+
+    static func successfulAXWriteIsCommitted(verification: PasteVerificationResult) -> Bool {
+        switch verification {
+        case .success, .indeterminate:
+            return true
+        case let .failure(reason):
+            // AX reported that the write itself succeeded synchronously. A later focus change
+            // only makes read-back unavailable; retrying with Cmd+V could duplicate the text in
+            // a new target. Only a stable, readable target that stayed unchanged contradicts
+            // the AX acknowledgement strongly enough to justify a paste fallback.
+            return reason != "input-text-unchanged"
+        }
+    }
+
     static func targetCapability(
         role: String?,
         hasSelectedRange: Bool,
@@ -440,11 +483,11 @@ final class AXTextInjector: TextInjector {
         strictFallbackEnabled && replaceSelection
     }
 
-    /// Plain insertions (voice dictation) cannot be reliably verified through
-    /// AX on apps like WeChat, Warp, Codex, terminals, and the Safari address
-    /// bar. We still run fail-open verification so deterministic failures can
-    /// surface the copy dialog, while indeterminate targets keep best-effort
-    /// paste behavior.
+    /// Plain insertions (voice dictation) cannot always be read back through AX
+    /// on apps like WeChat, Warp, Codex, terminals, and browser address bars.
+    /// Still attempt verification: readable unchanged targets fail explicitly;
+    /// opaque targets require post-dispatch pasteboard delivery evidence while
+    /// the focused target remains stable.
     static func shouldAttemptPasteVerification(
         replaceSelection: Bool,
         strictFallbackEnabled: Bool

--- a/Sources/Typeflux/TextInjection/AXTextInjector.swift
+++ b/Sources/Typeflux/TextInjection/AXTextInjector.swift
@@ -4,6 +4,61 @@ import ApplicationServices
 import Foundation
 import os
 
+enum TextTargetCapability: Equatable {
+    case writable
+    case notWritable
+    case opaque
+}
+
+final class PasteboardDeliveryProbe: NSObject, NSPasteboardItemDataProvider, @unchecked Sendable {
+    private let text: String
+    private let now: @Sendable () -> TimeInterval
+    private let lock = NSLock()
+    private var dispatchedAt: TimeInterval?
+    private var requestTimes: [TimeInterval] = []
+
+    init(
+        text: String,
+        now: @escaping @Sendable () -> TimeInterval = { ProcessInfo.processInfo.systemUptime }
+    ) {
+        self.text = text
+        self.now = now
+    }
+
+    func markDispatched() {
+        lock.lock()
+        dispatchedAt = now()
+        lock.unlock()
+    }
+
+    var wasRequestedAfterDispatch: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        guard let dispatchedAt else { return false }
+        return requestTimes.contains { $0 >= dispatchedAt }
+    }
+
+    var wasRequestedBeforeDispatch: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        guard let dispatchedAt else { return !requestTimes.isEmpty }
+        return requestTimes.contains { $0 < dispatchedAt }
+    }
+
+    func pasteboard(
+        _: NSPasteboard?,
+        item: NSPasteboardItem,
+        provideDataForType type: NSPasteboard.PasteboardType
+    ) {
+        lock.lock()
+        requestTimes.append(now())
+        lock.unlock()
+        item.setString(text, forType: type)
+    }
+
+    func pasteboardFinishedWithDataProvider(_: NSPasteboard) {}
+}
+
 final class AXTextInjector: TextInjector {
     static let nativeEditableRoles: Set<String> = [
         "AXTextArea",
@@ -16,6 +71,20 @@ final class AXTextInjector: TextInjector {
         "AXGroup",
         "AXWebArea",
         "AXUnknown"
+    ]
+
+    static let opaqueContainerRoles: Set<String> = [
+        "AXColumn",
+        "AXGrid",
+        "AXLayoutArea",
+        "AXList",
+        "AXOutline",
+        "AXRow",
+        "AXScrollArea",
+        "AXSplitGroup",
+        "AXTabGroup",
+        "AXTable",
+        "AXWindow"
     ]
 
     static let nonEditableFalsePositiveRoles: Set<String> = [
@@ -133,6 +202,7 @@ final class AXTextInjector: TextInjector {
 
     var latestSelectionContext: SelectionContext?
     var lastInjectionMethod: TextInjectionMethod?
+    var activePasteboardDeliveryProbe: PasteboardDeliveryProbe?
 
     func isTypefluxOwnedTarget(processID: pid_t?, bundleIdentifier: String?) -> Bool {
         if processID == getpid() {
@@ -276,6 +346,42 @@ final class AXTextInjector: TextInjector {
         case success
         case failure(String)
         case indeterminate
+    }
+
+    static func targetCapability(
+        role: String?,
+        hasSelectedRange: Bool,
+        hasSettableTextAttributes: Bool
+    ) -> TextTargetCapability {
+        if nativeEditableRoles.contains(role ?? "") {
+            return .writable
+        }
+
+        if opaqueContainerRoles.contains(role ?? "") {
+            return .opaque
+        }
+
+        if let role, nonEditableFalsePositiveRoles.contains(role) {
+            return .notWritable
+        }
+
+        if genericEditableRoles.contains(role ?? "") {
+            return hasSelectedRange || hasSettableTextAttributes ? .writable : .opaque
+        }
+
+        if hasSelectedRange && hasSettableTextAttributes {
+            return .writable
+        }
+
+        return .opaque
+    }
+
+    static func replacingUTF16Range(in source: String, range: CFRange, with replacement: String) -> String? {
+        guard range.location >= 0, range.length >= 0 else { return nil }
+        let nsRange = NSRange(location: range.location, length: range.length)
+        let source = source as NSString
+        guard NSMaxRange(nsRange) <= source.length else { return nil }
+        return source.replacingCharacters(in: nsRange, with: replacement)
     }
 
     enum PasteDispatchMethod: Equatable {

--- a/Sources/Typeflux/Workflow/WorkflowController+Analytics.swift
+++ b/Sources/Typeflux/Workflow/WorkflowController+Analytics.swift
@@ -81,6 +81,8 @@ extension WorkflowController {
                 textInjector.lastInjectionMethod?.rawValue ?? TextInjectionMethod.ax.rawValue
             case .presentedInDialog:
                 "clipboard_fallback"
+            case .copiedToClipboard:
+                "clipboard_fallback"
             }
             dictationAnalyticsContexts[recordID] = context
         }
@@ -111,12 +113,17 @@ extension WorkflowController {
         let durationMilliseconds = record.pipelineStats?.endToEndMilliseconds
             ?? record.pipelineTiming?.generatedStats().endToEndMilliseconds
             ?? 0
+        let applyOutcomeName = switch outcome {
+        case .inserted: "inserted"
+        case .presentedInDialog: "presentedInDialog"
+        case .copiedToClipboard: "copiedToClipboard"
+        }
         var properties = [
             "flow_id": context.flowID,
             "audio_seconds": String(format: "%.3f", max(0, record.recordingDurationSeconds ?? 0)),
             "output_chars": "\(record.finalText?.count ?? 0)",
             "pipeline_duration_ms": "\(max(0, durationMilliseconds))",
-            "apply_outcome": outcome == .inserted ? "inserted" : "presentedInDialog",
+            "apply_outcome": applyOutcomeName,
             "injection_method": context.injectionMethod ?? "clipboard_fallback",
             "target_app_category": context.targetAppCategory.rawValue
         ]

--- a/Sources/Typeflux/Workflow/WorkflowController+Processing.swift
+++ b/Sources/Typeflux/Workflow/WorkflowController+Processing.swift
@@ -353,9 +353,9 @@ extension WorkflowController {
             )
             return (.inserted, text)
         } catch {
-            NetworkDebugLogger.logError(context: "[Apply Text] fallback to result dialog", error: error)
-            presentResultDialog(title: fallbackTitle, text: text)
-            return (.presentedInDialog, text)
+            NetworkDebugLogger.logError(context: "[Apply Text] fallback to copied result notice", error: error)
+            presentInsertionFailureFallback(text: text)
+            return (.copiedToClipboard, text)
         }
     }
 
@@ -2425,6 +2425,23 @@ extension WorkflowController {
             guard let self else { return }
             lastDialogResultText = text
             overlayController.showResultDialog(title: title, message: text)
+        }
+
+        if Thread.isMainThread {
+            work()
+        } else {
+            DispatchQueue.main.sync(execute: work)
+        }
+    }
+
+    func presentInsertionFailureFallback(text: String) {
+        let work = { [weak self] in
+            guard let self else { return }
+            clipboard.write(text: text)
+            lastDialogResultText = text
+            overlayController.showPassiveNotice(
+                message: L("workflow.result.insertionFailedCopied")
+            )
         }
 
         if Thread.isMainThread {

--- a/Sources/Typeflux/Workflow/WorkflowController.swift
+++ b/Sources/Typeflux/Workflow/WorkflowController.swift
@@ -76,6 +76,7 @@ final class WorkflowController {
     enum ApplyOutcome {
         case inserted
         case presentedInDialog
+        case copiedToClipboard
 
         var message: String {
             switch self {
@@ -83,6 +84,8 @@ final class WorkflowController {
                 L("workflow.apply.inserted")
             case .presentedInDialog:
                 L("workflow.apply.presentedInDialog")
+            case .copiedToClipboard:
+                L("workflow.apply.copiedToClipboard")
             }
         }
     }

--- a/Tests/TypefluxTests/AXTextInjectorTests.swift
+++ b/Tests/TypefluxTests/AXTextInjectorTests.swift
@@ -3,6 +3,94 @@ import ApplicationServices
 import XCTest
 
 final class AXTextInjectorTests: XCTestCase {
+    func testTargetCapabilityDistinguishesWritableNonWritableAndOpaqueTargets() {
+        XCTAssertEqual(
+            AXTextInjector.targetCapability(
+                role: "AXTextArea",
+                hasSelectedRange: false,
+                hasSettableTextAttributes: false
+            ),
+            .writable
+        )
+        XCTAssertEqual(
+            AXTextInjector.targetCapability(
+                role: "AXButton",
+                hasSelectedRange: true,
+                hasSettableTextAttributes: true
+            ),
+            .notWritable
+        )
+        XCTAssertEqual(
+            AXTextInjector.targetCapability(
+                role: "AXGroup",
+                hasSelectedRange: false,
+                hasSettableTextAttributes: false
+            ),
+            .opaque
+        )
+        XCTAssertEqual(
+            AXTextInjector.targetCapability(
+                role: "AXGroup",
+                hasSelectedRange: true,
+                hasSettableTextAttributes: false
+            ),
+            .writable
+        )
+        XCTAssertEqual(
+            AXTextInjector.targetCapability(
+                role: "AXWindow",
+                hasSelectedRange: false,
+                hasSettableTextAttributes: false
+            ),
+            .opaque
+        )
+    }
+
+    func testReplacingUTF16RangeHandlesEmojiAndRejectsInvalidRanges() {
+        XCTAssertEqual(
+            AXTextInjector.replacingUTF16Range(
+                in: "A😀B",
+                range: CFRange(location: 1, length: 2),
+                with: "hello"
+            ),
+            "AhelloB"
+        )
+        XCTAssertNil(
+            AXTextInjector.replacingUTF16Range(
+                in: "short",
+                range: CFRange(location: 4, length: 2),
+                with: "x"
+            )
+        )
+    }
+
+    func testPasteboardDeliveryProbeSeparatesRequestsBeforeAndAfterDispatch() {
+        let clock = TestMonotonicClock(now: 1)
+        let contaminatedProbe = PasteboardDeliveryProbe(text: "hello", now: { clock.read() })
+        contaminatedProbe.pasteboard(
+            nil,
+            item: NSPasteboardItem(),
+            provideDataForType: .string
+        )
+        clock.set(2)
+        contaminatedProbe.markDispatched()
+
+        XCTAssertTrue(contaminatedProbe.wasRequestedBeforeDispatch)
+        XCTAssertFalse(contaminatedProbe.wasRequestedAfterDispatch)
+
+        let deliveredProbe = PasteboardDeliveryProbe(text: "hello", now: { clock.read() })
+        deliveredProbe.markDispatched()
+        clock.set(3)
+        deliveredProbe.pasteboard(
+            nil,
+            item: NSPasteboardItem(),
+            provideDataForType: .string
+        )
+
+        XCTAssertFalse(deliveredProbe.wasRequestedBeforeDispatch)
+        XCTAssertTrue(deliveredProbe.wasRequestedAfterDispatch)
+    }
+
     private final class InjectorBox: @unchecked Sendable {
         let value = AXTextInjector()
     }
@@ -488,6 +576,7 @@ final class AXTextInjectorTests: XCTestCase {
             processName: "Notes",
             role: "AXTextArea",
             text: "Hello",
+            selectedRange: CFRange(location: 5, length: 0),
             isEditable: true,
             isFocusedTarget: true,
             failureReason: nil
@@ -503,7 +592,7 @@ final class AXTextInjectorTests: XCTestCase {
         )
 
         let result = AXTextInjector.evaluatePasteVerification(
-            insertedText: "world",
+            insertedText: " world",
             replaceSelection: false,
             targetProcessID: 42,
             before: before,
@@ -511,6 +600,38 @@ final class AXTextInjectorTests: XCTestCase {
         )
 
         XCTAssertEqual(result, .success)
+    }
+
+    func testEvaluatePasteVerificationRequiresExactCaretTransition() {
+        let before = CurrentInputTextSnapshot(
+            processID: 42,
+            processName: "Notes",
+            role: "AXTextArea",
+            text: "world Hello",
+            selectedRange: CFRange(location: 11, length: 0),
+            isEditable: true,
+            isFocusedTarget: true,
+            failureReason: nil
+        )
+        let after = CurrentInputTextSnapshot(
+            processID: 42,
+            processName: "Notes",
+            role: "AXTextArea",
+            text: "world Hello",
+            isEditable: true,
+            isFocusedTarget: true,
+            failureReason: nil
+        )
+
+        let result = AXTextInjector.evaluatePasteVerification(
+            insertedText: "world",
+            replaceSelection: false,
+            targetProcessID: 42,
+            before: before,
+            after: after
+        )
+
+        XCTAssertEqual(result, .failure("input-text-unchanged"))
     }
 
     func testEvaluatePasteVerificationFailsWhenFocusedProcessChanges() {
@@ -544,7 +665,7 @@ final class AXTextInjectorTests: XCTestCase {
         XCTAssertEqual(result, .failure("focused-process-changed"))
     }
 
-    func testEvaluatePasteVerificationIsIndeterminateWhenReadableInputTextDoesNotChangeForInsert() {
+    func testEvaluatePasteVerificationFailsWhenReadableInputTextDoesNotChangeForInsert() {
         let before = CurrentInputTextSnapshot(
             processID: 42,
             processName: "Notes",
@@ -576,7 +697,7 @@ final class AXTextInjectorTests: XCTestCase {
             after: after
         )
 
-        XCTAssertEqual(result, .indeterminate)
+        XCTAssertEqual(result, .failure("input-text-unchanged"))
     }
 
     func testEvaluatePasteVerificationFailsWhenReadableInputTextDoesNotChangeForReplace() {
@@ -614,7 +735,7 @@ final class AXTextInjectorTests: XCTestCase {
         XCTAssertEqual(result, .failure("input-text-unchanged"))
     }
 
-    func testEvaluatePasteVerificationIsIndeterminateWhenBrowserAXValueIsUnchangedForInsert() {
+    func testEvaluatePasteVerificationFailsWhenBrowserAXValueIsUnchangedForInsert() {
         let before = CurrentInputTextSnapshot(
             processID: 42,
             processName: "Arc",
@@ -646,10 +767,10 @@ final class AXTextInjectorTests: XCTestCase {
             after: after
         )
 
-        XCTAssertEqual(result, .indeterminate)
+        XCTAssertEqual(result, .failure("input-text-unchanged"))
     }
 
-    func testEvaluatePasteVerificationIsIndeterminateWhenUnknownBrowserLikeAXValueIsEmptyForInsert() {
+    func testEvaluatePasteVerificationFailsWhenUnknownBrowserLikeAXValueIsEmptyForInsert() {
         let before = CurrentInputTextSnapshot(
             processID: 42,
             processName: "New Browser",
@@ -681,7 +802,7 @@ final class AXTextInjectorTests: XCTestCase {
             after: after
         )
 
-        XCTAssertEqual(result, .indeterminate)
+        XCTAssertEqual(result, .failure("input-text-unchanged"))
     }
 
     func testEvaluatePasteVerificationIsIndeterminateWhenTextCannotBeReadBack() {
@@ -1042,5 +1163,26 @@ final class AXTextInjectorTests: XCTestCase {
         )
 
         XCTAssertEqual(result, .indeterminate)
+    }
+}
+
+private final class TestMonotonicClock: @unchecked Sendable {
+    private let lock = NSLock()
+    private var now: TimeInterval
+
+    init(now: TimeInterval) {
+        self.now = now
+    }
+
+    func read() -> TimeInterval {
+        lock.lock()
+        defer { lock.unlock() }
+        return now
+    }
+
+    func set(_ value: TimeInterval) {
+        lock.lock()
+        now = value
+        lock.unlock()
     }
 }

--- a/Tests/TypefluxTests/AXTextInjectorTests.swift
+++ b/Tests/TypefluxTests/AXTextInjectorTests.swift
@@ -91,6 +91,73 @@ final class AXTextInjectorTests: XCTestCase {
         XCTAssertTrue(deliveredProbe.wasRequestedAfterDispatch)
     }
 
+    func testFinalPasteVerificationUsesLatestReadbackAndDeliveryEvidence() {
+        XCTAssertEqual(
+            AXTextInjector.finalPasteVerification(
+                lastReadback: .indeterminate,
+                payloadRequestedAfterDispatch: true,
+                payloadRequestedBeforeDispatch: false,
+                targetStableThroughout: true
+            ),
+            .success
+        )
+        XCTAssertEqual(
+            AXTextInjector.finalPasteVerification(
+                lastReadback: .failure("input-text-unchanged"),
+                payloadRequestedAfterDispatch: true,
+                payloadRequestedBeforeDispatch: false,
+                targetStableThroughout: true
+            ),
+            .failure("input-text-unchanged")
+        )
+        XCTAssertEqual(
+            AXTextInjector.finalPasteVerification(
+                lastReadback: .indeterminate,
+                payloadRequestedAfterDispatch: true,
+                payloadRequestedBeforeDispatch: false,
+                targetStableThroughout: false
+            ),
+            .failure("focused-target-changed")
+        )
+        XCTAssertEqual(
+            AXTextInjector.finalPasteVerification(
+                lastReadback: .indeterminate,
+                payloadRequestedAfterDispatch: false,
+                payloadRequestedBeforeDispatch: true,
+                targetStableThroughout: true
+            ),
+            .failure("pasteboard-request-contaminated-before-dispatch")
+        )
+        XCTAssertEqual(
+            AXTextInjector.finalPasteVerification(
+                lastReadback: .indeterminate,
+                payloadRequestedAfterDispatch: false,
+                payloadRequestedBeforeDispatch: false,
+                targetStableThroughout: true
+            ),
+            .failure("pasteboard-payload-not-requested")
+        )
+    }
+
+    func testSuccessfulAXWriteOnlyFallsBackForStableUnchangedInput() {
+        XCTAssertTrue(
+            AXTextInjector.successfulAXWriteIsCommitted(verification: .success)
+        )
+        XCTAssertTrue(
+            AXTextInjector.successfulAXWriteIsCommitted(verification: .indeterminate)
+        )
+        XCTAssertTrue(
+            AXTextInjector.successfulAXWriteIsCommitted(
+                verification: .failure("focused-process-changed")
+            )
+        )
+        XCTAssertFalse(
+            AXTextInjector.successfulAXWriteIsCommitted(
+                verification: .failure("input-text-unchanged")
+            )
+        )
+    }
+
     private final class InjectorBox: @unchecked Sendable {
         let value = AXTextInjector()
     }
@@ -634,6 +701,37 @@ final class AXTextInjectorTests: XCTestCase {
         XCTAssertEqual(result, .failure("input-text-unchanged"))
     }
 
+    func testEvaluatePasteVerificationDoesNotTreatWhitespaceChangeAsUnchanged() {
+        let before = CurrentInputTextSnapshot(
+            processID: 42,
+            processName: "Notes",
+            role: "AXTextArea",
+            text: "Hello",
+            isEditable: true,
+            isFocusedTarget: true,
+            failureReason: nil
+        )
+        let after = CurrentInputTextSnapshot(
+            processID: 42,
+            processName: "Notes",
+            role: "AXTextArea",
+            text: "Hello\n",
+            isEditable: true,
+            isFocusedTarget: true,
+            failureReason: nil
+        )
+
+        let result = AXTextInjector.evaluatePasteVerification(
+            insertedText: "\n",
+            replaceSelection: false,
+            targetProcessID: 42,
+            before: before,
+            after: after
+        )
+
+        XCTAssertEqual(result, .indeterminate)
+    }
+
     func testEvaluatePasteVerificationFailsWhenFocusedProcessChanges() {
         let before = CurrentInputTextSnapshot(
             processID: 42,
@@ -735,7 +833,7 @@ final class AXTextInjectorTests: XCTestCase {
         XCTAssertEqual(result, .failure("input-text-unchanged"))
     }
 
-    func testEvaluatePasteVerificationFailsWhenBrowserAXValueIsUnchangedForInsert() {
+    func testEvaluatePasteVerificationIsIndeterminateWhenBrowserAXValueIsUnchangedForInsert() {
         let before = CurrentInputTextSnapshot(
             processID: 42,
             processName: "Arc",
@@ -767,10 +865,45 @@ final class AXTextInjectorTests: XCTestCase {
             after: after
         )
 
-        XCTAssertEqual(result, .failure("input-text-unchanged"))
+        XCTAssertEqual(result, .indeterminate)
     }
 
-    func testEvaluatePasteVerificationFailsWhenUnknownBrowserLikeAXValueIsEmptyForInsert() {
+    func testEvaluatePasteVerificationIsIndeterminateWhenKnownBrowserAXValueIsStale() {
+        let before = CurrentInputTextSnapshot(
+            processID: 42,
+            processName: "Arc",
+            bundleIdentifier: "company.thebrowser.Browser",
+            role: "AXTextArea",
+            text: "Stale editor value",
+            isEditable: true,
+            isFocusedTarget: true,
+            failureReason: nil,
+            textSource: "ax-value"
+        )
+        let after = CurrentInputTextSnapshot(
+            processID: 42,
+            processName: "Arc",
+            bundleIdentifier: "company.thebrowser.Browser",
+            role: "AXTextArea",
+            text: "Stale editor value",
+            isEditable: true,
+            isFocusedTarget: true,
+            failureReason: nil,
+            textSource: "ax-value"
+        )
+
+        let result = AXTextInjector.evaluatePasteVerification(
+            insertedText: "new text",
+            replaceSelection: false,
+            targetProcessID: 42,
+            before: before,
+            after: after
+        )
+
+        XCTAssertEqual(result, .indeterminate)
+    }
+
+    func testEvaluatePasteVerificationIsIndeterminateWhenUnknownBrowserLikeAXValueIsEmptyForInsert() {
         let before = CurrentInputTextSnapshot(
             processID: 42,
             processName: "New Browser",
@@ -802,7 +935,7 @@ final class AXTextInjectorTests: XCTestCase {
             after: after
         )
 
-        XCTAssertEqual(result, .failure("input-text-unchanged"))
+        XCTAssertEqual(result, .indeterminate)
     }
 
     func testEvaluatePasteVerificationIsIndeterminateWhenTextCannotBeReadBack() {

--- a/Tests/TypefluxTests/WorkflowControllerProcessingTests.swift
+++ b/Tests/TypefluxTests/WorkflowControllerProcessingTests.swift
@@ -60,7 +60,7 @@ final class WorkflowControllerProcessingTests: XCTestCase {
         XCTAssertTrue(textInjector.insertedTexts.isEmpty)
     }
 
-    func testApplyTextPresentsCopyDialogWhenInsertThrows() async {
+    func testApplyTextCopiesResultWhenInsertThrows() async {
         let textInjector = MockProcessingTextInjector(
             insertError: NSError(
                 domain: "AXTextInjector",
@@ -68,13 +68,18 @@ final class WorkflowControllerProcessingTests: XCTestCase {
                 userInfo: [NSLocalizedDescriptionKey: "Paste insertion could not be verified"]
             )
         )
-        let controller = makeWorkflowController(textInjector: textInjector)
+        let clipboard = MockClipboardService()
+        let controller = makeWorkflowController(
+            textInjector: textInjector,
+            clipboard: clipboard
+        )
 
         let (outcome, processed) = await controller.applyText("Manual copy fallback", replace: false)
 
-        XCTAssertEqual(outcome, .presentedInDialog)
+        XCTAssertEqual(outcome, .copiedToClipboard)
         XCTAssertEqual(processed, "Manual copy fallback")
         XCTAssertEqual(controller.lastDialogResultText, "Manual copy fallback")
+        XCTAssertEqual(clipboard.storedText, "Manual copy fallback")
         XCTAssertTrue(textInjector.insertedTexts.isEmpty)
     }
 

--- a/Tests/TypefluxTests/WorkflowControllerProcessingTests.swift
+++ b/Tests/TypefluxTests/WorkflowControllerProcessingTests.swift
@@ -80,6 +80,7 @@ final class WorkflowControllerProcessingTests: XCTestCase {
         XCTAssertEqual(processed, "Manual copy fallback")
         XCTAssertEqual(controller.lastDialogResultText, "Manual copy fallback")
         XCTAssertEqual(clipboard.storedText, "Manual copy fallback")
+        XCTAssertTrue(controller.overlayController.isShowingPassiveNotice)
         XCTAssertTrue(textInjector.insertedTexts.isEmpty)
     }
 


### PR DESCRIPTION
## Summary

- classify the current focused target as writable, non-writable, or opaque and use direct AX insertion for writable controls
- verify readable targets against the exact UTF-16 caret transition and use a lazy pasteboard provider as delivery evidence for opaque targets
- require the focused AX element (or process fallback) to remain stable from dispatch through verification, including same-app focus changes
- automatically copy text and show a non-activating transient notice only when insertion cannot be confirmed
- record clipboard fallback as its own apply outcome and localize the notice in all supported languages

## Deep review fixes

- use the latest readback result instead of retaining a stale early failure
- treat whitespace-only text changes as real changes
- avoid duplicate Cmd+V fallback after a successful synchronous AX write loses readback focus
- treat known browser AX values as potentially stale and require delivery evidence instead
- poll focused target identity during the verification window and reject target changes

## Tests

- `swift test --filter 'AXTextInjectorTests|WorkflowControllerProcessingTests'` (169 passed)
- `swift test` (2488 passed, 8 unrelated pre-existing Persona prompt assertion failures from the current GUL-68 base)
- `git diff --check`
- `make format` unavailable because `swiftformat` is not installed in the runtime

Closes GUL-75
