### PR TITLE
GUL-76: enforce voice processing deadline

### DIFF
--- a/Sources/Typeflux/Overlay/OverlayController.swift
+++ b/Sources/Typeflux/Overlay/OverlayController.swift
@@ -657,9 +657,11 @@ final class OverlayController {
         refreshWindow()
     }
 
-    func showTimeoutFailure() {
+    func showTimeoutFailure(timeoutSeconds: Int) {
         if !Thread.isMainThread {
-            DispatchQueue.main.async { [weak self] in self?.showTimeoutFailure() }
+            DispatchQueue.main.async { [weak self] in
+                self?.showTimeoutFailure(timeoutSeconds: timeoutSeconds)
+            }
             return
         }
         cancelPendingPresentationTransition()
@@ -668,7 +670,7 @@ final class OverlayController {
         ensureWindow()
         model.presentation = .failure
         model.statusText = L("overlay.timeout.title")
-        model.detailText = L("overlay.timeout.message")
+        model.detailText = L("overlay.timeout.message", timeoutSeconds)
         model.failureTone = .error
         model.failureActions = wrapFailureActions([
             OverlayFailureAction(

--- a/Sources/Typeflux/Resources/en.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/en.lproj/Localizable.strings
@@ -154,7 +154,7 @@
 "settings.advanced.soundEffects.title" = "Enable sound effects";
 "settings.advanced.soundEffects.subtitle" = "Play start, done, and error sounds during recording workflow feedback.";
 "settings.advanced.voiceProcessingTimeout.title" = "Recognition wait time";
-"settings.advanced.voiceProcessingTimeout.subtitle" = "Choose how long cloud speech recognition and AI rewriting get priority before Typeflux uses the available fallback result.";
+"settings.advanced.voiceProcessingTimeout.subtitle" = "Set the maximum time for speech recognition and AI processing. Typeflux stops and reports a timeout if processing does not finish in time.";
 "settings.advanced.voiceProcessingTimeout.option" = "%d seconds";
 "settings.advanced.autoUpdate.title" = "Automatic Updates";
 "settings.advanced.autoUpdate.subtitle" = "Automatically check for and install updates every 3 hours.";
@@ -364,7 +364,7 @@
 "overlay.processing.thinking" = "Thinking";
 "overlay.failure.title" = "Processing failed";
 "overlay.timeout.title" = "Processing timed out";
-"overlay.timeout.message" = "Processing took longer than 120 seconds. Please try again.";
+"overlay.timeout.message" = "Processing took longer than %d seconds. Please try again.";
 "overlay.notice.title" = "Notice";
 "overlay.personaPicker.switchTitle" = "Switch Global Persona";
 "overlay.personaPicker.switchInstructions" = "Choose the global persona used when the current application has no active app persona.";
@@ -386,7 +386,7 @@
 "workflow.cancel.retry" = "Cancelled due to retry.";
 "workflow.cancel.newRecording" = "Cancelled by a new recording.";
 "workflow.cancel.userCancelled" = "Cancelled by user.";
-"workflow.timeout.reason" = "Processing timed out after 120 seconds.";
+"workflow.timeout.reason" = "Processing timed out after %d seconds.";
 "workflow.timeout.status" = "Processing timed out";
 "workflow.devApp.requiredMessage" = "Please run via scripts/run_dev_app.sh (app bundle required for privacy permissions)";
 "workflow.devApp.requiredStatus" = "Run as .app";

--- a/Sources/Typeflux/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/ja.lproj/Localizable.strings
@@ -154,7 +154,7 @@
 "settings.advanced.soundEffects.title" = "効果音を有効にする";
 "settings.advanced.soundEffects.subtitle" = "ワークフローのフィードバックの記録中に、開始音、完了音、エラー音を再生します。";
 "settings.advanced.voiceProcessingTimeout.title" = "認識の待機時間";
-"settings.advanced.voiceProcessingTimeout.subtitle" = "クラウド音声認識と AI 書き換えを優先して待つ時間を選択します。時間を超えると、利用可能な代替結果を使用します。";
+"settings.advanced.voiceProcessingTimeout.subtitle" = "音声認識と AI 処理の最大時間を設定します。時間内に完了しない場合は処理を停止してタイムアウトを通知します。";
 "settings.advanced.voiceProcessingTimeout.option" = "%d 秒";
 "settings.advanced.autoUpdate.title" = "自動アップデート";
 "settings.advanced.autoUpdate.subtitle" = "3 時間ごとに自動的に新しいバージョンを確認してインストールします。";
@@ -360,7 +360,7 @@
 "overlay.processing.thinking" = "思考中";
 "overlay.failure.title" = "処理に失敗しました";
 "overlay.timeout.title" = "処理がタイムアウトしました";
-"overlay.timeout.message" = "処理に 120 秒以上かかりました。もう一度試してください。";
+"overlay.timeout.message" = "処理に %d 秒以上かかりました。もう一度試してください。";
 "overlay.notice.title" = "お知らせ";
 "overlay.personaPicker.switchTitle" = "グローバル ペルソナを切り替え";
 "overlay.personaPicker.switchInstructions" = "現在のアプリに有効なアプリ ペルソナがない場合に使うグローバル ペルソナを選択します。";
@@ -382,7 +382,7 @@
 "workflow.cancel.retry" = "再試行のためキャンセルされました。";
 "workflow.cancel.newRecording" = "新規録音によりキャンセルされました。";
 "workflow.cancel.userCancelled" = "ユーザーによりキャンセルされました。";
-"workflow.timeout.reason" = "処理は 120 秒後にタイムアウトしました。";
+"workflow.timeout.reason" = "処理は %d 秒後にタイムアウトしました。";
 "workflow.timeout.status" = "処理がタイムアウトしました";
 "workflow.devApp.requiredMessage" = "scripts/run_dev_app.sh 経由で実行してください (プライバシー許可にはアプリ バンドルが必要です)";
 "workflow.devApp.requiredStatus" = ".appとして実行";

--- a/Sources/Typeflux/Resources/ko.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/ko.lproj/Localizable.strings
@@ -154,7 +154,7 @@
 "settings.advanced.soundEffects.title" = "음향 효과 활성화";
 "settings.advanced.soundEffects.subtitle" = "워크플로 피드백을 기록하는 동안 시작, 완료 및 오류 소리를 재생합니다.";
 "settings.advanced.voiceProcessingTimeout.title" = "인식 대기 시간";
-"settings.advanced.voiceProcessingTimeout.subtitle" = "클라우드 음성 인식과 AI 재작성 결과를 우선 대기할 시간을 선택합니다. 시간이 지나면 사용 가능한 대체 결과를 사용합니다.";
+"settings.advanced.voiceProcessingTimeout.subtitle" = "음성 인식과 AI 처리의 최대 시간을 설정합니다. 제시간에 완료되지 않으면 처리를 중지하고 시간 초과를 알립니다.";
 "settings.advanced.voiceProcessingTimeout.option" = "%d초";
 "settings.advanced.autoUpdate.title" = "자동 업데이트";
 "settings.advanced.autoUpdate.subtitle" = "3시간마다 자동으로 새 버전을 확인하고 설치합니다.";
@@ -360,7 +360,7 @@
 "overlay.processing.thinking" = "생각 중";
 "overlay.failure.title" = "처리 실패";
 "overlay.timeout.title" = "처리 시간이 초과되었습니다.";
-"overlay.timeout.message" = "처리하는 데 120초 이상이 걸렸습니다. 다시 시도해 주세요.";
+"overlay.timeout.message" = "처리하는 데 %d초 이상이 걸렸습니다. 다시 시도해 주세요.";
 "overlay.notice.title" = "공지사항";
 "overlay.personaPicker.switchTitle" = "전역 페르소나 전환";
 "overlay.personaPicker.switchInstructions" = "현재 애플리케이션에 활성 앱 페르소나가 없을 때 사용할 전역 페르소나를 선택하세요.";
@@ -382,7 +382,7 @@
 "workflow.cancel.retry" = "재시도 때문에 취소되었습니다.";
 "workflow.cancel.newRecording" = "새 녹음으로 인해 취소되었습니다.";
 "workflow.cancel.userCancelled" = "사용자가 취소했습니다.";
-"workflow.timeout.reason" = "120초 후에 처리 시간이 초과되었습니다.";
+"workflow.timeout.reason" = "%d초 후에 처리 시간이 초과되었습니다.";
 "workflow.timeout.status" = "처리 시간이 초과되었습니다.";
 "workflow.devApp.requiredMessage" = "scripts/run_dev_app.sh(개인 정보 보호 권한을 위해 필요한 App Bundle)를 통해 실행하세요.";
 "workflow.devApp.requiredStatus" = ".app으로 실행";

--- a/Sources/Typeflux/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/zh-Hans.lproj/Localizable.strings
@@ -146,7 +146,7 @@
 "settings.advanced.soundEffects.title" = "启用声音特效";
 "settings.advanced.soundEffects.subtitle" = "在开始录音、完成操作和发生错误时播放提示音。";
 "settings.advanced.voiceProcessingTimeout.title" = "识别等待时间";
-"settings.advanced.voiceProcessingTimeout.subtitle" = "设置云端语音识别和 AI 改写的优先等待时间，超时后使用已有的备用结果。";
+"settings.advanced.voiceProcessingTimeout.subtitle" = "设置语音识别和 AI 处理的最长时间，未能按时完成时将停止处理并提示超时。";
 "settings.advanced.voiceProcessingTimeout.option" = "%d 秒";
 "settings.advanced.autoUpdate.title" = "自动更新";
 "settings.advanced.autoUpdate.subtitle" = "每 3 小时自动检查并安装新版本。";
@@ -364,7 +364,7 @@
 "overlay.processing.thinking" = "思考中";
 "overlay.failure.title" = "处理失败";
 "overlay.timeout.title" = "处理超时";
-"overlay.timeout.message" = "处理时间超过 120 秒，请重试。";
+"overlay.timeout.message" = "处理时间超过 %d 秒，请重试。";
 "overlay.notice.title" = "提示";
 "overlay.personaPicker.switchTitle" = "切换全局人设";
 "overlay.personaPicker.switchInstructions" = "选择当前应用没有启用应用人设时使用的全局人设。";
@@ -386,7 +386,7 @@
 "workflow.cancel.retry" = "由于重试已取消。";
 "workflow.cancel.newRecording" = "已被新的录音任务取消。";
 "workflow.cancel.userCancelled" = "已被用户取消。";
-"workflow.timeout.reason" = "处理超时（超过 120 秒）。";
+"workflow.timeout.reason" = "处理超时（超过 %d 秒）。";
 "workflow.timeout.status" = "处理超时";
 "workflow.devApp.requiredMessage" = "请通过 scripts/run_dev_app.sh 运行（隐私权限需要 .app 包）";
 "workflow.devApp.requiredStatus" = "请以 .app 运行";

--- a/Sources/Typeflux/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/zh-Hant.lproj/Localizable.strings
@@ -146,7 +146,7 @@
 "settings.advanced.soundEffects.title" = "啟用音效";
 "settings.advanced.soundEffects.subtitle" = "在開始錄音、完成操作與發生錯誤時播放提示音。";
 "settings.advanced.voiceProcessingTimeout.title" = "辨識等待時間";
-"settings.advanced.voiceProcessingTimeout.subtitle" = "設定雲端語音辨識和 AI 改寫的優先等待時間，逾時後使用已有的備用結果。";
+"settings.advanced.voiceProcessingTimeout.subtitle" = "設定語音辨識和 AI 處理的最長時間，未能按時完成時將停止處理並提示逾時。";
 "settings.advanced.voiceProcessingTimeout.option" = "%d 秒";
 "settings.advanced.autoUpdate.title" = "自動更新";
 "settings.advanced.autoUpdate.subtitle" = "每 3 小時自動檢查並安裝新版本。";
@@ -362,7 +362,7 @@
 "overlay.processing.thinking" = "思考中";
 "overlay.failure.title" = "處理失敗";
 "overlay.timeout.title" = "處理逾時";
-"overlay.timeout.message" = "處理時間超過 120 秒，請重試。";
+"overlay.timeout.message" = "處理時間超過 %d 秒，請重試。";
 "overlay.notice.title" = "提示";
 "overlay.personaPicker.switchTitle" = "切換全域人設";
 "overlay.personaPicker.switchInstructions" = "選擇目前應用未啟用應用人設時使用的全域人設。";
@@ -384,7 +384,7 @@
 "workflow.cancel.retry" = "因重試已取消。";
 "workflow.cancel.newRecording" = "已被新的錄音任務取消。";
 "workflow.cancel.userCancelled" = "已被使用者取消。";
-"workflow.timeout.reason" = "處理逾時（超過 120 秒）。";
+"workflow.timeout.reason" = "處理逾時（超過 %d 秒）。";
 "workflow.timeout.status" = "處理逾時";
 "workflow.devApp.requiredMessage" = "請透過 scripts/run_dev_app.sh 執行（隱私權限需要 .app 包）";
 "workflow.devApp.requiredStatus" = "請以 .app 執行";

--- a/Sources/Typeflux/Settings/SettingsStore.swift
+++ b/Sources/Typeflux/Settings/SettingsStore.swift
@@ -79,7 +79,6 @@ enum VoiceProcessingTimeout: Int, CaseIterable, Identifiable {
     case fiveSeconds = 5
     case tenSeconds = 10
     case thirtySeconds = 30
-    case sixtySeconds = 60
 
     static let defaultValue: VoiceProcessingTimeout = .threeSeconds
 
@@ -212,9 +211,15 @@ final class SettingsStore {
             guard defaults.object(forKey: "voice.processing.timeoutSeconds") != nil else {
                 return .defaultValue
             }
-            return VoiceProcessingTimeout(
-                rawValue: defaults.integer(forKey: "voice.processing.timeoutSeconds")
-            ) ?? .defaultValue
+            let storedSeconds = defaults.integer(forKey: "voice.processing.timeoutSeconds")
+            if storedSeconds == 60 {
+                defaults.set(
+                    VoiceProcessingTimeout.thirtySeconds.rawValue,
+                    forKey: "voice.processing.timeoutSeconds"
+                )
+                return .thirtySeconds
+            }
+            return VoiceProcessingTimeout(rawValue: storedSeconds) ?? .defaultValue
         }
         set { defaults.set(newValue.rawValue, forKey: "voice.processing.timeoutSeconds") }
     }

--- a/Sources/Typeflux/Workflow/WorkflowController+Persona.swift
+++ b/Sources/Typeflux/Workflow/WorkflowController+Persona.swift
@@ -176,7 +176,7 @@ extension WorkflowController {
 
         cancelCurrentProcessing(resetUI: false, reason: L("workflow.cancel.newRecording"))
         let sessionID = beginProcessingSession()
-        let timeoutSeconds = Self.processingTimeoutSeconds(recordingDurationSeconds: nil)
+        let timeoutSeconds = settingsStore.voiceProcessingTimeout.seconds
         startProcessingTimeout(sessionID: sessionID, timeoutSeconds: timeoutSeconds)
 
         var record = HistoryRecord(

--- a/Sources/Typeflux/Workflow/WorkflowController+Processing.swift
+++ b/Sources/Typeflux/Workflow/WorkflowController+Processing.swift
@@ -534,9 +534,7 @@ extension WorkflowController {
             let personaPrompt = activePersonaProfile.map {
                 settingsStore.resolvedPersonaPrompt(for: $0)
             }
-            let processingTimeoutSeconds = Self.processingTimeoutSeconds(
-                recordingDurationSeconds: validatedAudioFile.duration
-            )
+            let processingTimeoutSeconds = settingsStore.voiceProcessingTimeout.seconds
 
             NetworkDebugLogger.logMessage(selectionSnapshotLog(selectionSnapshot))
             if WorkflowOverlayPresentationPolicy.shouldShowProcessingAfterRecording() {

--- a/Sources/Typeflux/Workflow/WorkflowController.swift
+++ b/Sources/Typeflux/Workflow/WorkflowController.swift
@@ -11,8 +11,6 @@ struct RecordingStartupContext: Sendable, Equatable {
 final class WorkflowController {
     let logger = Logger(subsystem: "ai.gulu.app.typeflux", category: "WorkflowController")
     static let recordingTimeoutNanoseconds: UInt64 = 600_000_000_000 // 10 minutes
-    static let minimumProcessingTimeoutSeconds: TimeInterval = 120
-    static let processingTimeoutGraceSeconds: TimeInterval = 90
     static let minimumRecordingDuration: TimeInterval = 0.35
     static let recordingTailCaptureDuration: Duration = .milliseconds(200)
     static let shortAudioRetryDuration: TimeInterval = 1.5
@@ -428,9 +426,7 @@ final class WorkflowController {
         cancelCurrentProcessing(resetUI: false, reason: L("workflow.cancel.retry"))
 
         let sessionID = beginProcessingSession()
-        let timeoutSeconds = Self.processingTimeoutSeconds(
-            recordingDurationSeconds: record.recordingDurationSeconds
-        )
+        let timeoutSeconds = settingsStore.voiceProcessingTimeout.seconds
         startProcessingTimeout(
             sessionID: sessionID,
             timeoutSeconds: timeoutSeconds
@@ -519,21 +515,6 @@ final class WorkflowController {
         }
     }
 
-    static func processingTimeoutSeconds(recordingDurationSeconds: TimeInterval?) -> TimeInterval {
-        let recordingDuration = max(0, recordingDurationSeconds ?? 0)
-        return max(
-            minimumProcessingTimeoutSeconds,
-            recordingDuration + processingTimeoutGraceSeconds
-        )
-    }
-
-    static func processingTimeoutNanoseconds(recordingDurationSeconds: TimeInterval?) -> UInt64 {
-        let timeoutSeconds = processingTimeoutSeconds(
-            recordingDurationSeconds: recordingDurationSeconds
-        )
-        return UInt64(timeoutSeconds * 1_000_000_000)
-    }
-
     func startProcessingTimeout(
         sessionID: UUID,
         timeoutSeconds: TimeInterval
@@ -544,7 +525,7 @@ final class WorkflowController {
             try? await Task.sleep(nanoseconds: timeoutNanoseconds)
             guard !Task.isCancelled else { return }
             NSLog("[Workflow] Processing timeout after %llu seconds", timeoutNanoseconds / 1_000_000_000)
-            self?.handleProcessingTimeout(sessionID: sessionID)
+            self?.handleProcessingTimeout(sessionID: sessionID, timeoutSeconds: timeoutSeconds)
         }
     }
 
@@ -553,7 +534,7 @@ final class WorkflowController {
         processingTimeoutTask = nil
     }
 
-    func handleProcessingTimeout(sessionID: UUID) {
+    func handleProcessingTimeout(sessionID: UUID, timeoutSeconds: TimeInterval) {
         guard processingSessionID == sessionID else { return }
         let recordID = activeProcessingRecordID
         let timeoutRecord = recordID.flatMap { historyStore.record(id: $0) }
@@ -563,12 +544,13 @@ final class WorkflowController {
                 forcedFailure: (stage: "processing", kind: "processing_timeout")
             )
         }
-        cancelCurrentProcessing(resetUI: false, reason: L("workflow.timeout.reason"))
+        let timeoutSeconds = Int(timeoutSeconds)
+        cancelCurrentProcessing(resetUI: false, reason: L("workflow.timeout.reason", timeoutSeconds))
         Task { @MainActor in
             self.lastRetryableFailureRecord = timeoutRecord
             self.soundEffectPlayer.play(.error)
             self.appState.setStatus(.failed(message: L("workflow.timeout.status")))
-            self.overlayController.showTimeoutFailure()
+            self.overlayController.showTimeoutFailure(timeoutSeconds: timeoutSeconds)
         }
     }
 

--- a/Tests/TypefluxTests/LocalizationResourceTests.swift
+++ b/Tests/TypefluxTests/LocalizationResourceTests.swift
@@ -41,7 +41,9 @@ final class LocalizationResourceTests: XCTestCase {
             "history.race.reason.cloudWithinWindow",
             "history.race.reason.cloudAfterWindow",
             "history.race.reason.localAtDeadline",
-            "history.race.reason.localAfterWindow"
+            "history.race.reason.localAfterWindow",
+            "overlay.timeout.message",
+            "workflow.timeout.reason"
         ]
 
         for language in AppLanguage.allCases {

--- a/Tests/TypefluxTests/SettingsStoreTests.swift
+++ b/Tests/TypefluxTests/SettingsStoreTests.swift
@@ -155,8 +155,15 @@ final class SettingsStoreTests: XCTestCase {
         XCTAssertEqual(store.voiceProcessingTimeout, .threeSeconds)
     }
 
+    func testVoiceProcessingTimeoutMigratesLegacySixtySecondsToThirtySeconds() {
+        defaults.set(60, forKey: "voice.processing.timeoutSeconds")
+
+        XCTAssertEqual(store.voiceProcessingTimeout, .thirtySeconds)
+        XCTAssertEqual(defaults.integer(forKey: "voice.processing.timeoutSeconds"), 30)
+    }
+
     func testVoiceProcessingTimeoutProvidesRequiredChoices() {
-        XCTAssertEqual(VoiceProcessingTimeout.allCases.map(\.rawValue), [1, 3, 5, 10, 30, 60])
+        XCTAssertEqual(VoiceProcessingTimeout.allCases.map(\.rawValue), [1, 3, 5, 10, 30])
     }
 
     // MARK: - Analytics Sharing

--- a/Tests/TypefluxTests/WorkflowControllerProcessingTests.swift
+++ b/Tests/TypefluxTests/WorkflowControllerProcessingTests.swift
@@ -588,32 +588,6 @@ final class WorkflowControllerProcessingTests: XCTestCase {
         }
     }
 
-    func testProcessingTimeoutUsesMinimumForShortOrMissingRecordings() {
-        XCTAssertEqual(
-            WorkflowController.processingTimeoutSeconds(recordingDurationSeconds: nil),
-            120
-        )
-        XCTAssertEqual(
-            WorkflowController.processingTimeoutSeconds(recordingDurationSeconds: 30),
-            120
-        )
-        XCTAssertEqual(
-            WorkflowController.processingTimeoutNanoseconds(recordingDurationSeconds: nil),
-            120_000_000_000
-        )
-        XCTAssertEqual(
-            WorkflowController.processingTimeoutNanoseconds(recordingDurationSeconds: 30),
-            120_000_000_000
-        )
-    }
-
-    func testProcessingTimeoutScalesWithRecordingDuration() {
-        XCTAssertEqual(
-            WorkflowController.processingTimeoutNanoseconds(recordingDurationSeconds: 132),
-            222_000_000_000
-        )
-    }
-
     func testPersonaRewriteTimeoutAfterTranscriptionIsThreeSeconds() {
         XCTAssertEqual(WorkflowController.llmTimeoutAfterTranscriptionSeconds, 3)
     }
@@ -624,9 +598,35 @@ final class WorkflowControllerProcessingTests: XCTestCase {
         })
         XCTAssertEqual(controller.llmTimeoutAfterTranscription, 10)
 
-        controller.settingsStore.voiceProcessingTimeout = .sixtySeconds
+        controller.settingsStore.voiceProcessingTimeout = .thirtySeconds
 
-        XCTAssertEqual(controller.llmTimeoutAfterTranscription, 60)
+        XCTAssertEqual(controller.llmTimeoutAfterTranscription, 30)
+    }
+
+    func testProcessingDeadlineCancelsSessionAndReportsConfiguredTimeout() async throws {
+        let historyStore = MockProcessingHistoryStore()
+        let controller = makeWorkflowController(historyStore: historyStore)
+        let record = HistoryRecord(
+            date: Date(),
+            recordingStatus: .succeeded,
+            transcriptionStatus: .running,
+            processingStatus: .pending,
+            applyStatus: .pending
+        )
+        controller.saveHistoryRecord(record)
+        controller.activeProcessingRecordID = record.id
+        let sessionID = controller.beginProcessingSession()
+
+        controller.startProcessingTimeout(sessionID: sessionID, timeoutSeconds: 0.01)
+        await waitUntil { controller.processingSessionID != sessionID }
+        await waitForMainActorWork()
+
+        XCTAssertNotEqual(controller.processingSessionID, sessionID)
+        XCTAssertEqual(controller.appState.status, .failed(message: L("workflow.timeout.status")))
+        XCTAssertEqual(
+            try XCTUnwrap(historyStore.record(id: record.id)).errorMessage,
+            L("workflow.timeout.reason", 0)
+        )
     }
 
     func testGenerateRewriteThrowsTimeoutWhenStreamDoesNotFinish() async {

--- a/docs/DATA_STORAGE.md
+++ b/docs/DATA_STORAGE.md
@@ -148,7 +148,7 @@ Application settings are managed through the `SettingsStore` singleton, backed b
 | `stt.local.downloadSource` | String | Model download source |
 | `stt.local.autoSetup` | Bool | Auto-setup local model |
 | `stt.multimodal.baseURL` | String | Multimodal LLM base URL |
-| `voice.processing.timeoutSeconds` | Int | Cloud ASR and post-transcription LLM priority wait (1, 3, 5, 10, 30, or 60 seconds; default 3) |
+| `voice.processing.timeoutSeconds` | Int | End-to-end voice recognition and AI processing deadline (1, 3, 5, 10, or 30 seconds; default 3; legacy 60-second values migrate to 30) |
 | `stt.multimodal.model` | String | Multimodal model |
 | `stt.multimodal.apiKey` | String | Multimodal API key |
 | `stt.alicloud.apiKey` | String | AliCloud API key |


### PR DESCRIPTION
## Summary
- enforce the selected voice-processing timeout as an end-to-end workflow deadline
- cap selectable timeouts at 30 seconds and migrate legacy 60-second settings to 30
- cancel timed-out sessions and show the configured duration in the localized error
- add timeout, migration, and localization contract tests

## Validation
- targeted suite: 246 tests passed
- full suite: 2511/2519 passed; 8 pre-existing Persona copy assertions still fail
- coverage run for the three new regression tests: passed; the broader coverage run hit the existing OverlayController non-zero retain-count signal 6
- all five Localizable.strings files pass plutil validation
- git diff --check passed

Closes GUL-76