### PR TITLE
GUL-75: restore responsive dictation insertion

### DIFF
--- a/Sources/Typeflux/TextInjection/AXTextInjector+Paste.swift
+++ b/Sources/Typeflux/TextInjection/AXTextInjector+Paste.swift
@@ -52,12 +52,36 @@ extension AXTextInjector {
             )
         }
 
-        var contextRestored = false
         let currentFocusedElement = focusedElement()
-        let beforeSnapshot = readCurrentInputTextSnapshot()
-        let focusedElementWasStableDuringSnapshot = focusedElementMatches(currentFocusedElement)
         let currentTargetCapability = currentFocusedElement
             .map(targetCapability(element:)) ?? .opaque
+
+        if !replaceSelection {
+            guard currentFocusedElement != nil else {
+                throw NSError(
+                    domain: "AXTextInjector",
+                    code: 12,
+                    userInfo: [NSLocalizedDescriptionKey: "No focused target is available"]
+                )
+            }
+            if currentTargetCapability == .notWritable {
+                throw NSError(
+                    domain: "AXTextInjector",
+                    code: 13,
+                    userInfo: [NSLocalizedDescriptionKey: "Focused target is not writable"]
+                )
+            }
+
+            NetworkDebugLogger.logMessage(
+                "[Text Injection] plain insert using eager paste path | capability: \(String(describing: currentTargetCapability))"
+            )
+            try setTextViaPaste(text, replaceSelection: false)
+            lastInjectionMethod = .paste
+            return
+        }
+
+        var contextRestored = false
+        let beforeSnapshot = readCurrentInputTextSnapshot()
         NetworkDebugLogger.logMessage(
             """
             [Text Injection] start
@@ -67,34 +91,8 @@ extension AXTextInjector {
             beforeSnapshot: \(snapshotSummary(beforeSnapshot))
             activeSelectionContext: \(selectionContextSummary(activeSelectionContext()))
             currentTargetCapability: \(String(describing: currentTargetCapability))
-            focusedElementWasStableDuringSnapshot: \(focusedElementWasStableDuringSnapshot)
             """
         )
