### PR TITLE
GUL-78: simplify settings feature controls

### DIFF
--- a/Sources/Typeflux/Audio/SoundEffectPlayer.swift
+++ b/Sources/Typeflux/Audio/SoundEffectPlayer.swift
@@ -30,16 +30,19 @@ final class SoundEffectPlayer {
     }
 
     private let settingsStore: SettingsStore
+    private let isEnabledOverride: (() -> Bool)?
     private let playerFactory: (URL) throws -> SoundEffectPlayback
     private var players: [Effect: SoundEffectPlayback] = [:]
 
     init(
         settingsStore: SettingsStore,
+        isEnabledOverride: (() -> Bool)? = nil,
         playerFactory: @escaping (URL) throws -> SoundEffectPlayback = { url in
             try AVAudioPlayer(contentsOf: url)
         }
     ) {
         self.settingsStore = settingsStore
+        self.isEnabledOverride = isEnabledOverride
         self.playerFactory = playerFactory
 
         preloadPlayers()
@@ -48,7 +51,7 @@ final class SoundEffectPlayer {
     @discardableResult
     @MainActor
     func play(_ effect: Effect) -> Bool {
-        guard settingsStore.soundEffectsEnabled else {
+        guard isEnabledOverride?() ?? settingsStore.soundEffectsEnabled else {
             stopPlayers()
             return false
         }

--- a/Sources/Typeflux/STT/LocalModelTranscriber.swift
+++ b/Sources/Typeflux/STT/LocalModelTranscriber.swift
@@ -21,6 +21,7 @@ final class LocalModelTranscriber: TranscriptionProfileAwareTranscriber {
     private let modelManager: LocalSTTModelManaging
     private let whisperKitTranscriberFactory: (String, String) -> LocalWhisperKitTranscribing
     private let whisperKitKeepAliveDurationWhenMemoryOptimized: TimeInterval
+    private let memoryOptimizationEnabledOverride: (() -> Bool)?
     private let whisperKitCacheLock = NSLock()
     /// Single active WhisperKit pipeline cache keyed by model name + resolved model folder.
     /// WhisperKit keeps CoreML graphs resident after the first load, so we drop stale
@@ -32,6 +33,7 @@ final class LocalModelTranscriber: TranscriptionProfileAwareTranscriber {
         settingsStore: SettingsStore,
         modelManager: LocalSTTModelManaging,
         whisperKitKeepAliveDuration: TimeInterval = defaultWhisperKitKeepAliveDuration,
+        memoryOptimizationEnabledOverride: (() -> Bool)? = nil,
         whisperKitTranscriberFactory: @escaping (String, String)
             -> LocalWhisperKitTranscribing = { modelName, modelFolder in
                 WhisperKitTranscriber(modelName: modelName, modelFolder: modelFolder)
@@ -40,6 +42,7 @@ final class LocalModelTranscriber: TranscriptionProfileAwareTranscriber {
         self.settingsStore = settingsStore
         self.modelManager = modelManager
         whisperKitKeepAliveDurationWhenMemoryOptimized = whisperKitKeepAliveDuration
+        self.memoryOptimizationEnabledOverride = memoryOptimizationEnabledOverride
         self.whisperKitTranscriberFactory = whisperKitTranscriberFactory
     }
 
@@ -187,7 +190,7 @@ final class LocalModelTranscriber: TranscriptionProfileAwareTranscriber {
     }
 
     private var whisperKitKeepAliveDuration: TimeInterval? {
-        settingsStore.localSTTMemoryOptimizationEnabled
+        (memoryOptimizationEnabledOverride?() ?? settingsStore.localSTTMemoryOptimizationEnabled)
             ? whisperKitKeepAliveDurationWhenMemoryOptimized
             : Self.persistentWhisperKitKeepAliveDuration
     }

--- a/Sources/Typeflux/Settings/SettingsStore.swift
+++ b/Sources/Typeflux/Settings/SettingsStore.swift
@@ -203,8 +203,17 @@ final class SettingsStore {
     }
 
     var soundEffectsEnabled: Bool {
-        get { defaults.object(forKey: "audio.soundEffects.enabled") as? Bool ?? true }
-        set { defaults.set(newValue, forKey: "audio.soundEffects.enabled") }
+        get {
+            // Sound effects are temporarily disabled until there is time to optimize them.
+            // Keep the persisted implementation here so the feature can be restored later.
+            // defaults.object(forKey: "audio.soundEffects.enabled") as? Bool ?? true
+            false
+        }
+        set {
+            // Sound effects are temporarily disabled until there is time to optimize them.
+            // defaults.set(newValue, forKey: "audio.soundEffects.enabled")
+            _ = newValue
+        }
     }
 
     var voiceProcessingTimeout: VoiceProcessingTimeout {
@@ -440,8 +449,16 @@ final class SettingsStore {
     }
 
     var personaHotkeyAppliesToSelection: Bool {
-        get { defaults.object(forKey: "persona.hotkeyAppliesToSelection") as? Bool ?? true }
-        set { defaults.set(newValue, forKey: "persona.hotkeyAppliesToSelection") }
+        get {
+            // Keep selection application enabled while its setting is hidden from users.
+            // defaults.object(forKey: "persona.hotkeyAppliesToSelection") as? Bool ?? true
+            true
+        }
+        set {
+            // Preserve the original persistence code for a future settings reintroduction.
+            // defaults.set(newValue, forKey: "persona.hotkeyAppliesToSelection")
+            _ = newValue
+        }
     }
 
     var quickInputEnabled: Bool {
@@ -814,8 +831,16 @@ final class SettingsStore {
     }
 
     var localSTTMemoryOptimizationEnabled: Bool {
-        get { defaults.object(forKey: "stt.local.memoryOptimization.enabled") as? Bool ?? false }
-        set { defaults.set(newValue, forKey: "stt.local.memoryOptimization.enabled") }
+        get {
+            // Memory optimization is paused until the implementation can be improved.
+            // defaults.object(forKey: "stt.local.memoryOptimization.enabled") as? Bool ?? false
+            false
+        }
+        set {
+            // Preserve the original persistence code so the feature can be restored later.
+            // defaults.set(newValue, forKey: "stt.local.memoryOptimization.enabled")
+            _ = newValue
+        }
     }
 
     var automaticVocabularyCollectionEnabled: Bool {
@@ -824,8 +849,16 @@ final class SettingsStore {
     }
 
     var inputContextOptimizationEnabled: Bool {
-        get { defaults.object(forKey: "inputContext.optimization.enabled") as? Bool ?? true }
-        set { defaults.set(newValue, forKey: "inputContext.optimization.enabled") }
+        get {
+            // Keep input-context optimization enabled while its beta setting is hidden.
+            // defaults.object(forKey: "inputContext.optimization.enabled") as? Bool ?? true
+            true
+        }
+        set {
+            // Preserve the original persistence code for a future settings reintroduction.
+            // defaults.set(newValue, forKey: "inputContext.optimization.enabled")
+            _ = newValue
+        }
     }
 
     // MARK: - Output Post-Processing

--- a/Sources/Typeflux/Settings/SettingsView.swift
+++ b/Sources/Typeflux/Settings/SettingsView.swift
@@ -2393,6 +2393,9 @@ struct StudioView: View {
 
             StudioCard {
                 VStack(alignment: .leading, spacing: StudioTheme.Spacing.cardGroup) {
+                    /*
+                     Sound effects are temporarily disabled until there is time to optimize them.
+                     Keep this setting UI for a future reintroduction.
                     StudioSettingRow(
                         title: L("settings.advanced.soundEffects.title"),
                         subtitle: L("settings.advanced.soundEffects.subtitle")
@@ -2409,6 +2412,7 @@ struct StudioView: View {
                     }
 
                     Divider().overlay(StudioTheme.border.opacity(StudioTheme.Opacity.divider))
+                    */
 
                     StudioSettingRow(
                         title: L("settings.advanced.autoVocabulary.title"),
@@ -2514,6 +2518,10 @@ struct StudioView: View {
 
                             Divider().overlay(StudioTheme.border.opacity(StudioTheme.Opacity.divider))
 
+                            /*
+                             Memory optimization is temporarily hidden and forced off until it can be
+                             improved.
+                             Keep this setting UI for a future reintroduction.
                             StudioSettingRow(
                                 title: L("settings.advanced.localSTTMemoryOptimization.title"),
                                 subtitle: L("settings.advanced.localSTTMemoryOptimization.subtitle")
@@ -2530,7 +2538,11 @@ struct StudioView: View {
                             }
 
                             Divider().overlay(StudioTheme.border.opacity(StudioTheme.Opacity.divider))
+                            */
 
+                            /*
+                             Applying personas to selected text now remains enabled without a user setting.
+                             Keep this beta setting UI in case configurability returns later.
                             StudioSettingRow(
                                 title: L("settings.advanced.personaHotkeyApply.title"),
                                 subtitle: L("settings.advanced.personaHotkeyApply.subtitle"),
@@ -2548,7 +2560,11 @@ struct StudioView: View {
                             }
 
                             Divider().overlay(StudioTheme.border.opacity(StudioTheme.Opacity.divider))
+                            */
 
+                            /*
+                             Input-context optimization now remains enabled without a user setting.
+                             Keep this beta setting UI in case configurability returns later.
                             StudioSettingRow(
                                 title: L("settings.advanced.inputContextOptimization.title"),
                                 subtitle: L("settings.advanced.inputContextOptimization.subtitle"),
@@ -2566,6 +2582,7 @@ struct StudioView: View {
                             }
 
                             Divider().overlay(StudioTheme.border.opacity(StudioTheme.Opacity.divider))
+                            */
 
                             StudioSettingRow(
                                 title: L("settings.advanced.agentFramework.title"),
@@ -2601,6 +2618,9 @@ struct StudioView: View {
                                 .toggleStyle(.switch)
                             }
 
+                            /*
+                             Apple Speech fallback is intentionally hidden from settings and should no longer
+                             be presented to users. Keep the entry code because the underlying fallback remains.
                             Divider().overlay(StudioTheme.border.opacity(StudioTheme.Opacity.divider))
 
                             StudioSettingRow(
@@ -2617,6 +2637,7 @@ struct StudioView: View {
                                 .labelsHidden()
                                 .toggleStyle(.switch)
                             }
+                            */
                         }
                     }
 
@@ -6193,8 +6214,10 @@ struct StudioView: View {
 
     private var modelOverviewExtraPill: String? {
         if viewModel.modelDomain == .stt {
-            return viewModel.appleSpeechFallback
-                ? L("settings.models.fallback.enabled") : L("settings.models.fallback.off")
+            // Apple Speech fallback is intentionally hidden from all settings summaries.
+            // return viewModel.appleSpeechFallback
+            //     ? L("settings.models.fallback.enabled") : L("settings.models.fallback.off")
+            return nil
         }
 
         return providerIsConfigured(activeModelProviderID)
@@ -6360,7 +6383,9 @@ struct StudioView: View {
 
     private var modelRoutingSecondaryTitle: String? {
         if viewModel.modelDomain == .stt {
-            return L("settings.models.routing.fallback")
+            // Apple Speech fallback is intentionally hidden from all settings summaries.
+            // return L("settings.models.routing.fallback")
+            return nil
         }
 
         return activeModelProviderID == .ollama
@@ -6369,9 +6394,11 @@ struct StudioView: View {
 
     private var modelRoutingSecondaryValue: String? {
         if viewModel.modelDomain == .stt {
-            return viewModel.appleSpeechFallback
-                ? L("settings.models.routing.fallbackEnabled")
-                : L("settings.models.routing.fallbackDisabled")
+            // Apple Speech fallback is intentionally hidden from all settings summaries.
+            // return viewModel.appleSpeechFallback
+            //     ? L("settings.models.routing.fallbackEnabled")
+            //     : L("settings.models.routing.fallbackDisabled")
+            return nil
         }
 
         if activeModelProviderID == .ollama {

--- a/Tests/TypefluxTests/AVFoundationAudioRecorderTests.swift
+++ b/Tests/TypefluxTests/AVFoundationAudioRecorderTests.swift
@@ -605,7 +605,7 @@ final class AVFoundationAudioRecorderTests: XCTestCase {
         XCTAssertEqual(muter.beginCallCount, 1)
     }
 
-    func testDelayedMuteWaitsForStartCueWhenSoundEffectsAreEnabled() async throws {
+    func testDelayedMuteUsesShortDelayWhenPersistedSoundEffectsValueIsEnabled() async throws {
         let suiteName = "AVFoundationAudioRecorderTests-\(UUID().uuidString)"
         let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
         defer { defaults.removePersistentDomain(forName: suiteName) }
@@ -627,7 +627,7 @@ final class AVFoundationAudioRecorderTests: XCTestCase {
         await sleepController.waitUntilSleeping()
 
         let durations = await sleepController.recordedDurations()
-        XCTAssertEqual(durations, [.milliseconds(1225)])
+        XCTAssertEqual(durations, [.milliseconds(180)])
         recorder.cancelMutedSessionForTesting()
         await sleepController.resume()
     }

--- a/Tests/TypefluxTests/LocalModelTranscriberTests.swift
+++ b/Tests/TypefluxTests/LocalModelTranscriberTests.swift
@@ -741,6 +741,7 @@ final class LocalModelTranscriberTests: XCTestCase {
             settingsStore: settingsStore,
             modelManager: manager,
             whisperKitKeepAliveDuration: 0.05,
+            memoryOptimizationEnabledOverride: { true },
             whisperKitTranscriberFactory: factory.makeTranscriber(modelName:modelFolder:)
         )
         let audioFile = try makeTestWAVFile()

--- a/Tests/TypefluxTests/SettingsStoreFeatureFlagTests.swift
+++ b/Tests/TypefluxTests/SettingsStoreFeatureFlagTests.swift
@@ -69,18 +69,15 @@ final class SettingsStoreFeatureFlagTests: XCTestCase {
         XCTAssertTrue(store.inputContextOptimizationEnabled)
     }
 
-    func testInputContextOptimizationEnabledCanBeEnabledAndDisabled() {
-        store.inputContextOptimizationEnabled = true
-        XCTAssertTrue(store.inputContextOptimizationEnabled)
-
+    func testInputContextOptimizationEnabledCannotBeDisabled() {
         store.inputContextOptimizationEnabled = false
-        XCTAssertFalse(store.inputContextOptimizationEnabled)
+        XCTAssertTrue(store.inputContextOptimizationEnabled)
     }
 
-    func testInputContextOptimizationEnabledPersistsExplicitFalse() {
-        store.inputContextOptimizationEnabled = false
+    func testInputContextOptimizationEnabledOverridesPersistedFalse() {
+        defaults.set(false, forKey: "inputContext.optimization.enabled")
 
         let reloaded = SettingsStore(defaults: defaults)
-        XCTAssertFalse(reloaded.inputContextOptimizationEnabled)
+        XCTAssertTrue(reloaded.inputContextOptimizationEnabled)
     }
 }

--- a/Tests/TypefluxTests/SettingsStoreTests.swift
+++ b/Tests/TypefluxTests/SettingsStoreTests.swift
@@ -127,12 +127,15 @@ final class SettingsStoreTests: XCTestCase {
 
     // MARK: - Sound Effects
 
-    func testDefaultSoundEffectsEnabled() {
-        XCTAssertTrue(store.soundEffectsEnabled)
+    func testDefaultSoundEffectsDisabled() {
+        XCTAssertFalse(store.soundEffectsEnabled)
     }
 
-    func testSetSoundEffectsDisabled() {
-        store.soundEffectsEnabled = false
+    func testSoundEffectsRemainDisabledWhenPersistedOrSetToTrue() {
+        defaults.set(true, forKey: "audio.soundEffects.enabled")
+        XCTAssertFalse(store.soundEffectsEnabled)
+
+        store.soundEffectsEnabled = true
         XCTAssertFalse(store.soundEffectsEnabled)
     }
 
@@ -502,9 +505,12 @@ final class SettingsStoreTests: XCTestCase {
         XCTAssertTrue(store.personaHotkeyAppliesToSelection)
     }
 
-    func testSetPersonaHotkeyAppliesToSelection() {
+    func testPersonaHotkeyAlwaysAppliesToSelection() {
+        defaults.set(false, forKey: "persona.hotkeyAppliesToSelection")
+        XCTAssertTrue(store.personaHotkeyAppliesToSelection)
+
         store.personaHotkeyAppliesToSelection = false
-        XCTAssertFalse(store.personaHotkeyAppliesToSelection)
+        XCTAssertTrue(store.personaHotkeyAppliesToSelection)
     }
 
     func testDefaultQuickInputDisabled() {
@@ -550,8 +556,11 @@ final class SettingsStoreTests: XCTestCase {
         XCTAssertFalse(store.localSTTMemoryOptimizationEnabled)
     }
 
-    func testSetLocalSTTMemoryOptimizationDisabled() {
-        store.localSTTMemoryOptimizationEnabled = false
+    func testLocalSTTMemoryOptimizationRemainsDisabledWhenPersistedOrSetToTrue() {
+        defaults.set(true, forKey: "stt.local.memoryOptimization.enabled")
+        XCTAssertFalse(store.localSTTMemoryOptimizationEnabled)
+
+        store.localSTTMemoryOptimizationEnabled = true
         XCTAssertFalse(store.localSTTMemoryOptimizationEnabled)
     }
 

--- a/Tests/TypefluxTests/SoundEffectPlayerTests.swift
+++ b/Tests/TypefluxTests/SoundEffectPlayerTests.swift
@@ -38,7 +38,7 @@ final class SoundEffectPlayerTests: XCTestCase {
         let settingsStore = try makeSettingsStore()
         var requestedURLs: [URL] = []
 
-        _ = SoundEffectPlayer(settingsStore: settingsStore) { url in
+        _ = SoundEffectPlayer(settingsStore: settingsStore, isEnabledOverride: { true }) { url in
             requestedURLs.append(url)
             return MockSoundEffectPlayback()
         }
@@ -52,7 +52,7 @@ final class SoundEffectPlayerTests: XCTestCase {
         let settingsStore = try makeSettingsStore()
         let playbackByName = PlaybackRegistry()
         var requestedURLs: [URL] = []
-        let player = SoundEffectPlayer(settingsStore: settingsStore) { url in
+        let player = SoundEffectPlayer(settingsStore: settingsStore, isEnabledOverride: { true }) { url in
             requestedURLs.append(url)
             let playback = MockSoundEffectPlayback()
             playbackByName[url.deletingPathExtension().lastPathComponent] = playback
@@ -74,7 +74,7 @@ final class SoundEffectPlayerTests: XCTestCase {
     func testPlayStopsOtherEffectPlayers() throws {
         let settingsStore = try makeSettingsStore()
         let playbackByName = PlaybackRegistry()
-        let player = SoundEffectPlayer(settingsStore: settingsStore) { url in
+        let player = SoundEffectPlayer(settingsStore: settingsStore, isEnabledOverride: { true }) { url in
             let playback = MockSoundEffectPlayback()
             playback.currentTime = 0.8
             playbackByName[url.deletingPathExtension().lastPathComponent] = playback
@@ -96,7 +96,7 @@ final class SoundEffectPlayerTests: XCTestCase {
         let settingsStore = try makeSettingsStore()
         settingsStore.soundEffectsEnabled = false
         let playbackByName = PlaybackRegistry()
-        let player = SoundEffectPlayer(settingsStore: settingsStore) { url in
+        let player = SoundEffectPlayer(settingsStore: settingsStore, isEnabledOverride: { false }) { url in
             let playback = MockSoundEffectPlayback()
             playback.currentTime = 0.6
             playbackByName[url.deletingPathExtension().lastPathComponent] = playback
@@ -118,7 +118,7 @@ final class SoundEffectPlayerTests: XCTestCase {
     func testPlayReturnsTrueWhenPlaybackStarts() throws {
         let settingsStore = try makeSettingsStore()
         let playback = MockSoundEffectPlayback()
-        let player = SoundEffectPlayer(settingsStore: settingsStore) { _ in
+        let player = SoundEffectPlayer(settingsStore: settingsStore, isEnabledOverride: { true }) { _ in
             playback
         }
 
@@ -129,7 +129,7 @@ final class SoundEffectPlayerTests: XCTestCase {
     func testPlayReturnsFalseWhenSoundEffectsAreDisabled() throws {
         let settingsStore = try makeSettingsStore()
         settingsStore.soundEffectsEnabled = false
-        let player = SoundEffectPlayer(settingsStore: settingsStore) { _ in
+        let player = SoundEffectPlayer(settingsStore: settingsStore, isEnabledOverride: { false }) { _ in
             MockSoundEffectPlayback()
         }
 
@@ -140,7 +140,7 @@ final class SoundEffectPlayerTests: XCTestCase {
         let settingsStore = try makeSettingsStore()
         let playbackByName = PlaybackRegistry()
         let playExpectation = expectation(description: "Async sound effect playback started")
-        let player = SoundEffectPlayer(settingsStore: settingsStore) { url in
+        let player = SoundEffectPlayer(settingsStore: settingsStore, isEnabledOverride: { true }) { url in
             let playback = MockSoundEffectPlayback()
             playbackByName[url.deletingPathExtension().lastPathComponent] = playback
             if url.lastPathComponent == "done.mp3" {

--- a/Tests/TypefluxTests/WorkflowControllerProcessingTests.swift
+++ b/Tests/TypefluxTests/WorkflowControllerProcessingTests.swift
@@ -2111,7 +2111,10 @@ final class WorkflowControllerProcessingTests: XCTestCase {
         defaults.removePersistentDomain(forName: suiteName)
         let settingsStore = SettingsStore(defaults: defaults)
         settingsStore.soundEffectsEnabled = soundEffectsEnabled
-        return SoundEffectPlayer(settingsStore: settingsStore) { _ in
+        return SoundEffectPlayer(
+            settingsStore: settingsStore,
+            isEnabledOverride: { soundEffectsEnabled }
+        ) { _ in
             MockSoundEffectPlayback(eventRecorder: eventRecorder)
         }
     }
@@ -2125,7 +2128,10 @@ final class WorkflowControllerProcessingTests: XCTestCase {
         defaults.removePersistentDomain(forName: suiteName)
         let settingsStore = SettingsStore(defaults: defaults)
         settingsStore.soundEffectsEnabled = soundEffectsEnabled
-        return SoundEffectPlayer(settingsStore: settingsStore) { url in
+        return SoundEffectPlayer(
+            settingsStore: settingsStore,
+            isEnabledOverride: { soundEffectsEnabled }
+        ) { url in
             let effectName = url.deletingPathExtension().lastPathComponent
             return MockSoundEffectPlayback(eventRecorder: eventRecorder, eventName: "cue-play-\(effectName)")
         }


### PR DESCRIPTION
## Summary

- hide the sound, memory optimization, input-context, selection-application, and Apple fallback settings
- force sound effects and memory optimization off, while keeping input context and selection application on
- preserve paused implementations with restoration comments and keep dormant paths testable

## Testing

- `swift test --filter 'SettingsStoreTests.test(DefaultSound|SoundEffects|DefaultPersonaHotkey|PersonaHotkey|DefaultLocalSTTMemory|LocalSTTMemory)|SettingsStoreFeatureFlagTests.testInputContext|SoundEffectPlayerTests|AVFoundationAudioRecorderTests.testDelayedMute|LocalModelTranscriberTests.testWhisperKitTranscriberCache|WorkflowControllerProcessingTests.testConfirmingPersonaSelection'` (28 passed)
- `swift test` (2511 passed; 8 pre-existing Persona localization assertion failures in unchanged test/code areas)
- `git diff --check`

Closes GUL-78
