### PR TITLE
GUL-79: keep SenseVoice fallback available

### DIFF
--- a/Sources/Typeflux/STT/AutoModelDownloadService.swift
+++ b/Sources/Typeflux/STT/AutoModelDownloadService.swift
@@ -9,7 +9,6 @@ extension Notification.Name {
 // MARK: - Download Status
 
 enum AutoModelDownloadStatus: Equatable {
-    case disabled
     case notStarted
     case downloading(progress: Double)
     case completed
@@ -19,10 +18,6 @@ enum AutoModelDownloadStatus: Equatable {
 // MARK: - Persistent State
 
 private struct AutoModelState: Codable {
-    var isCompleted: Bool = false
-    var completedStoragePath: String?
-    var completedModelType: String?
-    var completedModelIdentifier: String?
     var attemptCount: Int = 0
     var lastAttemptDate: Date?
     var nextRetryDate: Date?
@@ -34,11 +29,12 @@ private struct AutoModelState: Codable {
 ///
 /// - All Macs (both Apple Silicon and Intel) use SenseVoice (sensevoice-small).
 ///
-/// The service maintains its own state independently of the user's local model settings,
-/// so it never overwrites the user's manually configured model record.
+/// Availability is determined by LocalModelManager's prepared model record and file
+/// validation. The service keeps only retry bookkeeping in UserDefaults, avoiding a
+/// second source of truth that can disagree with the Models settings page.
 ///
 /// Retry strategy:
-/// - On every app launch: retry immediately if not completed.
+/// - On every app launch: retry immediately if unavailable.
 /// - Within a session after failure: exponential backoff (1 min → 3 min → 9 min … capped at 3 h).
 final class AutoModelDownloadService {
     // MARK: - Threading
@@ -54,8 +50,7 @@ final class AutoModelDownloadService {
         stateLock.withLock { _status }
     }
 
-    /// True when the auto model is ready to use for transcription.
-    /// Only ever transitions false → true.
+    /// True when the baseline model was ready at the last validation.
     var isModelReady: Bool {
         stateLock.withLock { _readyStoragePath != nil }
     }
@@ -71,6 +66,7 @@ final class AutoModelDownloadService {
 
     private var downloadTask: Task<Void, Never>?
     private var retryTask: Task<Void, Never>?
+    private var isDownloadInFlight = false
 
     private static let stateDefaultsKey = "stt.autoModelDownload.state"
     private static let maxBackoffInterval: TimeInterval = 3 * 60 * 60 // 3 hours
@@ -83,45 +79,26 @@ final class AutoModelDownloadService {
         self.modelManager = modelManager
         self.settingsStore = settingsStore
         self.notificationService = notificationService
-        NotificationCenter.default.addObserver(
-            forName: .localOptimizationDidEnable,
-            object: nil,
-            queue: .main
-        ) { [weak self] _ in
-            self?.triggerIfNeeded()
-        }
     }
 
     // MARK: - Public API
 
-    /// Call once on app start. Starts a download if the model is not yet ready.
+    /// Call on app start and whenever baseline availability needs to be reconciled.
+    /// SenseVoice is a system fallback, so installation is independent of the local
+    /// optimization routing preference.
     func triggerIfNeeded() {
-        guard settingsStore.localOptimizationEnabled else {
-            setStatus(.disabled)
-            LocalModelDownloadProgressCenter.shared.clear()
-            return
-        }
-
         let config = Self.recommendedConfiguration()
 
         if let prepared = modelManager.preparedModelInfo(for: config) {
             markReady(config: config, storagePath: prepared.storagePath)
             return
         }
+        guard !stateLock.withLock({ isDownloadInFlight }) else { return }
 
-        // If already downloaded in a previous session, mark ready immediately.
-        let state = loadState()
-        if state.isCompleted,
-           let path = state.completedStoragePath,
-           state.completedModelType == config.model.rawValue,
-           state.completedModelIdentifier == config.modelIdentifier,
-           modelManager.isStoragePathReady(path, for: config.model) {
-            markReady(config: config, storagePath: path)
-            return
-        }
-
-        // Always attempt download on launch (regardless of retry timer).
-        startDownload()
+        clearReady()
+        // Always attempt repair on launch/use. LocalModelManager reuses complete files
+        // already on disk and writes the canonical prepared record before returning.
+        startDownloadIfNeeded()
     }
 
     /// Creates a ready-to-use transcriber, or nil if the model is not yet available.
@@ -132,7 +109,15 @@ final class AutoModelDownloadService {
         let path = _readyStoragePath
         stateLock.unlock()
 
-        guard let config, let path else { return nil }
+        guard let config, let path else {
+            triggerIfNeeded()
+            return nil
+        }
+        guard modelManager.isStoragePathReady(path, for: config.model) else {
+            clearReady()
+            startDownloadIfNeeded()
+            return nil
+        }
 
         switch config.model {
         case .whisperLocal, .whisperLocalLarge:
@@ -162,16 +147,29 @@ final class AutoModelDownloadService {
 
     // MARK: - Download
 
-    private func startDownload() {
+    private func startDownloadIfNeeded() {
+        let shouldStart = stateLock.withLock { () -> Bool in
+            guard !isDownloadInFlight else { return false }
+            isDownloadInFlight = true
+            return true
+        }
+        guard shouldStart else { return }
+
         retryTask?.cancel()
         retryTask = nil
-        downloadTask?.cancel()
         downloadTask = Task { [weak self] in
             await self?.performDownload()
         }
     }
 
     private func performDownload() async {
+        defer {
+            stateLock.withLock {
+                isDownloadInFlight = false
+                downloadTask = nil
+            }
+        }
+
         let config = Self.recommendedConfiguration()
         setStatus(.downloading(progress: 0))
         LocalModelDownloadProgressCenter.shared.reportDownloading(model: config.model, progress: 0)
@@ -179,14 +177,10 @@ final class AutoModelDownloadService {
         var state = loadState()
         state.attemptCount += 1
         state.lastAttemptDate = Date()
-        state.completedModelType = config.model.rawValue
-        state.completedModelIdentifier = config.modelIdentifier
         saveState(state)
 
         do {
-            let storagePath = try await modelManager.downloadModelFilesOnly(
-                configuration: config
-            ) { [weak self] update in
+            try await modelManager.prepareModel(configuration: config) { [weak self] update in
                 self?.setStatus(.downloading(progress: update.progress))
                 LocalModelDownloadProgressCenter.shared.reportDownloading(
                     model: config.model,
@@ -194,19 +188,18 @@ final class AutoModelDownloadService {
                 )
             }
 
-            guard modelManager.isStoragePathReady(storagePath, for: config.model) else {
+            guard let prepared = modelManager.preparedModelInfo(for: config) else {
                 throw NSError(
                     domain: "AutoModelDownloadService",
                     code: 1,
-                    userInfo: [NSLocalizedDescriptionKey: "Model files not usable after download"]
+                    userInfo: [NSLocalizedDescriptionKey: "Model is not usable after preparation"]
                 )
             }
 
-            markReady(config: config, storagePath: storagePath)
+            markReady(config: config, storagePath: prepared.storagePath)
 
             var completedState = loadState()
-            completedState.isCompleted = true
-            completedState.completedStoragePath = storagePath
+            completedState.attemptCount = 0
             completedState.nextRetryDate = nil
             saveState(completedState)
             LocalModelDownloadProgressCenter.shared.clear()
@@ -252,6 +245,19 @@ final class AutoModelDownloadService {
         notifyStateChanged()
     }
 
+    private func clearReady() {
+        let needsNotify = stateLock.withLock { () -> Bool in
+            let needsNotify = _readyStoragePath != nil || _status == .completed
+            _readyConfig = nil
+            _readyStoragePath = nil
+            _status = .notStarted
+            return needsNotify
+        }
+        if needsNotify {
+            notifyStateChanged()
+        }
+    }
+
     private func setStatus(_ newStatus: AutoModelDownloadStatus) {
         let needsNotify = stateLock.withLock { () -> Bool in
             let needsNotify = _status != newStatus
@@ -275,7 +281,7 @@ final class AutoModelDownloadService {
         retryTask = Task { [weak self] in
             try? await Task.sleep(nanoseconds: UInt64(interval * 1_000_000_000))
             guard !Task.isCancelled else { return }
-            self?.startDownload()
+            self?.startDownloadIfNeeded()
         }
     }
 

--- a/Sources/Typeflux/STT/STTRouter+Fallbacks.swift
+++ b/Sources/Typeflux/STT/STTRouter+Fallbacks.swift
@@ -160,8 +160,7 @@ extension STTRouter {
         audioFile: AudioFile,
         onUpdate: @escaping @Sendable (TranscriptionSnapshot) async -> Void
     ) async -> String? {
-        guard settingsStore.localOptimizationEnabled,
-              let transcriber = autoModelDownloadService?.makeTranscriberIfReady()
+        guard let transcriber = autoModelDownloadService?.makeTranscriberIfReady()
         else {
             return nil
         }

--- a/Sources/Typeflux/Settings/SettingsView.swift
+++ b/Sources/Typeflux/Settings/SettingsView.swift
@@ -5773,7 +5773,9 @@ struct StudioView: View {
                 )
             }
 
-            if viewModel.isModelAvailable(model) {
+            // SenseVoice is the system-managed baseline fallback. It can be repaired or
+            // re-downloaded, but must not be permanently removed from the app.
+            if model != .senseVoiceSmall, viewModel.isModelAvailable(model) {
                 Divider()
                 Button(role: .destructive) {
                     localSTTPendingDelete = model

--- a/Tests/TypefluxTests/LocalModelTranscriberTests.swift
+++ b/Tests/TypefluxTests/LocalModelTranscriberTests.swift
@@ -432,6 +432,108 @@ final class LocalModelTranscriberTests: XCTestCase {
         await fulfillment(of: [progressNotification], timeout: 2)
     }
 
+    func testAutoModelDownloadServiceInstallsBaselineWhenOptimizationIsDisabled() async throws {
+        let suiteName = "LocalModelTranscriberTests-\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let settingsStore = SettingsStore(defaults: defaults)
+        settingsStore.localOptimizationEnabled = false
+        let fakeInstaller = FakeSherpaOnnxInstaller()
+        let manager = LocalModelManager(
+            fileManager: .default,
+            sherpaOnnxInstaller: fakeInstaller,
+            applicationSupportURL: makeTemporaryApplicationSupportURL(),
+            downloadSourceResolver: FixedLocalModelDownloadSourceResolver(sources: [.huggingFace]),
+            bundledModelsRootURL: FileManager.default.temporaryDirectory
+                .appendingPathComponent("typeflux-auto-empty-bundle-\(UUID().uuidString)", isDirectory: true)
+        )
+        let service = AutoModelDownloadService(modelManager: manager, settingsStore: settingsStore)
+
+        service.triggerIfNeeded()
+        try await waitForAutoModel(service)
+
+        let configuration = AutoModelDownloadService.recommendedConfiguration()
+        XCTAssertEqual(service.status, .completed)
+        XCTAssertTrue(service.isModelReady)
+        XCTAssertNotNil(manager.preparedModelInfo(for: configuration))
+        XCTAssertEqual(fakeInstaller.preparedSources, [.huggingFace])
+    }
+
+    func testAutoModelDownloadServiceCoalescesConcurrentTriggers() async throws {
+        let suiteName = "LocalModelTranscriberTests-\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let settingsStore = SettingsStore(defaults: defaults)
+        let fakeInstaller = FakeSherpaOnnxInstaller()
+        let manager = LocalModelManager(
+            fileManager: .default,
+            sherpaOnnxInstaller: fakeInstaller,
+            applicationSupportURL: makeTemporaryApplicationSupportURL(),
+            downloadSourceResolver: FixedLocalModelDownloadSourceResolver(sources: [.huggingFace]),
+            bundledModelsRootURL: FileManager.default.temporaryDirectory
+                .appendingPathComponent("typeflux-auto-empty-bundle-\(UUID().uuidString)", isDirectory: true)
+        )
+        let service = AutoModelDownloadService(modelManager: manager, settingsStore: settingsStore)
+
+        service.triggerIfNeeded()
+        service.triggerIfNeeded()
+        service.triggerIfNeeded()
+        try await waitForAutoModel(service)
+
+        XCTAssertEqual(fakeInstaller.preparedSources, [.huggingFace])
+    }
+
+    func testAutoModelDownloadServiceRepairsFilesThatBecomeInvalid() async throws {
+        let suiteName = "LocalModelTranscriberTests-\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let settingsStore = SettingsStore(defaults: defaults)
+        let fakeInstaller = FakeSherpaOnnxInstaller()
+        let manager = LocalModelManager(
+            fileManager: .default,
+            sherpaOnnxInstaller: fakeInstaller,
+            applicationSupportURL: makeTemporaryApplicationSupportURL(),
+            downloadSourceResolver: FixedLocalModelDownloadSourceResolver(sources: [.huggingFace]),
+            bundledModelsRootURL: FileManager.default.temporaryDirectory
+                .appendingPathComponent("typeflux-auto-empty-bundle-\(UUID().uuidString)", isDirectory: true)
+        )
+        let service = AutoModelDownloadService(modelManager: manager, settingsStore: settingsStore)
+
+        service.triggerIfNeeded()
+        try await waitForAutoModel(service)
+        let configuration = AutoModelDownloadService.recommendedConfiguration()
+        let prepared = try XCTUnwrap(manager.preparedModelInfo(for: configuration))
+        let layout = try XCTUnwrap(SherpaOnnxModelLayout.layout(for: .senseVoiceSmall))
+        let tokensURL = URL(fileURLWithPath: prepared.storagePath, isDirectory: true)
+            .appendingPathComponent(layout.modelRootDirectory, isDirectory: true)
+            .appendingPathComponent("tokens.txt", isDirectory: false)
+        try FileManager.default.removeItem(at: tokensURL)
+
+        XCTAssertNil(service.makeTranscriberIfReady())
+        try await waitForAutoModel(service)
+
+        XCTAssertEqual(service.status, .completed)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: tokensURL.path))
+        XCTAssertEqual(fakeInstaller.preparedSources, [.huggingFace, .huggingFace])
+    }
+
+    private func waitForAutoModel(
+        _ service: AutoModelDownloadService,
+        timeout: TimeInterval = 2
+    ) async throws {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if service.status == .completed {
+                return
+            }
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+        XCTFail("Timed out waiting for the baseline model")
+    }
+
     func testLocalModelManagerPersistsQwen3PreparedModelInfo() async throws {
         let suiteName = "LocalModelTranscriberTests-\(UUID().uuidString)"
         let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
@@ -1491,7 +1593,7 @@ private final class CapturingProcessRunner: ProcessCommandRunning {
     }
 }
 
-private final class FakeSherpaOnnxInstaller: SherpaOnnxModelInstalling {
+final class FakeSherpaOnnxInstaller: SherpaOnnxModelInstalling {
     private let failingSources: Set<ModelDownloadSource>
     var lastPreparedModel: LocalSTTModel?
     var lastStorageURL: URL?

--- a/Tests/TypefluxTests/STTRouterTests.swift
+++ b/Tests/TypefluxTests/STTRouterTests.swift
@@ -783,6 +783,49 @@ final class STTRouterTests: XCTestCase {
         XCTAssertEqual(appleSpeech.transcribeCallCount, 1)
     }
 
+    func testAutoModelFallbackReconcilesBaselineWhenOptimizationIsDisabled() async throws {
+        settings.localOptimizationEnabled = false
+        let applicationSupportURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("typeflux-router-auto-model-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: applicationSupportURL) }
+
+        let manager = LocalModelManager(
+            fileManager: .default,
+            sherpaOnnxInstaller: FakeSherpaOnnxInstaller(),
+            applicationSupportURL: applicationSupportURL,
+            downloadSourceResolver: FixedLocalModelDownloadSourceResolver(sources: [.huggingFace]),
+            bundledModelsRootURL: applicationSupportURL.appendingPathComponent("empty-bundle", isDirectory: true)
+        )
+        let service = AutoModelDownloadService(modelManager: manager, settingsStore: settings)
+        let router = STTRouter(
+            settingsStore: settings,
+            whisper: whisper,
+            freeSTT: freeSTT,
+            appleSpeech: appleSpeech,
+            localModel: localModel,
+            multimodal: multimodal,
+            aliCloud: aliCloud,
+            doubaoRealtime: doubaoRealtime,
+            googleCloud: googleCloud,
+            groq: groq,
+            soniox: MockTranscriber(),
+            typefluxOfficial: typefluxOfficial,
+            autoModelDownloadService: service
+        )
+
+        let result = await router.transcribeWithAutoModelIfReady(
+            audioFile: dummyAudioFile(),
+            onUpdate: { _ in }
+        )
+
+        XCTAssertNil(result)
+        let deadline = Date().addingTimeInterval(2)
+        while service.status != .completed, Date() < deadline {
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+        XCTAssertEqual(service.status, .completed)
+    }
+
     // MARK: - prepareForRecording
 
     func testPrepareForRecordingDelegatesToDoubaoRealtime() async {


### PR DESCRIPTION
## Summary

- make SenseVoice a system-managed baseline independent of the local optimization preference
- use the prepared model manifest as the single source of truth, coalesce concurrent installs, and self-repair invalid files
- prevent deleting the SenseVoice baseline from Models settings while retaining repair/re-download actions
- allow fallback routing to use the baseline even when local optimization is disabled

## Testing

- `swift test --filter LocalModelTranscriberTests` — 39 passed
- `swift test --filter STTRouterTests.testAutoModelFallbackReconcilesBaselineWhenOptimizationIsDisabled` — 1 passed
- `swift test --enable-code-coverage --filter LocalModelTranscriberTests` — 39 passed; `AutoModelDownloadService.swift` line coverage 81.61%
- `swift test` — 2515/2523 passed; 8 existing Persona localization assertions fail in untouched code

Closes GUL-79