-
-        if !replaceSelection {
-            if currentTargetCapability == .notWritable {
-                throw NSError(
-                    domain: "AXTextInjector",
-                    code: 13,
-                    userInfo: [NSLocalizedDescriptionKey: "Focused target is not writable"]
-                )
-            }
-
-            if let currentFocusedElement,
-               focusedElementWasStableDuringSnapshot,
-               currentTargetCapability == .writable,
-               try insertTextViaAX(
-                   text,
-                   into: currentFocusedElement,
-                   replaceSelection: false,
-                   selectionRange: beforeSnapshot.selectedRange,
-                   beforeSnapshot: beforeSnapshot
-               ) {
-                NetworkDebugLogger.logMessage("[Text Injection] insert completed via focused AX path")
-                lastInjectionMethod = .ax
-                return
-            }
-        }
 
         if replaceSelection, let context = activeSelectionContext() {
             NetworkDebugLogger.logMessage(
@@ -277,6 +275,24 @@ extension AXTextInjector {
             targetProcessID: targetPID
         )
 
+        if !replaceSelection {
+            pasteboard.clearContents()
+            guard pasteboard.setString(text, forType: .string) else {
+                throw NSError(
+                    domain: "AXTextInjector",
+                    code: 15,
+                    userInfo: [NSLocalizedDescriptionKey: "Unable to prepare text for paste"]
+                )
+            }
+            dispatchPasteShortcut(method: dispatchMethod, targetPID: targetPID)
+            restorePasteboardAfterPaste(
+                previousSnapshot,
+                delayNanoseconds: Self.unverifiedPasteRestoreDelayNanoseconds
+            )
+            NetworkDebugLogger.logMessage("[Text Injection] eager paste dispatched")
+            return
+        }
+
         let targetElement = focusedElement()
         let initialSnapshot = readCurrentInputTextSnapshot()
         guard focusedElementMatches(targetElement) else {
@@ -333,26 +349,8 @@ extension AXTextInjector {
         pasteboard.writeObjects([pasteboardItem])
         activePasteboardDeliveryProbe = deliveryProbe
 
-        let source = CGEventSource(stateID: .combinedSessionState)
-        let vDown = CGEvent(keyboardEventSource: source, virtualKey: 0x09, keyDown: true)
-        vDown?.flags = .maskCommand
-        let vUp = CGEvent(keyboardEventSource: source, virtualKey: 0x09, keyDown: false)
-        vUp?.flags = .maskCommand
-
         deliveryProbe.markDispatched()
-        switch dispatchMethod {
-        case .postToPid:
-            if let targetPID {
-                vDown?.postToPid(targetPID)
-                vUp?.postToPid(targetPID)
-            } else {
-                vDown?.post(tap: .cghidEventTap)
-                vUp?.post(tap: .cghidEventTap)
-            }
-        case .hidTap:
-            vDown?.post(tap: .cghidEventTap)
-            vUp?.post(tap: .cghidEventTap)
-        }
+        dispatchPasteShortcut(method: dispatchMethod, targetPID: targetPID)
 
         if allowClipboardSelectionFallback {
             NetworkDebugLogger.logMessage(
@@ -388,6 +386,28 @@ extension AXTextInjector {
             deliveryProbe: deliveryProbe,
             targetElement: targetElement
         )
+    }
+
+    private func dispatchPasteShortcut(method: PasteDispatchMethod, targetPID: pid_t?) {
+        let source = CGEventSource(stateID: .combinedSessionState)
+        let vDown = CGEvent(keyboardEventSource: source, virtualKey: 0x09, keyDown: true)
+        vDown?.flags = .maskCommand
+        let vUp = CGEvent(keyboardEventSource: source, virtualKey: 0x09, keyDown: false)
+        vUp?.flags = .maskCommand
+
+        switch method {
+        case .postToPid:
+            if let targetPID {
+                vDown?.postToPid(targetPID)
+                vUp?.postToPid(targetPID)
+            } else {
+                vDown?.post(tap: .cghidEventTap)
+                vUp?.post(tap: .cghidEventTap)
+            }
+        case .hidTap:
+            vDown?.post(tap: .cghidEventTap)
+            vUp?.post(tap: .cghidEventTap)
+        }
     }
 
     private func verifyPasteInsertion(

--- a/Sources/Typeflux/TextInjection/AXTextInjector.swift
+++ b/Sources/Typeflux/TextInjection/AXTextInjector.swift
@@ -483,16 +483,14 @@ final class AXTextInjector: TextInjector {
         strictFallbackEnabled && replaceSelection
     }
 
-    /// Plain insertions (voice dictation) cannot always be read back through AX
-    /// on apps like WeChat, Warp, Codex, terminals, and browser address bars.
-    /// Still attempt verification: readable unchanged targets fail explicitly;
-    /// opaque targets require post-dispatch pasteboard delivery evidence while
-    /// the focused target remains stable.
+    /// Plain dictation uses the eager paste fast path and must never enter the
+    /// synchronous verification loop. Strict verification remains scoped to
+    /// selection replacement, where the original text is available for recovery.
     static func shouldAttemptPasteVerification(
         replaceSelection: Bool,
         strictFallbackEnabled: Bool
     ) -> Bool {
-        !replaceSelection || shouldPerformStrictPasteVerification(
+        shouldPerformStrictPasteVerification(
             replaceSelection: replaceSelection,
             strictFallbackEnabled: strictFallbackEnabled
         )

--- a/Tests/TypefluxTests/AXTextInjectorTests.swift
+++ b/Tests/TypefluxTests/AXTextInjectorTests.swift
@@ -1195,22 +1195,22 @@ final class AXTextInjectorTests: XCTestCase {
         XCTAssertFalse(result)
     }
 
-    func testShouldAttemptPasteVerificationReturnsTrueForInsertWhenFlagDisabled() {
+    func testShouldAttemptPasteVerificationReturnsFalseForInsertWhenFlagDisabled() {
         let result = AXTextInjector.shouldAttemptPasteVerification(
             replaceSelection: false,
             strictFallbackEnabled: false
         )
 
-        XCTAssertTrue(result)
+        XCTAssertFalse(result)
     }
 
-    func testShouldAttemptPasteVerificationReturnsTrueForInsertWhenFlagEnabled() {
+    func testShouldAttemptPasteVerificationReturnsFalseForInsertWhenFlagEnabled() {
         let result = AXTextInjector.shouldAttemptPasteVerification(
             replaceSelection: false,
             strictFallbackEnabled: true
         )
 
-        XCTAssertTrue(result)
+        XCTAssertFalse(result)
     }
 
     func testShouldAttemptPasteVerificationReturnsFalseForReplaceWhenFlagDisabled() {


### PR DESCRIPTION
## Summary

- restore normal dictation to an eager clipboard write followed by immediate Command-V
- remove synchronous AX full-text snapshots, direct AX writes, and paste verification polling from plain insertion
- preserve strict verification and recovery for selection replacement
- fail early when no focused target exists or the focused element is explicitly not writable, allowing the existing auto-copy fallback to handle delivery

## Verification

- `swift test --filter TypefluxTests.AXTextInjectorTests` (79 passed)
- `swift test --filter TypefluxTests.WorkflowControllerProcessingTests` (91 passed)
- `swift test --enable-code-coverage --filter TypefluxTests.AXTextInjectorTests` (79 passed)
- `swift test` (2511 passed, 8 existing Persona prompt assertion failures unchanged from the current baseline)
- `git diff --check`

GUL-75
