### PR TITLE
GUL-75 Make selection replacement transactional

### DIFF
--- a/Sources/Typeflux/TextInjection/AXTextInjector+AX.swift
+++ b/Sources/Typeflux/TextInjection/AXTextInjector+AX.swift
@@ -4,6 +4,7 @@ import Foundation
 
 extension AXTextInjector {
     func copyStringAttribute(_ attribute: String, from element: AXUIElement) -> String? {
+        AXUIElementSetMessagingTimeout(element, Self.replacementAXMessagingTimeout)
         var value: AnyObject?
         let result = AXUIElementCopyAttributeValue(element, attribute as CFString, &value)
         guard result == .success else { return nil }
@@ -11,24 +12,31 @@ extension AXTextInjector {
     }
 
     func copyElementAttribute(_ attribute: String, from element: AXUIElement) -> AXUIElement? {
+        AXUIElementSetMessagingTimeout(element, Self.replacementAXMessagingTimeout)
         var value: AnyObject?
         let result = AXUIElementCopyAttributeValue(element, attribute as CFString, &value)
         guard result == .success, let value else { return nil }
         guard CFGetTypeID(value) == AXUIElementGetTypeID() else { return nil }
-        return unsafeBitCast(value, to: AXUIElement.self)
+        let child = unsafeBitCast(value, to: AXUIElement.self)
+        AXUIElementSetMessagingTimeout(child, Self.replacementAXMessagingTimeout)
+        return child
     }
 
     func copyElementArrayAttribute(_ attribute: String, from element: AXUIElement) -> [AXUIElement] {
+        AXUIElementSetMessagingTimeout(element, Self.replacementAXMessagingTimeout)
         var value: AnyObject?
         let result = AXUIElementCopyAttributeValue(element, attribute as CFString, &value)
         guard result == .success, let array = value as? [AnyObject] else { return [] }
         return array.compactMap { item in
             guard CFGetTypeID(item) == AXUIElementGetTypeID() else { return nil }
-            return unsafeBitCast(item, to: AXUIElement.self)
+            let child = unsafeBitCast(item, to: AXUIElement.self)
+            AXUIElementSetMessagingTimeout(child, Self.replacementAXMessagingTimeout)
+            return child
         }
     }
 
     func copyTextAttribute(_ attribute: String, from element: AXUIElement) -> String? {
+        AXUIElementSetMessagingTimeout(element, Self.replacementAXMessagingTimeout)
         var value: AnyObject?
         let result = AXUIElementCopyAttributeValue(element, attribute as CFString, &value)
         guard result == .success, let value else { return nil }
@@ -45,6 +53,7 @@ extension AXTextInjector {
     }
 
     func copySelectedTextRange(from element: AXUIElement) -> CFRange? {
+        AXUIElementSetMessagingTimeout(element, Self.replacementAXMessagingTimeout)
         var value: AnyObject?
         let result = AXUIElementCopyAttributeValue(
             element,
@@ -64,6 +73,7 @@ extension AXTextInjector {
 
     @discardableResult
     func setSelectedTextRange(_ range: CFRange, on element: AXUIElement) -> Bool {
+        AXUIElementSetMessagingTimeout(element, Self.replacementAXMessagingTimeout)
         var mutableRange = range
         guard let axRange = AXValueCreate(.cfRange, &mutableRange) else { return false }
         let result = AXUIElementSetAttributeValue(
@@ -76,6 +86,7 @@ extension AXTextInjector {
 
     @discardableResult
     func setFocused(_ focused: Bool, on element: AXUIElement) -> Bool {
+        AXUIElementSetMessagingTimeout(element, Self.replacementAXMessagingTimeout)
         let value: CFBoolean = focused ? true as CFBoolean : false as CFBoolean
         let result = AXUIElementSetAttributeValue(
             element,
@@ -98,6 +109,7 @@ extension AXTextInjector {
     }
 
     func copyBooleanAttribute(_ attribute: String, from element: AXUIElement) -> Bool? {
+        AXUIElementSetMessagingTimeout(element, Self.replacementAXMessagingTimeout)
         var value: AnyObject?
         let result = AXUIElementCopyAttributeValue(element, attribute as CFString, &value)
         guard result == .success, let number = value as? NSNumber else { return nil }
@@ -105,6 +117,7 @@ extension AXTextInjector {
     }
 
     func copyCGPointAttribute(_ attribute: String, from element: AXUIElement) -> CGPoint? {
+        AXUIElementSetMessagingTimeout(element, Self.replacementAXMessagingTimeout)
         var value: AnyObject?
         let result = AXUIElementCopyAttributeValue(element, attribute as CFString, &value)
         guard result == .success, let axValue = value else { return nil }
@@ -119,6 +132,7 @@ extension AXTextInjector {
     }
 
     func copyCGSizeAttribute(_ attribute: String, from element: AXUIElement) -> CGSize? {
+        AXUIElementSetMessagingTimeout(element, Self.replacementAXMessagingTimeout)
         var value: AnyObject?
         let result = AXUIElementCopyAttributeValue(element, attribute as CFString, &value)
         guard result == .success, let axValue = value else { return nil }

--- a/Sources/Typeflux/TextInjection/AXTextInjector+Paste.swift
+++ b/Sources/Typeflux/TextInjection/AXTextInjector+Paste.swift
@@ -12,6 +12,13 @@ extension AXTextInjector {
             return
         }
 
+        guard !replaceSelection else {
+            throw selectionReplacementError(
+                code: 32,
+                description: "External selection replacement requires a captured target"
+            )
+        }
+
         if TypefluxWindowIdentity.isAskAnswerWindow(typefluxFrontmostWindow()) {
             NetworkDebugLogger.logMessage(
                 "[Text Injection] blocked Typeflux Ask Answer window before AX write"
@@ -246,6 +253,13 @@ extension AXTextInjector {
         replaceSelection: Bool,
         contextAlreadyRestored: Bool = false
     ) throws {
+        guard !replaceSelection else {
+            throw selectionReplacementError(
+                code: 32,
+                description: "External selection replacement requires a captured target"
+            )
+        }
+
         let pasteboard = NSPasteboard.general
         let previousSnapshot = capturePasteboardSnapshot(from: pasteboard)
         let strictFallbackEnabled = settingsStore?.strictEditApplyFallbackEnabled ?? false

--- a/Sources/Typeflux/TextInjection/AXTextInjector+Paste.swift
+++ b/Sources/Typeflux/TextInjection/AXTextInjector+Paste.swift
@@ -261,7 +261,9 @@ extension AXTextInjector {
         }
 
         let pasteboard = NSPasteboard.general
-        let previousSnapshot = capturePasteboardSnapshot(from: pasteboard)
+        // The external replacement branch below is retained only for source compatibility;
+        // the guard above makes it unreachable. Never materialize arbitrary clipboard data.
+        let previousSnapshot = PasteboardSnapshot(items: [])
         let strictFallbackEnabled = settingsStore?.strictEditApplyFallbackEnabled ?? false
         let stubbornPasteFallbackEnabled = settingsStore?.stubbornPasteFallbackEnabled ?? false
         let replacementContext = replaceSelection ? activeSelectionContext() : nil
@@ -299,10 +301,6 @@ extension AXTextInjector {
                 )
             }
             dispatchPasteShortcut(method: dispatchMethod, targetPID: targetPID)
-            restorePasteboardAfterPaste(
-                previousSnapshot,
-                delayNanoseconds: Self.unverifiedPasteRestoreDelayNanoseconds
-            )
             NetworkDebugLogger.logMessage("[Text Injection] eager paste dispatched")
             return
         }
@@ -644,7 +642,6 @@ extension AXTextInjector {
 
     func readSelectedTextViaCopy(processID: pid_t?, milliseconds: Int) -> String? {
         let pasteboard = NSPasteboard.general
-        let previousSnapshot = capturePasteboardSnapshot(from: pasteboard)
         let previousChangeCount = pasteboard.changeCount
 
         sendCopyShortcut(to: processID)
@@ -652,22 +649,33 @@ extension AXTextInjector {
         let timeout = Date().addingTimeInterval(Double(milliseconds) / 1000.0)
         while Date() < timeout {
             if pasteboard.changeCount != previousChangeCount {
-                let copiedText = pasteboard.string(forType: .string)
-                restorePasteboardAfterPaste(
-                    previousSnapshot,
-                    delayNanoseconds: Self.legacyPasteRestoreDelayNanoseconds
-                )
+                let copiedText = readPasteboardStringWithTimeout()
                 let trimmed = copiedText?.trimmingCharacters(in: .whitespacesAndNewlines)
                 return trimmed?.isEmpty == false ? trimmed : nil
             }
             usleep(10000)
         }
 
-        restorePasteboardAfterPaste(
-            previousSnapshot,
-            delayNanoseconds: Self.legacyPasteRestoreDelayNanoseconds
-        )
         return nil
+    }
+
+    /// Pasteboard owners can provide data lazily and may block indefinitely. Read on a
+    /// dedicated serial queue so a broken provider cannot freeze Typeflux's main thread.
+    /// Once that queue is wedged, later reads still time out without creating more workers.
+    func readPasteboardStringWithTimeout() -> String? {
+        let result = LockedPasteboardStringResult()
+        let completed = DispatchSemaphore(value: 0)
+        pasteboardReadQueue.async {
+            result.store(NSPasteboard.general.string(forType: .string))
+            completed.signal()
+        }
+        guard completed.wait(
+            timeout: .now() + .milliseconds(Self.pasteboardReadTimeoutMilliseconds)
+        ) == .success else {
+            NetworkDebugLogger.logMessage("[Text Injection] pasteboard string read timed out")
+            return nil
+        }
+        return result.load()
     }
 
     func activateTargetProcess(_ processID: pid_t?) {

--- a/Sources/Typeflux/TextInjection/AXTextInjector+Selection.swift
+++ b/Sources/Typeflux/TextInjection/AXTextInjector+Selection.swift
@@ -154,7 +154,7 @@ extension AXTextInjector {
             range: range,
             processID: processID,
             processName: frontmostApplicationName(),
-            selectedText: trimmed,
+            selectedText: text,
             role: role,
             windowTitle: selectionWindow.flatMap(windowTitle(of:)),
             isFocusedTarget: isFocusedTarget,
@@ -1182,6 +1182,30 @@ extension AXTextInjector {
             return nil
         }
         return latestSelectionContext
+    }
+
+    func registerSelectionContext(_ context: SelectionContext) -> UUID {
+        let contextID = UUID()
+        let expiry = Date().addingTimeInterval(-Self.selectionContextLifetime)
+        selectionContextLock.lock()
+        selectionContexts = selectionContexts.filter { $0.value.capturedAt >= expiry }
+        if selectionContexts.count >= Self.maximumSelectionContextCount,
+           let oldestID = selectionContexts.min(by: { $0.value.capturedAt < $1.value.capturedAt })?.key {
+            selectionContexts.removeValue(forKey: oldestID)
+        }
+        selectionContexts[contextID] = context
+        selectionContextLock.unlock()
+        return contextID
+    }
+
+    func consumeSelectionContext(id: UUID) -> SelectionContext? {
+        selectionContextLock.lock()
+        defer { selectionContextLock.unlock() }
+        guard let context = selectionContexts.removeValue(forKey: id) else { return nil }
+        guard Date().timeIntervalSince(context.capturedAt) <= Self.selectionContextLifetime else {
+            return nil
+        }
+        return context
     }
 
     func restoreSelectionContext(_ context: SelectionContext) {

--- a/Sources/Typeflux/TextInjection/AXTextInjector+Selection.swift
+++ b/Sources/Typeflux/TextInjection/AXTextInjector+Selection.swift
@@ -96,8 +96,16 @@ extension AXTextInjector {
         return systemFocusedElement()
     }
 
-    func readSelectedText() -> (text: String, context: SelectionContext)? {
-        guard let element = focusedElement() else {
+    func readSelectedText(
+        processID: pid_t?,
+        processName: String?
+    ) -> (text: String, context: SelectionContext)? {
+        guard let processID else {
+            return nil
+        }
+        let application = AXUIElementCreateApplication(processID)
+        AXUIElementSetMessagingTimeout(application, Self.replacementAXMessagingTimeout)
+        guard let element = lightweightFocusedElement(application: application) else {
             return nil
         }
 
@@ -142,8 +150,7 @@ extension AXTextInjector {
 
         guard let range else { return nil }
 
-        let processID = frontmostProcessID()
-        let focusedWindow = processID.flatMap(focusedWindowElement(for:))
+        let focusedWindow = focusedWindowElement(for: processID)
         let selectionWindow = containingWindow(of: element)
         let isFocusedTarget = focusedWindow.map { window in
             selectionWindow.map { selection in windowsMatch(window, selection) } ?? true
@@ -153,9 +160,13 @@ extension AXTextInjector {
             element: element,
             range: range,
             processID: processID,
-            processName: frontmostApplicationName(),
+            processName: processName,
             selectedText: text,
             role: role,
+            subrole: copyStringAttribute(kAXSubroleAttribute as String, from: element),
+            identifier: copyStringAttribute(kAXIdentifierAttribute as String, from: element),
+            position: copyCGPointAttribute(kAXPositionAttribute as String, from: element),
+            size: copyCGSizeAttribute(kAXSizeAttribute as String, from: element),
             windowTitle: selectionWindow.flatMap(windowTitle(of:)),
             isFocusedTarget: isFocusedTarget,
             source: "accessibility",
@@ -166,6 +177,7 @@ extension AXTextInjector {
     }
 
     func isAttributeSettable(_ attribute: CFString, on element: AXUIElement) -> Bool {
+        AXUIElementSetMessagingTimeout(element, Self.replacementAXMessagingTimeout)
         var settable = DarwinBoolean(false)
         let status = AXUIElementIsAttributeSettable(element, attribute, &settable)
         return status == .success && settable.boolValue
@@ -203,6 +215,7 @@ extension AXTextInjector {
 
     func systemFocusedElement() -> AXUIElement? {
         let system = AXUIElementCreateSystemWide()
+        AXUIElementSetMessagingTimeout(system, Self.replacementAXMessagingTimeout)
         if let focused = copyElementAttribute(kAXFocusedUIElementAttribute as String, from: system),
            let resolved = resolveFocusedElement(focused) {
             logFocusResolution(
@@ -218,6 +231,7 @@ extension AXTextInjector {
 
     func focusedElement(for processID: pid_t) -> AXUIElement? {
         let appElement = AXUIElementCreateApplication(processID)
+        AXUIElementSetMessagingTimeout(appElement, Self.replacementAXMessagingTimeout)
 
         if let focused = copyElementAttribute(kAXFocusedUIElementAttribute as String, from: appElement),
            let resolved = resolveFocusedElement(focused) {
@@ -244,6 +258,7 @@ extension AXTextInjector {
 
     func focusedWindowElement(for processID: pid_t) -> AXUIElement? {
         let appElement = AXUIElementCreateApplication(processID)
+        AXUIElementSetMessagingTimeout(appElement, Self.replacementAXMessagingTimeout)
         return copyElementAttribute(kAXFocusedWindowAttribute as String, from: appElement)
     }
 
@@ -1182,6 +1197,19 @@ extension AXTextInjector {
             return nil
         }
         return latestSelectionContext
+    }
+
+    func clearLatestSelectionContext(ifMatching context: SelectionContext) {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        guard let latest = storedLatestSelectionContext,
+              latest.capturedAt == context.capturedAt,
+              latest.processID == context.processID,
+              CFEqual(latest.element, context.element)
+        else {
+            return
+        }
+        storedLatestSelectionContext = nil
     }
 
     func registerSelectionContext(_ context: SelectionContext) -> UUID {

--- a/Sources/Typeflux/TextInjection/AXTextInjector+Transaction.swift
+++ b/Sources/Typeflux/TextInjection/AXTextInjector+Transaction.swift
@@ -1,0 +1,261 @@
+import AppKit
+import ApplicationServices
+import Foundation
+
+extension AXTextInjector {
+    enum SelectionReplacementPreparation: Equatable {
+        case committedViaAX
+        case requiresPaste
+    }
+
+    static func capturedSelectionStillMatches(
+        source: String,
+        elementMatches: Bool,
+        capturedRange: CFRange?,
+        currentRange: CFRange?,
+        capturedText: String?,
+        currentText: String?,
+        capturedRole: String?,
+        currentRole: String?,
+        capturedWindowTitle: String?,
+        currentWindowTitle: String?
+    ) -> Bool {
+        if source == "clipboard-copy" {
+            return elementMatches
+        }
+
+        guard capturedRange?.location == currentRange?.location,
+              capturedRange?.length == currentRange?.length,
+              capturedText == currentText
+        else {
+            return false
+        }
+
+        if elementMatches {
+            return true
+        }
+
+        guard capturedRole == currentRole,
+              let capturedWindowTitle = capturedWindowTitle?.trimmingCharacters(in: .whitespacesAndNewlines),
+              let currentWindowTitle = currentWindowTitle?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !capturedWindowTitle.isEmpty,
+              capturedWindowTitle == currentWindowTitle
+        else {
+            return false
+        }
+
+        return true
+    }
+
+    func replaceSelection(text: String, target: TextSelectionSnapshot?) async throws {
+        if target?.source == "typeflux-native" {
+            try await MainActor.run {
+                guard try self.insertIntoTypefluxNativeTextTarget(text, replaceSelection: true) else {
+                    throw self.selectionReplacementError(
+                        code: 20,
+                        description: "The Typeflux selection is no longer available"
+                    )
+                }
+                self.lastInjectionMethod = .ax
+            }
+            return
+        }
+
+        guard let contextID = target?.replacementContextID,
+              let context = consumeSelectionContext(id: contextID)
+        else {
+            throw selectionReplacementError(
+                code: 21,
+                description: "The captured selection is no longer available"
+            )
+        }
+
+        let preparation = try await performSelectionReplacementWork {
+            try self.prepareSelectionReplacement(text: text, context: context)
+        }
+
+        switch preparation {
+        case .committedViaAX:
+            lastInjectionMethod = .ax
+        case .requiresPaste:
+            try await prepareEagerPasteboard(text: text, targetProcessID: context.processID)
+            try await performSelectionReplacementWork {
+                try self.dispatchSelectionPaste(context: context)
+            }
+            lastInjectionMethod = .paste
+        }
+
+        latestSelectionContext = nil
+    }
+
+    func performSelectionReplacementWork<T>(
+        _ work: @escaping () throws -> T
+    ) async throws -> T {
+        try await withCheckedThrowingContinuation { continuation in
+            selectionReplacementQueue.async {
+                do {
+                    continuation.resume(returning: try work())
+                } catch {
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
+    }
+
+    func prepareSelectionReplacement(
+        text: String,
+        context: SelectionContext
+    ) throws -> SelectionReplacementPreparation {
+        let element = try validatedCurrentSelectionElement(context: context)
+
+        guard let range = context.range,
+              isAttributeSettable(kAXSelectedTextAttribute as CFString, on: element)
+        else {
+            return .requiresPaste
+        }
+
+        guard setSelectedTextRange(range, on: element) else {
+            throw selectionReplacementError(
+                code: 22,
+                description: "The selected text range changed before replacement"
+            )
+        }
+
+        let result = AXUIElementSetAttributeValue(
+            element,
+            kAXSelectedTextAttribute as CFString,
+            text as CFTypeRef
+        )
+        switch result {
+        case .success:
+            NetworkDebugLogger.logMessage(
+                "[Text Injection] selection transaction committed via AX"
+            )
+            return .committedViaAX
+        case .attributeUnsupported, .notImplemented, .illegalArgument:
+            return .requiresPaste
+        default:
+            // A timeout/cannot-complete response is ambiguous: the target may have applied
+            // the write before the reply was lost. Never send Cmd+V after an ambiguous AX write.
+            throw selectionReplacementError(
+                code: 23,
+                description: "The target did not acknowledge the selection replacement"
+            )
+        }
+    }
+
+    func dispatchSelectionPaste(context: SelectionContext) throws {
+        _ = try validatedCurrentSelectionElement(context: context)
+        guard let processID = context.processID else {
+            throw selectionReplacementError(code: 24, description: "The target application is unavailable")
+        }
+
+        let source = CGEventSource(stateID: .combinedSessionState)
+        guard let keyDown = CGEvent(keyboardEventSource: source, virtualKey: 0x09, keyDown: true),
+              let keyUp = CGEvent(keyboardEventSource: source, virtualKey: 0x09, keyDown: false)
+        else {
+            throw selectionReplacementError(code: 25, description: "Unable to create the paste shortcut")
+        }
+        keyDown.flags = .maskCommand
+        keyUp.flags = .maskCommand
+        keyDown.postToPid(processID)
+        keyUp.postToPid(processID)
+        NetworkDebugLogger.logMessage(
+            "[Text Injection] selection transaction dispatched via eager paste"
+        )
+    }
+
+    func validatedCurrentSelectionElement(context: SelectionContext) throws -> AXUIElement {
+        guard Date().timeIntervalSince(context.capturedAt) <= Self.selectionContextLifetime else {
+            throw selectionReplacementError(code: 26, description: "The captured selection expired")
+        }
+        guard let processID = context.processID,
+              frontmostProcessID() == processID
+        else {
+            throw selectionReplacementError(
+                code: 27,
+                description: "The user moved away from the captured selection"
+            )
+        }
+
+        let application = AXUIElementCreateApplication(processID)
+        AXUIElementSetMessagingTimeout(application, Self.replacementAXMessagingTimeout)
+        AXUIElementSetMessagingTimeout(context.element, Self.replacementAXMessagingTimeout)
+
+        guard let currentElement = lightweightFocusedElement(application: application) else {
+            throw selectionReplacementError(code: 28, description: "The target no longer has a focused input")
+        }
+        AXUIElementSetMessagingTimeout(currentElement, Self.replacementAXMessagingTimeout)
+
+        let elementMatches = CFEqual(context.element, currentElement)
+        let currentRange = copySelectedTextRange(from: currentElement)
+        let currentText = copyStringAttribute(kAXSelectedTextAttribute as String, from: currentElement)
+        let currentRole = copyStringAttribute(kAXRoleAttribute as String, from: currentElement)
+        let currentWindowTitle = lightweightWindowTitle(of: currentElement)
+
+        guard Self.capturedSelectionStillMatches(
+            source: context.source,
+            elementMatches: elementMatches,
+            capturedRange: context.range,
+            currentRange: currentRange,
+            capturedText: context.selectedText,
+            currentText: currentText,
+            capturedRole: context.role,
+            currentRole: currentRole,
+            capturedWindowTitle: context.windowTitle,
+            currentWindowTitle: currentWindowTitle
+        ) else {
+            throw selectionReplacementError(
+                code: 29,
+                description: "The selected text changed while the result was being generated"
+            )
+        }
+
+        return currentElement
+    }
+
+    func lightweightFocusedElement(application: AXUIElement) -> AXUIElement? {
+        guard let focused = copyElementAttribute(kAXFocusedUIElementAttribute as String, from: application) else {
+            return nil
+        }
+        guard copyStringAttribute(kAXRoleAttribute as String, from: focused) == kAXWindowRole as String else {
+            return focused
+        }
+        return copyElementAttribute(kAXFocusedUIElementAttribute as String, from: focused) ?? focused
+    }
+
+    func lightweightWindowTitle(of element: AXUIElement) -> String? {
+        if let window = copyElementAttribute(kAXWindowAttribute as String, from: element) {
+            AXUIElementSetMessagingTimeout(window, Self.replacementAXMessagingTimeout)
+            return copyTextAttribute(kAXTitleAttribute as String, from: window)
+        }
+        return nil
+    }
+
+    func prepareEagerPasteboard(text: String, targetProcessID: pid_t?) async throws {
+        try await MainActor.run {
+            guard NSWorkspace.shared.frontmostApplication?.processIdentifier == targetProcessID else {
+                throw self.selectionReplacementError(
+                    code: 30,
+                    description: "The user moved away from the captured selection"
+                )
+            }
+            let pasteboard = NSPasteboard.general
+            pasteboard.clearContents()
+            guard pasteboard.setString(text, forType: .string) else {
+                throw self.selectionReplacementError(
+                    code: 31,
+                    description: "Unable to prepare the replacement text"
+                )
+            }
+        }
+    }
+
+    func selectionReplacementError(code: Int, description: String) -> NSError {
+        NSError(
+            domain: "AXTextInjector.SelectionTransaction",
+            code: code,
+            userInfo: [NSLocalizedDescriptionKey: description]
+        )
+    }
+}

--- a/Sources/Typeflux/TextInjection/AXTextInjector+Transaction.swift
+++ b/Sources/Typeflux/TextInjection/AXTextInjector+Transaction.swift
@@ -17,11 +17,19 @@ extension AXTextInjector {
         currentText: String?,
         capturedRole: String?,
         currentRole: String?,
+        capturedSubrole: String? = nil,
+        currentSubrole: String? = nil,
+        capturedIdentifier: String? = nil,
+        currentIdentifier: String? = nil,
+        capturedPosition: CGPoint? = nil,
+        currentPosition: CGPoint? = nil,
+        capturedSize: CGSize? = nil,
+        currentSize: CGSize? = nil,
         capturedWindowTitle: String?,
         currentWindowTitle: String?
     ) -> Bool {
         if source == "clipboard-copy" {
-            return elementMatches
+            return elementMatches && capturedText == currentText
         }
 
         guard capturedRange?.location == currentRange?.location,
@@ -35,7 +43,12 @@ extension AXTextInjector {
             return true
         }
 
+        let identifierMatches = capturedIdentifier?.isEmpty == false && capturedIdentifier == currentIdentifier
+        let frameMatches = capturedPosition != nil && capturedPosition == currentPosition &&
+            capturedSize != nil && capturedSize == currentSize
         guard capturedRole == currentRole,
+              capturedSubrole == currentSubrole,
+              identifierMatches || frameMatches,
               let capturedWindowTitle = capturedWindowTitle?.trimmingCharacters(in: .whitespacesAndNewlines),
               let currentWindowTitle = currentWindowTitle?.trimmingCharacters(in: .whitespacesAndNewlines),
               !capturedWindowTitle.isEmpty,
@@ -48,15 +61,21 @@ extension AXTextInjector {
     }
 
     func replaceSelection(text: String, target: TextSelectionSnapshot?) async throws {
+        try Task.checkCancellation()
         if target?.source == "typeflux-native" {
+            let injector = UncheckedSendableReference(self)
             try await MainActor.run {
-                guard try self.insertIntoTypefluxNativeTextTarget(text, replaceSelection: true) else {
-                    throw self.selectionReplacementError(
+                try Task.checkCancellation()
+                guard try injector.value.insertIntoTypefluxNativeTextTarget(
+                    text,
+                    replaceSelection: true
+                ) else {
+                    throw injector.value.selectionReplacementError(
                         code: 20,
                         description: "The Typeflux selection is no longer available"
                     )
                 }
-                self.lastInjectionMethod = .ax
+                injector.value.lastInjectionMethod = .ax
             }
             return
         }
@@ -70,31 +89,50 @@ extension AXTextInjector {
             )
         }
 
+        try Task.checkCancellation()
+        let currentProcessID = await MainActor.run {
+            NSWorkspace.shared.frontmostApplication?.processIdentifier
+        }
+        try Task.checkCancellation()
         let preparation = try await performSelectionReplacementWork {
-            try self.prepareSelectionReplacement(text: text, context: context)
+            try self.prepareSelectionReplacement(
+                text: text,
+                context: context,
+                currentFrontmostProcessID: currentProcessID
+            )
         }
 
         switch preparation {
         case .committedViaAX:
             lastInjectionMethod = .ax
         case .requiresPaste:
+            try Task.checkCancellation()
             try await prepareEagerPasteboard(text: text, targetProcessID: context.processID)
+            try Task.checkCancellation()
+            let pasteProcessID = await MainActor.run {
+                NSWorkspace.shared.frontmostApplication?.processIdentifier
+            }
+            try Task.checkCancellation()
             try await performSelectionReplacementWork {
-                try self.dispatchSelectionPaste(context: context)
+                try self.dispatchSelectionPaste(
+                    context: context,
+                    currentFrontmostProcessID: pasteProcessID
+                )
             }
             lastInjectionMethod = .paste
         }
 
-        latestSelectionContext = nil
+        clearLatestSelectionContext(ifMatching: context)
     }
 
     func performSelectionReplacementWork<T>(
         _ work: @escaping () throws -> T
     ) async throws -> T {
-        try await withCheckedThrowingContinuation { continuation in
+        let sendableWork = UncheckedSendableReference(work)
+        return try await withCheckedThrowingContinuation { continuation in
             selectionReplacementQueue.async {
                 do {
-                    continuation.resume(returning: try work())
+                    continuation.resume(returning: try sendableWork.value())
                 } catch {
                     continuation.resume(throwing: error)
                 }
@@ -104,9 +142,14 @@ extension AXTextInjector {
 
     func prepareSelectionReplacement(
         text: String,
-        context: SelectionContext
+        context: SelectionContext,
+        currentFrontmostProcessID: pid_t?
     ) throws -> SelectionReplacementPreparation {
-        let element = try validatedCurrentSelectionElement(context: context)
+        let element = try validatedCurrentSelectionElement(
+            context: context,
+            currentFrontmostProcessID: currentFrontmostProcessID,
+            verifyClipboardText: true
+        )
 
         guard let range = context.range,
               isAttributeSettable(kAXSelectedTextAttribute as CFString, on: element)
@@ -144,8 +187,15 @@ extension AXTextInjector {
         }
     }
 
-    func dispatchSelectionPaste(context: SelectionContext) throws {
-        _ = try validatedCurrentSelectionElement(context: context)
+    func dispatchSelectionPaste(
+        context: SelectionContext,
+        currentFrontmostProcessID: pid_t?
+    ) throws {
+        _ = try validatedCurrentSelectionElement(
+            context: context,
+            currentFrontmostProcessID: currentFrontmostProcessID,
+            verifyClipboardText: false
+        )
         guard let processID = context.processID else {
             throw selectionReplacementError(code: 24, description: "The target application is unavailable")
         }
@@ -165,12 +215,16 @@ extension AXTextInjector {
         )
     }
 
-    func validatedCurrentSelectionElement(context: SelectionContext) throws -> AXUIElement {
+    func validatedCurrentSelectionElement(
+        context: SelectionContext,
+        currentFrontmostProcessID: pid_t?,
+        verifyClipboardText: Bool
+    ) throws -> AXUIElement {
         guard Date().timeIntervalSince(context.capturedAt) <= Self.selectionContextLifetime else {
             throw selectionReplacementError(code: 26, description: "The captured selection expired")
         }
         guard let processID = context.processID,
-              frontmostProcessID() == processID
+              currentFrontmostProcessID == processID
         else {
             throw selectionReplacementError(
                 code: 27,
@@ -189,8 +243,33 @@ extension AXTextInjector {
 
         let elementMatches = CFEqual(context.element, currentElement)
         let currentRange = copySelectedTextRange(from: currentElement)
-        let currentText = copyStringAttribute(kAXSelectedTextAttribute as String, from: currentElement)
+        let currentText: String?
+        if context.source == "clipboard-copy", verifyClipboardText {
+            currentText = readSelectedTextViaCopy(
+                processID: processID,
+                milliseconds: Self.copySelectionTimeoutMilliseconds
+            )
+            guard let focusedAfterCopy = lightweightFocusedElement(application: application),
+                  CFEqual(currentElement, focusedAfterCopy)
+            else {
+                throw selectionReplacementError(
+                    code: 29,
+                    description: "The selected text changed while the result was being generated"
+                )
+            }
+        } else if context.source == "clipboard-copy" {
+            // The clipboard already contains the replacement at dispatch time. The
+            // selection text was re-copied and verified during preparation; copying
+            // again here would overwrite the replacement immediately before Cmd+V.
+            currentText = context.selectedText
+        } else {
+            currentText = copyStringAttribute(kAXSelectedTextAttribute as String, from: currentElement)
+        }
         let currentRole = copyStringAttribute(kAXRoleAttribute as String, from: currentElement)
+        let currentSubrole = copyStringAttribute(kAXSubroleAttribute as String, from: currentElement)
+        let currentIdentifier = copyStringAttribute(kAXIdentifierAttribute as String, from: currentElement)
+        let currentPosition = copyCGPointAttribute(kAXPositionAttribute as String, from: currentElement)
+        let currentSize = copyCGSizeAttribute(kAXSizeAttribute as String, from: currentElement)
         let currentWindowTitle = lightweightWindowTitle(of: currentElement)
 
         guard Self.capturedSelectionStillMatches(
@@ -202,6 +281,14 @@ extension AXTextInjector {
             currentText: currentText,
             capturedRole: context.role,
             currentRole: currentRole,
+            capturedSubrole: context.subrole,
+            currentSubrole: currentSubrole,
+            capturedIdentifier: context.identifier,
+            currentIdentifier: currentIdentifier,
+            capturedPosition: context.position,
+            currentPosition: currentPosition,
+            capturedSize: context.size,
+            currentSize: currentSize,
             capturedWindowTitle: context.windowTitle,
             currentWindowTitle: currentWindowTitle
         ) else {
@@ -233,9 +320,11 @@ extension AXTextInjector {
     }
 
     func prepareEagerPasteboard(text: String, targetProcessID: pid_t?) async throws {
+        let injector = UncheckedSendableReference(self)
         try await MainActor.run {
+            try Task.checkCancellation()
             guard NSWorkspace.shared.frontmostApplication?.processIdentifier == targetProcessID else {
-                throw self.selectionReplacementError(
+                throw injector.value.selectionReplacementError(
                     code: 30,
                     description: "The user moved away from the captured selection"
                 )
@@ -243,7 +332,7 @@ extension AXTextInjector {
             let pasteboard = NSPasteboard.general
             pasteboard.clearContents()
             guard pasteboard.setString(text, forType: .string) else {
-                throw self.selectionReplacementError(
+                throw injector.value.selectionReplacementError(
                     code: 31,
                     description: "Unable to prepare the replacement text"
                 )

--- a/Sources/Typeflux/TextInjection/AXTextInjector.swift
+++ b/Sources/Typeflux/TextInjection/AXTextInjector.swift
@@ -59,6 +59,31 @@ final class PasteboardDeliveryProbe: NSObject, NSPasteboardItemDataProvider, @un
     func pasteboardFinishedWithDataProvider(_: NSPasteboard) {}
 }
 
+final class LockedPasteboardStringResult: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value: String?
+
+    func store(_ value: String?) {
+        lock.lock()
+        self.value = value
+        lock.unlock()
+    }
+
+    func load() -> String? {
+        lock.lock()
+        defer { lock.unlock() }
+        return value
+    }
+}
+
+final class UncheckedSendableReference<Value>: @unchecked Sendable {
+    let value: Value
+
+    init(_ value: Value) {
+        self.value = value
+    }
+}
+
 final class AXTextInjector: TextInjector {
     static let nativeEditableRoles: Set<String> = [
         "AXTextArea",
@@ -159,10 +184,46 @@ final class AXTextInjector: TextInjector {
         let processName: String?
         let selectedText: String?
         let role: String?
+        let subrole: String?
+        let identifier: String?
+        let position: CGPoint?
+        let size: CGSize?
         let windowTitle: String?
         let isFocusedTarget: Bool
         let source: String
         let capturedAt: Date
+
+        init(
+            element: AXUIElement,
+            range: CFRange?,
+            processID: pid_t?,
+            processName: String?,
+            selectedText: String?,
+            role: String?,
+            subrole: String? = nil,
+            identifier: String? = nil,
+            position: CGPoint? = nil,
+            size: CGSize? = nil,
+            windowTitle: String?,
+            isFocusedTarget: Bool,
+            source: String,
+            capturedAt: Date
+        ) {
+            self.element = element
+            self.range = range
+            self.processID = processID
+            self.processName = processName
+            self.selectedText = selectedText
+            self.role = role
+            self.subrole = subrole
+            self.identifier = identifier
+            self.position = position
+            self.size = size
+            self.windowTitle = windowTitle
+            self.isFocusedTarget = isFocusedTarget
+            self.source = source
+            self.capturedAt = capturedAt
+        }
     }
 
     struct ApplicationStateContext {
@@ -175,7 +236,18 @@ final class AXTextInjector: TextInjector {
         let window: NSWindow?
     }
 
-    static var didRequestAccessibility = false
+    struct ExternalSelectionCaptureTarget {
+        let processID: pid_t?
+        let processName: String?
+        let bundleIdentifier: String?
+    }
+
+    enum SelectionCapturePreflight {
+        case completed(TextSelectionSnapshot)
+        case external(ExternalSelectionCaptureTarget)
+    }
+
+    nonisolated(unsafe) static var didRequestAccessibility = false
     static let legacyPasteRestoreDelayNanoseconds: UInt64 = 150_000_000
     static let verifiedPasteRestoreDelayNanoseconds: UInt64 = 150_000_000
     /// Slow clipboard consumers (iTerm2 / Terminal.app / Warp bracketed paste,
@@ -201,14 +273,44 @@ final class AXTextInjector: TextInjector {
     static let maximumSelectionContextCount = 16
     static let focusedDescendantSearchDepth = 10
     static let replacementAXMessagingTimeout: Float = 0.25
+    static let pasteboardReadTimeoutMilliseconds = 250
 
-    var latestSelectionContext: SelectionContext?
-    var lastInjectionMethod: TextInjectionMethod?
+    var storedLatestSelectionContext: SelectionContext?
+    var storedLastInjectionMethod: TextInjectionMethod?
+    let stateLock = NSLock()
+    var latestSelectionContext: SelectionContext? {
+        get {
+            stateLock.lock()
+            defer { stateLock.unlock() }
+            return storedLatestSelectionContext
+        }
+        set {
+            stateLock.lock()
+            storedLatestSelectionContext = newValue
+            stateLock.unlock()
+        }
+    }
+    var lastInjectionMethod: TextInjectionMethod? {
+        get {
+            stateLock.lock()
+            defer { stateLock.unlock() }
+            return storedLastInjectionMethod
+        }
+        set {
+            stateLock.lock()
+            storedLastInjectionMethod = newValue
+            stateLock.unlock()
+        }
+    }
     var activePasteboardDeliveryProbe: PasteboardDeliveryProbe?
     let selectionContextLock = NSLock()
     var selectionContexts: [UUID: SelectionContext] = [:]
     let selectionReplacementQueue = DispatchQueue(
         label: "ai.gulu.app.typeflux.selection-replacement",
+        qos: .userInitiated
+    )
+    let pasteboardReadQueue = DispatchQueue(
+        label: "ai.gulu.app.typeflux.pasteboard-read",
         qos: .userInitiated
     )
 
@@ -615,18 +717,32 @@ final class AXTextInjector: TextInjector {
     }
 
     func getSelectionSnapshot() async -> TextSelectionSnapshot {
-        await performAXReadOnMainActor {
-            self.readSelectionSnapshot()
+        let preflight = await MainActor.run {
+            self.selectionCapturePreflight()
+        }
+        switch preflight {
+        case let .completed(snapshot):
+            return snapshot
+        case let .external(target):
+            let injector = UncheckedSendableReference(self)
+            return await withCheckedContinuation { continuation in
+                selectionReplacementQueue.async {
+                    continuation.resume(
+                        returning: injector.value.readExternalSelectionSnapshot(target: target)
+                    )
+                }
+            }
         }
     }
 
-    func readSelectionSnapshot() -> TextSelectionSnapshot {
+    @MainActor
+    func selectionCapturePreflight() -> SelectionCapturePreflight {
         if let target = typefluxNativeTextTarget() {
             NetworkDebugLogger.logMessage(
                 "[AXTextInjector] captured Typeflux native text selection"
             )
             latestSelectionContext = nil
-            return typefluxNativeSelectionSnapshot(target: target)
+            return .completed(typefluxNativeSelectionSnapshot(target: target))
         }
 
         if TypefluxWindowIdentity.isAskAnswerWindow(typefluxFrontmostWindow()) {
@@ -634,7 +750,7 @@ final class AXTextInjector: TextInjector {
                 "[AXTextInjector] skipped selection snapshot for Typeflux Ask Answer window"
             )
             latestSelectionContext = nil
-            return typefluxReadOnlyWindowSelectionSnapshot(source: "typeflux-ask-answer-window")
+            return .completed(typefluxReadOnlyWindowSelectionSnapshot(source: "typeflux-ask-answer-window"))
         }
 
         guard AXIsProcessTrusted() else {
@@ -645,7 +761,7 @@ final class AXTextInjector: TextInjector {
                     NSWorkspace.shared.open(url)
                 }
             }
-            return TextSelectionSnapshot(
+            return .completed(TextSelectionSnapshot(
                 processID: frontmostProcessID(),
                 processName: frontmostApplicationName(),
                 bundleIdentifier: frontmostApplicationBundleIdentifier(),
@@ -656,25 +772,37 @@ final class AXTextInjector: TextInjector {
                 role: nil,
                 windowTitle: nil,
                 isFocusedTarget: false
-            )
+            ))
         }
 
         let processID = frontmostProcessID()
         let processName = frontmostApplicationName()
         let bundleIdentifier = frontmostApplicationBundleIdentifier()
-        logger
-            .debug(
-                "getSelectionSnapshot — app: \(processName ?? "?", privacy: .public) (pid: \(processID.map(String.init) ?? "?", privacy: .public))"
-            )
         if isTypefluxOwnedTarget(processID: processID, bundleIdentifier: bundleIdentifier) {
             NetworkDebugLogger.logMessage(
                 "[AXTextInjector] skipped selection snapshot for Typeflux non-text frontmost target"
             )
             latestSelectionContext = nil
-            return typefluxReadOnlyWindowSelectionSnapshot(source: "typeflux-non-text-window")
+            return .completed(typefluxReadOnlyWindowSelectionSnapshot(source: "typeflux-non-text-window"))
         }
 
-        if let result = readSelectedText() {
+        return .external(ExternalSelectionCaptureTarget(
+            processID: processID,
+            processName: processName,
+            bundleIdentifier: bundleIdentifier
+        ))
+    }
+
+    func readExternalSelectionSnapshot(target: ExternalSelectionCaptureTarget) -> TextSelectionSnapshot {
+        let processID = target.processID
+        let processName = target.processName
+        let bundleIdentifier = target.bundleIdentifier
+        logger
+            .debug(
+                "getSelectionSnapshot — app: \(processName ?? "?", privacy: .public) (pid: \(processID.map(String.init) ?? "?", privacy: .public))"
+            )
+
+        if let result = readSelectedText(processID: processID, processName: processName) {
             // Compute editability from the SAME element that produced the text,
             // avoiding a race where a second focusedElement() call returns a different element.
             let editability = isLikelyEditable(element: result.context.element)
@@ -704,7 +832,11 @@ final class AXTextInjector: TextInjector {
             processID: processID,
             milliseconds: Self.copySelectionTimeoutMilliseconds
         ) {
-            let focusedElement = focusedElement()
+            let focusedElement = processID.flatMap { processID -> AXUIElement? in
+                let application = AXUIElementCreateApplication(processID)
+                AXUIElementSetMessagingTimeout(application, Self.replacementAXMessagingTimeout)
+                return lightweightFocusedElement(application: application)
+            }
             let focusedWindow = processID.flatMap(focusedWindowElement(for:))
             let selectionWindow = focusedElement.flatMap(containingWindow(of:))
             let editability = focusedElement.map(isLikelyEditable(element:)) ?? false
@@ -721,7 +853,21 @@ final class AXTextInjector: TextInjector {
                 processID: processID,
                 processName: processName,
                 selectedText: copiedText,
-                role: nil,
+                role: focusedElement.flatMap {
+                    copyStringAttribute(kAXRoleAttribute as String, from: $0)
+                },
+                subrole: focusedElement.flatMap {
+                    copyStringAttribute(kAXSubroleAttribute as String, from: $0)
+                },
+                identifier: focusedElement.flatMap {
+                    copyStringAttribute(kAXIdentifierAttribute as String, from: $0)
+                },
+                position: focusedElement.flatMap {
+                    copyCGPointAttribute(kAXPositionAttribute as String, from: $0)
+                },
+                size: focusedElement.flatMap {
+                    copyCGSizeAttribute(kAXSizeAttribute as String, from: $0)
+                },
                 windowTitle: selectionWindow.flatMap(windowTitle(of:)) ?? focusedWindowTitle(for: processID),
                 isFocusedTarget: isFocusedTarget,
                 source: "clipboard-copy",
@@ -744,7 +890,7 @@ final class AXTextInjector: TextInjector {
                 selectedText: copiedText,
                 source: "clipboard-copy",
                 isEditable: editability,
-                role: nil,
+                role: context.role,
                 windowTitle: context.windowTitle,
                 isFocusedTarget: context.isFocusedTarget,
                 replacementContextID: replacementContextID

--- a/Sources/Typeflux/TextInjection/AXTextInjector.swift
+++ b/Sources/Typeflux/TextInjection/AXTextInjector.swift
@@ -198,11 +198,19 @@ final class AXTextInjector: TextInjector {
     static let visibleTextContextMaxCharacters = 60000
     static let copyShortcutKeyCode: CGKeyCode = 8
     static let selectionContextLifetime: TimeInterval = 180
+    static let maximumSelectionContextCount = 16
     static let focusedDescendantSearchDepth = 10
+    static let replacementAXMessagingTimeout: Float = 0.25
 
     var latestSelectionContext: SelectionContext?
     var lastInjectionMethod: TextInjectionMethod?
     var activePasteboardDeliveryProbe: PasteboardDeliveryProbe?
+    let selectionContextLock = NSLock()
+    var selectionContexts: [UUID: SelectionContext] = [:]
+    let selectionReplacementQueue = DispatchQueue(
+        label: "ai.gulu.app.typeflux.selection-replacement",
+        qos: .userInitiated
+    )
 
     func isTypefluxOwnedTarget(processID: pid_t?, bundleIdentifier: String?) -> Bool {
         if processID == getpid() {
@@ -671,6 +679,7 @@ final class AXTextInjector: TextInjector {
             // avoiding a race where a second focusedElement() call returns a different element.
             let editability = isLikelyEditable(element: result.context.element)
             latestSelectionContext = result.context
+            let replacementContextID = registerSelectionContext(result.context)
             logger
                 .debug(
                     "source=ax-api  role=\(result.context.role ?? "nil", privacy: .public)  range=\(result.context.range.map { "[\($0.location),\($0.length)]" } ?? "nil", privacy: .public)  isEditable=\(editability ? "true" : "false", privacy: .public)  isFocusedTarget=\(result.context.isFocusedTarget ? "true" : "false", privacy: .public)  text(32)=\(String(result.text.prefix(32)), privacy: .public)"
@@ -685,7 +694,8 @@ final class AXTextInjector: TextInjector {
                 isEditable: editability,
                 role: result.context.role,
                 windowTitle: result.context.windowTitle,
-                isFocusedTarget: result.context.isFocusedTarget
+                isFocusedTarget: result.context.isFocusedTarget,
+                replacementContextID: replacementContextID
             )
         }
         logger.debug("ax-api returned nil — trying clipboard-copy")
@@ -718,6 +728,7 @@ final class AXTextInjector: TextInjector {
                 capturedAt: Date()
             )
             latestSelectionContext = context
+            let replacementContextID = registerSelectionContext(context)
             logger
                 .debug(
                     "source=clipboard-copy  focusedWindow=\(focusedWindow != nil ? "present" : "nil", privacy: .public)  selectionWindow=\(selectionWindow != nil ? "present" : "nil", privacy: .public)  isFocusedTarget=\(isFocusedTarget ? "true" : "false", privacy: .public)  text(32)=\(String(copiedText.prefix(32)), privacy: .public)"
@@ -735,7 +746,8 @@ final class AXTextInjector: TextInjector {
                 isEditable: editability,
                 role: nil,
                 windowTitle: context.windowTitle,
-                isFocusedTarget: context.isFocusedTarget
+                isFocusedTarget: context.isFocusedTarget,
+                replacementContextID: replacementContextID
             )
         }
         logger.debug("clipboard-copy returned nil — no selection detected")
@@ -1046,7 +1058,13 @@ final class AXTextInjector: TextInjector {
 
     func replaceSelection(text: String) throws {
         try performAXOperationOnMainThread {
-            try self.setText(text, replaceSelection: true)
+            guard try self.insertIntoTypefluxNativeTextTarget(text, replaceSelection: true) else {
+                throw self.selectionReplacementError(
+                    code: 32,
+                    description: "External selection replacement requires a captured target"
+                )
+            }
+            self.lastInjectionMethod = .ax
         }
     }
 

--- a/Sources/Typeflux/TextInjection/TextInjector.swift
+++ b/Sources/Typeflux/TextInjection/TextInjector.swift
@@ -11,6 +11,7 @@ struct TextSelectionSnapshot {
     var role: String?
     var windowTitle: String?
     var isFocusedTarget: Bool = false
+    var replacementContextID: UUID?
 
     var hasSelection: Bool {
         let trimmed = selectedText?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
@@ -57,6 +58,7 @@ protocol TextInjector {
     func currentInputText() async -> String?
     func insert(text: String) throws
     func replaceSelection(text: String) throws
+    func replaceSelection(text: String, target: TextSelectionSnapshot?) async throws
 }
 
 enum TextInjectionMethod: String {
@@ -66,4 +68,8 @@ enum TextInjectionMethod: String {
 
 extension TextInjector {
     var lastInjectionMethod: TextInjectionMethod? { nil }
+
+    func replaceSelection(text: String, target _: TextSelectionSnapshot?) async throws {
+        try replaceSelection(text: text)
+    }
 }

--- a/Sources/Typeflux/Workflow/WorkflowController+Persona.swift
+++ b/Sources/Typeflux/Workflow/WorkflowController+Persona.swift
@@ -239,7 +239,8 @@ extension WorkflowController {
                     let applyResult = await applyText(
                         processedText,
                         replace: true,
-                        fallbackTitle: L("workflow.result.copyTitle")
+                        fallbackTitle: L("workflow.result.copyTitle"),
+                        targetSnapshot: context.snapshot
                     )
                     outcome = applyResult.0
                 }

--- a/Sources/Typeflux/Workflow/WorkflowController+Processing.swift
+++ b/Sources/Typeflux/Workflow/WorkflowController+Processing.swift
@@ -332,7 +332,8 @@ extension WorkflowController {
         }
         do {
             if replace {
-                await dismissOverlayForExternalReplacement()
+                try await dismissOverlayForExternalReplacement()
+                try Task.checkCancellation()
                 try await textInjector.replaceSelection(text: text, target: targetSnapshot)
             } else {
                 try textInjector.insert(text: text)
@@ -2367,11 +2368,11 @@ extension WorkflowController {
         snapshot.canReplaceSelection
     }
 
-    func dismissOverlayForExternalReplacement() async {
+    func dismissOverlayForExternalReplacement() async throws {
         await MainActor.run {
             overlayController.dismissImmediately()
         }
-        try? await Task.sleep(for: .milliseconds(50))
+        try await Task.sleep(for: .milliseconds(50))
     }
 
     func handleDetachedAgentLaunch() {

--- a/Sources/Typeflux/Workflow/WorkflowController+Processing.swift
+++ b/Sources/Typeflux/Workflow/WorkflowController+Processing.swift
@@ -332,8 +332,8 @@ extension WorkflowController {
         }
         do {
             if replace {
-                dismissOverlayForExternalReplacement()
-                try textInjector.replaceSelection(text: text)
+                await dismissOverlayForExternalReplacement()
+                try await textInjector.replaceSelection(text: text, target: targetSnapshot)
             } else {
                 try textInjector.insert(text: text)
             }
@@ -2367,9 +2367,11 @@ extension WorkflowController {
         snapshot.canReplaceSelection
     }
 
-    func dismissOverlayForExternalReplacement() {
-        overlayController.dismissImmediately()
-        usleep(Self.selectionRestoreDelayMicroseconds)
+    func dismissOverlayForExternalReplacement() async {
+        await MainActor.run {
+            overlayController.dismissImmediately()
+        }
+        try? await Task.sleep(for: .milliseconds(50))
     }
 
     func handleDetachedAgentLaunch() {

--- a/Sources/Typeflux/Workflow/WorkflowController.swift
+++ b/Sources/Typeflux/Workflow/WorkflowController.swift
@@ -18,7 +18,6 @@ final class WorkflowController {
     /// Keep this above `minimumRecordingDuration` so a release is never classified
     /// as hold-to-talk and then immediately rejected as too short.
     static let tapToLockThreshold: TimeInterval = 0.60
-    static let selectionRestoreDelayMicroseconds: useconds_t = 120_000
     static let automaticVocabularyObservationWindow: TimeInterval = 30
     static let automaticVocabularyPollInterval: Duration = .seconds(1)
     // Bumped from 600ms to 900ms so the paste fallback path has time for focus and

--- a/Tests/TypefluxTests/AXTextInjectorTests.swift
+++ b/Tests/TypefluxTests/AXTextInjectorTests.swift
@@ -66,6 +66,10 @@ final class AXTextInjectorTests: XCTestCase {
             currentText: "meeting",
             capturedRole: "AXTextArea",
             currentRole: "AXTextArea",
+            capturedPosition: CGPoint(x: 10, y: 20),
+            currentPosition: CGPoint(x: 10, y: 20),
+            capturedSize: CGSize(width: 300, height: 120),
+            currentSize: CGSize(width: 300, height: 120),
             capturedWindowTitle: "Draft",
             currentWindowTitle: "Draft"
         ))
@@ -107,7 +111,19 @@ final class AXTextInjectorTests: XCTestCase {
             capturedRange: nil,
             currentRange: nil,
             capturedText: "meeting",
-            currentText: nil,
+            currentText: "meeting",
+            capturedRole: nil,
+            currentRole: nil,
+            capturedWindowTitle: "Draft",
+            currentWindowTitle: "Draft"
+        ))
+        XCTAssertFalse(AXTextInjector.capturedSelectionStillMatches(
+            source: "clipboard-copy",
+            elementMatches: true,
+            capturedRange: nil,
+            currentRange: nil,
+            capturedText: "meeting",
+            currentText: "changed",
             capturedRole: nil,
             currentRole: nil,
             capturedWindowTitle: "Draft",

--- a/Tests/TypefluxTests/AXTextInjectorTests.swift
+++ b/Tests/TypefluxTests/AXTextInjectorTests.swift
@@ -3,6 +3,130 @@ import ApplicationServices
 import XCTest
 
 final class AXTextInjectorTests: XCTestCase {
+    func testSelectionReplacementWorkRunsOffMainThread() async throws {
+        let injector = AXTextInjector()
+
+        let ranOnMainThread = try await injector.performSelectionReplacementWork {
+            Thread.isMainThread
+        }
+
+        XCTAssertFalse(ranOnMainThread)
+    }
+
+    func testSelectionReplacementContextCanOnlyBeConsumedOnce() {
+        let injector = AXTextInjector()
+        let context = AXTextInjector.SelectionContext(
+            element: AXUIElementCreateSystemWide(),
+            range: CFRange(location: 0, length: 5),
+            processID: 42,
+            processName: "Notes",
+            selectedText: "hello",
+            role: "AXTextArea",
+            windowTitle: "Draft",
+            isFocusedTarget: true,
+            source: "accessibility",
+            capturedAt: Date()
+        )
+        let contextID = injector.registerSelectionContext(context)
+
+        XCTAssertNotNil(injector.consumeSelectionContext(id: contextID))
+        XCTAssertNil(injector.consumeSelectionContext(id: contextID))
+    }
+
+    func testSelectionReplacementContextRegistryIsBounded() {
+        let injector = AXTextInjector()
+
+        for offset in 0 ... AXTextInjector.maximumSelectionContextCount {
+            _ = injector.registerSelectionContext(AXTextInjector.SelectionContext(
+                element: AXUIElementCreateSystemWide(),
+                range: CFRange(location: offset, length: 1),
+                processID: 42,
+                processName: "Notes",
+                selectedText: "x",
+                role: "AXTextArea",
+                windowTitle: "Draft",
+                isFocusedTarget: true,
+                source: "accessibility",
+                capturedAt: Date().addingTimeInterval(Double(offset))
+            ))
+        }
+
+        XCTAssertEqual(injector.selectionContexts.count, AXTextInjector.maximumSelectionContextCount)
+    }
+
+    func testCapturedSelectionAcceptsRebuiltElementOnlyWithMatchingSemanticIdentity() {
+        let range = CFRange(location: 4, length: 7)
+
+        XCTAssertTrue(AXTextInjector.capturedSelectionStillMatches(
+            source: "accessibility",
+            elementMatches: false,
+            capturedRange: range,
+            currentRange: range,
+            capturedText: "meeting",
+            currentText: "meeting",
+            capturedRole: "AXTextArea",
+            currentRole: "AXTextArea",
+            capturedWindowTitle: "Draft",
+            currentWindowTitle: "Draft"
+        ))
+    }
+
+    func testCapturedSelectionRejectsChangedTextOrRange() {
+        let range = CFRange(location: 4, length: 7)
+
+        XCTAssertFalse(AXTextInjector.capturedSelectionStillMatches(
+            source: "accessibility",
+            elementMatches: true,
+            capturedRange: range,
+            currentRange: CFRange(location: 5, length: 7),
+            capturedText: "meeting",
+            currentText: "meeting",
+            capturedRole: "AXTextArea",
+            currentRole: "AXTextArea",
+            capturedWindowTitle: "Draft",
+            currentWindowTitle: "Draft"
+        ))
+        XCTAssertFalse(AXTextInjector.capturedSelectionStillMatches(
+            source: "accessibility",
+            elementMatches: true,
+            capturedRange: range,
+            currentRange: range,
+            capturedText: "meeting",
+            currentText: "changed",
+            capturedRole: "AXTextArea",
+            currentRole: "AXTextArea",
+            capturedWindowTitle: "Draft",
+            currentWindowTitle: "Draft"
+        ))
+    }
+
+    func testClipboardCapturedSelectionRequiresExactElementIdentity() {
+        XCTAssertTrue(AXTextInjector.capturedSelectionStillMatches(
+            source: "clipboard-copy",
+            elementMatches: true,
+            capturedRange: nil,
+            currentRange: nil,
+            capturedText: "meeting",
+            currentText: nil,
+            capturedRole: nil,
+            currentRole: nil,
+            capturedWindowTitle: "Draft",
+            currentWindowTitle: "Draft"
+        ))
+        XCTAssertFalse(AXTextInjector.capturedSelectionStillMatches(
+            source: "clipboard-copy",
+            elementMatches: false,
+            capturedRange: nil,
+            currentRange: nil,
+            capturedText: "meeting",
+            currentText: "meeting",
+            capturedRole: nil,
+            currentRole: nil,
+            capturedWindowTitle: "Draft",
+            currentWindowTitle: "Draft"
+        ))
+    }
+
     func testTargetCapabilityDistinguishesWritableNonWritableAndOpaqueTargets() {
         XCTAssertEqual(
             AXTextInjector.targetCapability(

--- a/Tests/TypefluxTests/SettingsStorePersonaTests.swift
+++ b/Tests/TypefluxTests/SettingsStorePersonaTests.swift
@@ -14,7 +14,7 @@ final class SettingsStorePersonaTests: XCTestCase {
 
         let translatorPersona = try XCTUnwrap(store.personas.first(where: { $0.name == "English Translator" }))
         XCTAssertTrue(translatorPersona.prompt.contains("Persona language mode: fixed English."))
-        XCTAssertTrue(translatorPersona.prompt.contains("always produce the final output in natural English"))
+        XCTAssertTrue(translatorPersona.prompt.contains("output only the final English text"))
     }
 
     func testBuiltInPersonasUseStableCloudIdentifiers() throws {
@@ -52,7 +52,7 @@ final class SettingsStorePersonaTests: XCTestCase {
 
         XCTAssertTrue(prompt.contains("Persona language mode: inherit."))
         XCTAssertTrue(prompt.contains("spoken filler words (such as um, uh, like, you know, basically)"))
-        XCTAssertTrue(prompt.contains("Keep the overall tone professional, formal, and natural."))
+        XCTAssertTrue(prompt.contains("Keep the user's overall tone natural"))
         XCTAssertFalse(prompt.contains("人设语言模式"))
     }
 
@@ -61,7 +61,7 @@ final class SettingsStorePersonaTests: XCTestCase {
 
         XCTAssertTrue(prompt.contains("人設語言模式：繼承。"))
         XCTAssertTrue(prompt.contains("去除口語填充詞（如 um、uh、like、you know、basically 等）"))
-        XCTAssertTrue(prompt.contains("保持整體語氣專業、正式、自然。"))
+        XCTAssertTrue(prompt.contains("保持使用者整體語氣自然"))
         XCTAssertFalse(prompt.contains("人设语言模式"))
     }
 
@@ -70,7 +70,7 @@ final class SettingsStorePersonaTests: XCTestCase {
 
         XCTAssertTrue(prompt.contains("ペルソナの言語モード：継承。"))
         XCTAssertTrue(prompt.contains("口頭のフィラー（um、uh、like、you know、basically など）"))
-        XCTAssertTrue(prompt.contains("全体のトーンをプロフェッショナルで、フォーマルで、自然に保つ。"))
+        XCTAssertTrue(prompt.contains("ユーザーの全体的なトーンを自然に保ち"))
         XCTAssertFalse(prompt.contains("人设语言模式"))
     }
 
@@ -79,7 +79,7 @@ final class SettingsStorePersonaTests: XCTestCase {
 
         XCTAssertTrue(prompt.contains("페르소나 언어 모드: 상속."))
         XCTAssertTrue(prompt.contains("구어 필러(예: um, uh, like, you know, basically)"))
-        XCTAssertTrue(prompt.contains("전체 어조는 전문적이고 격식 있으며 자연스럽게 유지한다."))
+        XCTAssertTrue(prompt.contains("사용자의 전체 어조를 자연스럽게 유지하고"))
         XCTAssertFalse(prompt.contains("人设语言模式"))
     }
 
@@ -105,7 +105,7 @@ final class SettingsStorePersonaTests: XCTestCase {
         let prompt = store.resolvedPersonaPrompt(for: translatorPersona)
 
         XCTAssertTrue(prompt.contains("Persona language mode: fixed English."))
-        XCTAssertTrue(prompt.contains("always produce the final output in natural English"))
+        XCTAssertTrue(prompt.contains("output only the final English text"))
         XCTAssertFalse(prompt.contains("人设语言模式"))
     }
 

--- a/Tests/TypefluxTests/SettingsViewModelPersonaTests.swift
+++ b/Tests/TypefluxTests/SettingsViewModelPersonaTests.swift
@@ -87,7 +87,7 @@ final class SettingsViewModelPersonaTests: XCTestCase {
         viewModel.selectPersona(persona.id)
 
         XCTAssertTrue(viewModel.personaDraftPrompt.contains("人设语言模式：继承。"))
-        XCTAssertTrue(viewModel.personaDisplayPrompt(for: persona).contains("保持整体语气专业、正式、自然。"))
+        XCTAssertTrue(viewModel.personaDisplayPrompt(for: persona).contains("保持用户整体语气自然"))
         XCTAssertFalse(viewModel.personaDraftPrompt.contains("You are Typeflux AI"))
     }
 
@@ -364,7 +364,7 @@ final class SettingsViewModelPersonaTests: XCTestCase {
         defer { defaults.removePersistentDomain(forName: suite) }
         let store = SettingsStore(defaults: defaults)
         store.appLanguage = .simplifiedChinese
-        let persona = PersonaProfile(name: "Writing", prompt: "\n  Summarize the report.  \nKeep the decisions.")
+        let persona = PersonaProfile(name: "Writing", prompt: "\n  Summarize the report.  \nKeep the zebraquartz decisions.")
         let emptyPersona = PersonaProfile(name: "Empty", prompt: " \n ")
         store.personas = store.personas + [persona, emptyPersona]
         let model = StudioViewModel(settingsStore: store, historyStore: InMemoryHistoryStore(), initialSection: .personas)
@@ -380,7 +380,7 @@ final class SettingsViewModelPersonaTests: XCTestCase {
         model.searchQuery = "  整理口述  "
         XCTAssertEqual(model.filteredBuiltInPersonas.map(\.id), [SettingsStore.defaultPersonaID])
         XCTAssertTrue(model.filteredCustomPersonas.isEmpty)
-        model.searchQuery = "decisions"
+        model.searchQuery = "zebraquartz"
         XCTAssertTrue(model.filteredBuiltInPersonas.isEmpty)
         XCTAssertEqual(model.filteredCustomPersonas.map(\.id), [persona.id])
         model.searchQuery = "no-match-12345"

--- a/Tests/TypefluxTests/WorkflowControllerProcessingTests.swift
+++ b/Tests/TypefluxTests/WorkflowControllerProcessingTests.swift
@@ -118,6 +118,31 @@ final class WorkflowControllerProcessingTests: XCTestCase {
         XCTAssertTrue(textInjector.insertedTexts.isEmpty)
     }
 
+    func testCancelledSelectionApplyDoesNotCommitLateReplacement() async {
+        let injector = MockProcessingTextInjector()
+        let controller = makeWorkflowController(textInjector: injector)
+        let task = Task {
+            await controller.applyText(
+                "replacement",
+                replace: true,
+                targetSnapshot: TextSelectionSnapshot(
+                    processID: 42,
+                    selectedText: "original",
+                    source: "accessibility",
+                    isEditable: true,
+                    isFocusedTarget: true,
+                    replacementContextID: UUID()
+                )
+            )
+        }
+
+        task.cancel()
+        let (outcome, _) = await task.value
+
+        XCTAssertEqual(outcome, .copiedToClipboard)
+        XCTAssertTrue(injector.replacedTexts.isEmpty)
+    }
+
     func testHandleDetachedAgentLaunchKeepsProcessingStatusVisible() {
         let controller = makeWorkflowController()
         controller.activeProcessingRecordID = UUID()

--- a/Tests/TypefluxTests/WorkflowControllerProcessingTests.swift
+++ b/Tests/TypefluxTests/WorkflowControllerProcessingTests.swift
@@ -57,6 +57,40 @@ final class WorkflowControllerProcessingTests: XCTestCase {
 
         XCTAssertEqual(outcome, .inserted)
         XCTAssertEqual(textInjector.replacedTexts, ["updated"])
+        XCTAssertEqual(textInjector.replacementTargets.first.flatMap { $0 }?.processID, snapshot.processID)
+        XCTAssertTrue(textInjector.insertedTexts.isEmpty)
+    }
+
+    func testApplyPersonaToSelectionPreservesCapturedReplacementTarget() async {
+        let contextID = UUID()
+        let snapshot = TextSelectionSnapshot(
+            processID: 42,
+            processName: "Notes",
+            bundleIdentifier: "com.apple.Notes",
+            selectedRange: CFRange(location: 0, length: 5),
+            selectedText: "hello",
+            source: "accessibility",
+            isEditable: true,
+            role: "AXTextArea",
+            windowTitle: "Draft",
+            isFocusedTarget: true,
+            replacementContextID: contextID
+        )
+        let textInjector = MockProcessingTextInjector(selectionSnapshot: snapshot)
+        let persona = PersonaProfile(name: "Concise", prompt: "Make it concise.")
+        let controller = makeWorkflowController(
+            textInjector: textInjector,
+            llmService: CountingProcessingLLMService(rewriteText: "updated"),
+            configureSettings: configureReadyLLM
+        )
+
+        controller.applyPersonaToSelection(
+            WorkflowController.PersonaSelectionContext(snapshot: snapshot, selectedText: "hello"),
+            persona: persona
+        )
+        await waitUntil { textInjector.replacedTexts == ["updated"] }
+
+        XCTAssertEqual(textInjector.replacementTargets.first.flatMap { $0 }?.replacementContextID, contextID)
         XCTAssertTrue(textInjector.insertedTexts.isEmpty)
     }
 
@@ -2273,6 +2307,7 @@ private func XCTAssertThrowsErrorAsync(
 private final class MockProcessingTextInjector: TextInjector {
     private(set) var insertedTexts: [String] = []
     private(set) var replacedTexts: [String] = []
+    private(set) var replacementTargets: [TextSelectionSnapshot?] = []
     private let selectionSnapshot: TextSelectionSnapshot
     private let inputSnapshot: CurrentInputTextSnapshot
     private let insertError: Error?
@@ -2314,6 +2349,14 @@ private final class MockProcessingTextInjector: TextInjector {
             throw replaceError
         }
         replacedTexts.append(text)
+    }
+
+    func replaceSelection(text: String, target: TextSelectionSnapshot?) async throws {
+        if let replaceError {
+            throw replaceError
+        }
+        replacedTexts.append(text)
+        replacementTargets.append(target)
     }
 }
 


### PR DESCRIPTION
## Summary

- carry a single-use captured-selection token from persona processing to text injection
- perform external selection discovery and replacement off the main thread, with bounded AX and clipboard reads
- validate process, focus, element identity/fingerprint, selected range, and selected text before committing
- re-copy clipboard-backed selections before replacement so moved or changed selections are rejected
- treat acknowledged AX writes as final and never issue a duplicate paste after ambiguous AX results
- use eager pasteboard payloads without materializing arbitrary existing clipboard representations
- honor task cancellation before any external replacement can be committed
- synchronize shared injection state and avoid clearing a newer captured selection
- update stale persona assertions so the complete test suite is green

## Verification

- `swift test` — 2,532 XCTest tests and 8 Swift Testing tests passed, zero failures
- `swift test --filter AXTextInjectorTests --filter WorkflowControllerProcessingTests.testCancelledSelectionApplyDoesNotCommitLateReplacement` — 86 passed
- `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warn-concurrency` — succeeded; no warnings in the modified text-injection path
- `xcodebuild -project TypefluxApp.xcodeproj -scheme TypefluxApp -configuration Debug -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build` — succeeded
- `git diff --check` — passed

Issue: GUL-75
