### PR TITLE
GUL-80: run client tests only on @autotest comments

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,25 +1,30 @@
 name: Tests
 
 on:
-  pull_request:
-    branches: [ main ]
-    paths-ignore:
-      - "**/*.md"
-      - "docs/**"
-      - "marketing/**"
-      - ".github/workflows/release.yml"
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
 
 concurrency:
-  group: tests-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: tests-autotest-${{ github.event.issue.number }}
   cancel-in-progress: true
 
 jobs:
   test:
+    if: >-
+      github.event.issue.pull_request &&
+      github.event.issue.state == 'open' &&
+      contains(github.event.comment.body, '@autotest') &&
+      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
     runs-on: macos-latest
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: refs/pull/${{ github.event.issue.number }}/merge
 
       - name: Run tests
         run: swift test

--- a/README.md
+++ b/README.md
@@ -124,6 +124,9 @@ make release-continue # resume an interrupted local release
 swift test        # run tests
 ```
 
+CI tests are opt-in. On an open pull request, a repository owner, member, or
+collaborator can comment `@autotest` to run the test workflow.
+
 > ⚠️ If you skip `setup_dev_cert.sh`, `make run` still works but macOS will re-prompt for permissions on each build (ad-hoc signing).
 
 See [CLAUDE.md](./CLAUDE.md) for the full development guide.


### PR DESCRIPTION
## Summary
- stop running the client test workflow on every pull request update
- run it only when an authorized collaborator comments `@autotest` on an open pull request
- check out the pull request merge ref and cancel superseded runs
- document the opt-in trigger

The disabled `.github/workflows/coverage.yml.bak` and the release workflow are intentionally unchanged.

## Validation
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/test.yml` — passed
- `git diff --check` — passed
- `swift test` — 2,516 of 2,524 XCTest cases passed; 8 pre-existing Persona localization assertions failed consistently (6 in `SettingsStorePersonaTests`, 2 in `SettingsViewModelPersonaTests`); the separate 8-case Swift Testing suite passed

Closes GUL-80