### PR TITLE
GUL-75: restore persona insertion in Electron apps

### DIFF
--- a/Sources/Typeflux/Overlay/OverlayController.swift
+++ b/Sources/Typeflux/Overlay/OverlayController.swift
@@ -272,6 +272,10 @@ final class OverlayController {
         model.presentation == .notice && !model.noticeDismissible
     }
 
+    var isShowingResultDialogForTesting: Bool {
+        model.presentation == .resultDialog
+    }
+
     var processingProgressForTesting: CGFloat {
         model.processingProgress
     }

--- a/Sources/Typeflux/Resources/en.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/en.lproj/Localizable.strings
@@ -400,7 +400,6 @@
 "workflow.transcription.noSpeech" = "No clear speech detected. Transcription cancelled.";
 "workflow.transcription.serverUnavailableNotice" = "Unable to connect to the server. Your recording was saved in History for retry.";
 "workflow.result.copyTitle" = "Copy Result";
-"workflow.result.insertionFailedCopied" = "Text couldn't be inserted. It has been copied; press ⌘V to paste.";
 "workflow.ask.answerTitle" = "Ask Anything";
 "workflow.ask.questionSectionTitle" = "Your Question";
 "workflow.ask.answerSectionTitle" = "Answer";

--- a/Sources/Typeflux/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/ja.lproj/Localizable.strings
@@ -396,7 +396,6 @@
 "workflow.transcription.noSpeech" = "明瞭な音声が検出されませんでした。転写はキャンセルされました。";
 "workflow.transcription.serverUnavailableNotice" = "サーバーに接続できません。録音は履歴に保存され、後で再試行できます。";
 "workflow.result.copyTitle" = "コピー結果";
-"workflow.result.insertionFailedCopied" = "テキストを挿入できなかったためコピーしました。⌘V で貼り付けできます。";
 "workflow.ask.answerTitle" = "何でも聞いてください";
 "workflow.ask.questionSectionTitle" = "あなたの質問";
 "workflow.ask.answerSectionTitle" = "答え";

--- a/Sources/Typeflux/Resources/ko.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/ko.lproj/Localizable.strings
@@ -396,7 +396,6 @@
 "workflow.transcription.noSpeech" = "명확한 음성이 감지되지 않았습니다. 스크립트 작성이 취소되었습니다.";
 "workflow.transcription.serverUnavailableNotice" = "서버에 연결할 수 없습니다. 녹음은 기록에 저장되어 나중에 다시 시도할 수 있습니다.";
 "workflow.result.copyTitle" = "결과 복사";
-"workflow.result.insertionFailedCopied" = "텍스트를 삽입하지 못해 복사했습니다. ⌘V로 붙여넣으세요.";
 "workflow.ask.answerTitle" = "무엇이든 물어보세요";
 "workflow.ask.questionSectionTitle" = "질문";
 "workflow.ask.answerSectionTitle" = "답변";

--- a/Sources/Typeflux/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/zh-Hans.lproj/Localizable.strings
@@ -400,7 +400,6 @@
 "workflow.transcription.noSpeech" = "未检测到清晰语音，本次转写已取消。";
 "workflow.transcription.serverUnavailableNotice" = "暂时无法连接服务器，录音已保存在历史记录中，可稍后重试。";
 "workflow.result.copyTitle" = "复制结果";
-"workflow.result.insertionFailedCopied" = "未能插入文本，内容已复制，可按 ⌘V 粘贴。";
 "workflow.ask.answerTitle" = "随便问";
 "workflow.ask.questionSectionTitle" = "你的问题";
 "workflow.ask.answerSectionTitle" = "回答";

--- a/Sources/Typeflux/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/zh-Hant.lproj/Localizable.strings
@@ -398,7 +398,6 @@
 "workflow.transcription.noSpeech" = "未偵測到清晰語音，本次轉寫已取消。";
 "workflow.transcription.serverUnavailableNotice" = "暫時無法連線至伺服器，錄音已儲存在歷史記錄中，可稍後重試。";
 "workflow.result.copyTitle" = "複製結果";
-"workflow.result.insertionFailedCopied" = "未能插入文字，內容已複製，可按 ⌘V 貼上。";
 "workflow.ask.answerTitle" = "隨便問";
 "workflow.ask.questionSectionTitle" = "你的問題";
 "workflow.ask.answerSectionTitle" = "回答";

--- a/Sources/Typeflux/TextInjection/AXTextInjector+Transaction.swift
+++ b/Sources/Typeflux/TextInjection/AXTextInjector+Transaction.swift
@@ -28,17 +28,52 @@ extension AXTextInjector {
         capturedWindowTitle: String?,
         currentWindowTitle: String?
     ) -> Bool {
-        if source == "clipboard-copy" {
-            return elementMatches && capturedText == currentText
-        }
-
-        guard capturedRange?.location == currentRange?.location,
-              capturedRange?.length == currentRange?.length,
-              capturedText == currentText
-        else {
+        guard capturedText == currentText else {
             return false
         }
 
+        if source != "clipboard-copy" {
+            guard capturedRange?.location == currentRange?.location,
+                  capturedRange?.length == currentRange?.length
+            else {
+                return false
+            }
+        }
+
+        return capturedElementStillMatches(
+            elementMatches: elementMatches,
+            capturedRole: capturedRole,
+            currentRole: currentRole,
+            capturedSubrole: capturedSubrole,
+            currentSubrole: currentSubrole,
+            capturedIdentifier: capturedIdentifier,
+            currentIdentifier: currentIdentifier,
+            capturedPosition: capturedPosition,
+            currentPosition: currentPosition,
+            capturedSize: capturedSize,
+            currentSize: currentSize,
+            capturedWindowTitle: capturedWindowTitle,
+            currentWindowTitle: currentWindowTitle,
+            allowsWindowScopedMatch: source == "clipboard-copy"
+        )
+    }
+
+    private static func capturedElementStillMatches(
+        elementMatches: Bool,
+        capturedRole: String?,
+        currentRole: String?,
+        capturedSubrole: String?,
+        currentSubrole: String?,
+        capturedIdentifier: String?,
+        currentIdentifier: String?,
+        capturedPosition: CGPoint?,
+        currentPosition: CGPoint?,
+        capturedSize: CGSize?,
+        currentSize: CGSize?,
+        capturedWindowTitle: String?,
+        currentWindowTitle: String?,
+        allowsWindowScopedMatch: Bool
+    ) -> Bool {
         if elementMatches {
             return true
         }
@@ -48,16 +83,27 @@ extension AXTextInjector {
             capturedSize != nil && capturedSize == currentSize
         guard capturedRole == currentRole,
               capturedSubrole == currentSubrole,
-              identifierMatches || frameMatches,
-              let capturedWindowTitle = capturedWindowTitle?.trimmingCharacters(in: .whitespacesAndNewlines),
-              let currentWindowTitle = currentWindowTitle?.trimmingCharacters(in: .whitespacesAndNewlines),
-              !capturedWindowTitle.isEmpty,
-              capturedWindowTitle == currentWindowTitle
+              capturedRole?.isEmpty == false
         else {
             return false
         }
 
-        return true
+        let normalizedCapturedWindowTitle = capturedWindowTitle?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let normalizedCurrentWindowTitle = currentWindowTitle?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let windowMatches = normalizedCapturedWindowTitle?.isEmpty == false &&
+            normalizedCapturedWindowTitle == normalizedCurrentWindowTitle
+
+        // Electron and Chromium frequently recreate the focused AX element while
+        // preserving the same role and window. A fresh Cmd-C that returned the
+        // original selected text is strong enough evidence for clipboard-backed
+        // selections. Prefer identifier/frame when available; otherwise use the
+        // focused window title, which is also captured for opaque AX hierarchies.
+        if allowsWindowScopedMatch {
+            return identifierMatches || frameMatches || windowMatches
+        }
+        return (identifierMatches || frameMatches) && windowMatches
     }
 
     func replaceSelection(text: String, target: TextSelectionSnapshot?) async throws {
@@ -107,18 +153,7 @@ extension AXTextInjector {
             lastInjectionMethod = .ax
         case .requiresPaste:
             try Task.checkCancellation()
-            try await prepareEagerPasteboard(text: text, targetProcessID: context.processID)
-            try Task.checkCancellation()
-            let pasteProcessID = await MainActor.run {
-                NSWorkspace.shared.frontmostApplication?.processIdentifier
-            }
-            try Task.checkCancellation()
-            try await performSelectionReplacementWork {
-                try self.dispatchSelectionPaste(
-                    context: context,
-                    currentFrontmostProcessID: pasteProcessID
-                )
-            }
+            try await commitSelectionPaste(text: text, targetProcessID: context.processID)
             lastInjectionMethod = .paste
         }
 
@@ -187,34 +222,6 @@ extension AXTextInjector {
         }
     }
 
-    func dispatchSelectionPaste(
-        context: SelectionContext,
-        currentFrontmostProcessID: pid_t?
-    ) throws {
-        _ = try validatedCurrentSelectionElement(
-            context: context,
-            currentFrontmostProcessID: currentFrontmostProcessID,
-            verifyClipboardText: false
-        )
-        guard let processID = context.processID else {
-            throw selectionReplacementError(code: 24, description: "The target application is unavailable")
-        }
-
-        let source = CGEventSource(stateID: .combinedSessionState)
-        guard let keyDown = CGEvent(keyboardEventSource: source, virtualKey: 0x09, keyDown: true),
-              let keyUp = CGEvent(keyboardEventSource: source, virtualKey: 0x09, keyDown: false)
-        else {
-            throw selectionReplacementError(code: 25, description: "Unable to create the paste shortcut")
-        }
-        keyDown.flags = .maskCommand
-        keyUp.flags = .maskCommand
-        keyDown.postToPid(processID)
-        keyUp.postToPid(processID)
-        NetworkDebugLogger.logMessage(
-            "[Text Injection] selection transaction dispatched via eager paste"
-        )
-    }
-
     func validatedCurrentSelectionElement(
         context: SelectionContext,
         currentFrontmostProcessID: pid_t?,
@@ -236,41 +243,41 @@ extension AXTextInjector {
         AXUIElementSetMessagingTimeout(application, Self.replacementAXMessagingTimeout)
         AXUIElementSetMessagingTimeout(context.element, Self.replacementAXMessagingTimeout)
 
-        guard let currentElement = lightweightFocusedElement(application: application) else {
+        guard var currentElement = lightweightFocusedElement(application: application) else {
             throw selectionReplacementError(code: 28, description: "The target no longer has a focused input")
         }
         AXUIElementSetMessagingTimeout(currentElement, Self.replacementAXMessagingTimeout)
 
-        let elementMatches = CFEqual(context.element, currentElement)
-        let currentRange = copySelectedTextRange(from: currentElement)
         let currentText: String?
         if context.source == "clipboard-copy", verifyClipboardText {
             currentText = readSelectedTextViaCopy(
                 processID: processID,
                 milliseconds: Self.copySelectionTimeoutMilliseconds
             )
-            guard let focusedAfterCopy = lightweightFocusedElement(application: application),
-                  CFEqual(currentElement, focusedAfterCopy)
-            else {
+            guard let focusedAfterCopy = lightweightFocusedElement(application: application) else {
                 throw selectionReplacementError(
                     code: 29,
                     description: "The selected text changed while the result was being generated"
                 )
             }
+            AXUIElementSetMessagingTimeout(focusedAfterCopy, Self.replacementAXMessagingTimeout)
+            currentElement = focusedAfterCopy
         } else if context.source == "clipboard-copy" {
-            // The clipboard already contains the replacement at dispatch time. The
-            // selection text was re-copied and verified during preparation; copying
-            // again here would overwrite the replacement immediately before Cmd+V.
             currentText = context.selectedText
         } else {
             currentText = copyStringAttribute(kAXSelectedTextAttribute as String, from: currentElement)
         }
+        let elementMatches = CFEqual(context.element, currentElement)
+        let currentRange = copySelectedTextRange(from: currentElement)
         let currentRole = copyStringAttribute(kAXRoleAttribute as String, from: currentElement)
         let currentSubrole = copyStringAttribute(kAXSubroleAttribute as String, from: currentElement)
         let currentIdentifier = copyStringAttribute(kAXIdentifierAttribute as String, from: currentElement)
         let currentPosition = copyCGPointAttribute(kAXPositionAttribute as String, from: currentElement)
         let currentSize = copyCGSizeAttribute(kAXSizeAttribute as String, from: currentElement)
-        let currentWindowTitle = lightweightWindowTitle(of: currentElement)
+        let currentWindowTitle = lightweightWindowTitle(
+            of: currentElement,
+            fallbackProcessID: processID
+        )
 
         guard Self.capturedSelectionStillMatches(
             source: context.source,
@@ -311,24 +318,45 @@ extension AXTextInjector {
         return copyElementAttribute(kAXFocusedUIElementAttribute as String, from: focused) ?? focused
     }
 
-    func lightweightWindowTitle(of element: AXUIElement) -> String? {
+    func lightweightWindowTitle(of element: AXUIElement, fallbackProcessID: pid_t?) -> String? {
         if let window = copyElementAttribute(kAXWindowAttribute as String, from: element) {
             AXUIElementSetMessagingTimeout(window, Self.replacementAXMessagingTimeout)
-            return copyTextAttribute(kAXTitleAttribute as String, from: window)
+            if let title = copyTextAttribute(kAXTitleAttribute as String, from: window) {
+                return title
+            }
         }
-        return nil
+        return focusedWindowTitle(for: fallbackProcessID)
     }
 
-    func prepareEagerPasteboard(text: String, targetProcessID: pid_t?) async throws {
+    func commitSelectionPaste(text: String, targetProcessID: pid_t?) async throws {
         let injector = UncheckedSendableReference(self)
         try await MainActor.run {
             try Task.checkCancellation()
-            guard NSWorkspace.shared.frontmostApplication?.processIdentifier == targetProcessID else {
+            guard let targetProcessID,
+                  NSWorkspace.shared.frontmostApplication?.processIdentifier == targetProcessID
+            else {
                 throw injector.value.selectionReplacementError(
                     code: 30,
                     description: "The user moved away from the captured selection"
                 )
             }
+
+            let source = CGEventSource(stateID: .combinedSessionState)
+            guard let keyDown = CGEvent(keyboardEventSource: source, virtualKey: 0x09, keyDown: true),
+                  let keyUp = CGEvent(keyboardEventSource: source, virtualKey: 0x09, keyDown: false)
+            else {
+                throw injector.value.selectionReplacementError(
+                    code: 25,
+                    description: "Unable to create the paste shortcut"
+                )
+            }
+            keyDown.flags = .maskCommand
+            keyUp.flags = .maskCommand
+
+            // All target validation has completed before the pasteboard changes.
+            // After this point, dispatch immediately without another AX round-trip:
+            // a rejected post-write validation would leave a failed transaction's
+            // result on the user's clipboard.
             let pasteboard = NSPasteboard.general
             pasteboard.clearContents()
             guard pasteboard.setString(text, forType: .string) else {
@@ -337,6 +365,11 @@ extension AXTextInjector {
                     description: "Unable to prepare the replacement text"
                 )
             }
+            keyDown.postToPid(targetProcessID)
+            keyUp.postToPid(targetProcessID)
+            NetworkDebugLogger.logMessage(
+                "[Text Injection] selection transaction dispatched via eager paste"
+            )
         }
     }
 

--- a/Sources/Typeflux/TextInjection/AXTextInjector+Transaction.swift
+++ b/Sources/Typeflux/TextInjection/AXTextInjector+Transaction.swift
@@ -2,6 +2,26 @@ import AppKit
 import ApplicationServices
 import Foundation
 
+private final class SelectionReplacementCancellationToken: @unchecked Sendable {
+    private let lock = NSLock()
+    private var cancelled = false
+
+    func cancel() {
+        lock.lock()
+        cancelled = true
+        lock.unlock()
+    }
+
+    func checkCancellation() throws {
+        lock.lock()
+        let isCancelled = cancelled
+        lock.unlock()
+        if isCancelled {
+            throw CancellationError()
+        }
+    }
+}
+
 extension AXTextInjector {
     enum SelectionReplacementPreparation: Equatable {
         case committedViaAX
@@ -78,9 +98,6 @@ extension AXTextInjector {
             return true
         }
 
-        let identifierMatches = capturedIdentifier?.isEmpty == false && capturedIdentifier == currentIdentifier
-        let frameMatches = capturedPosition != nil && capturedPosition == currentPosition &&
-            capturedSize != nil && capturedSize == currentSize
         guard capturedRole == currentRole,
               capturedSubrole == currentSubrole,
               capturedRole?.isEmpty == false
@@ -100,10 +117,24 @@ extension AXTextInjector {
         // original selected text is strong enough evidence for clipboard-backed
         // selections. Prefer identifier/frame when available; otherwise use the
         // focused window title, which is also captured for opaque AX hierarchies.
-        if allowsWindowScopedMatch {
-            return identifierMatches || frameMatches || windowMatches
+        // Prefer the strongest evidence that both snapshots expose. A matching
+        // window title must never override an explicitly different identifier or
+        // frame; that could redirect a result to another editor in the same window.
+        let hasCapturedIdentifier = capturedIdentifier?.isEmpty == false
+        let hasCurrentIdentifier = currentIdentifier?.isEmpty == false
+        if hasCapturedIdentifier, hasCurrentIdentifier {
+            let identifierMatches = capturedIdentifier == currentIdentifier
+            return identifierMatches && (allowsWindowScopedMatch || windowMatches)
         }
-        return (identifierMatches || frameMatches) && windowMatches
+
+        let hasCapturedFrame = capturedPosition != nil && capturedSize != nil
+        let hasCurrentFrame = currentPosition != nil && currentSize != nil
+        if hasCapturedFrame, hasCurrentFrame {
+            let frameMatches = capturedPosition == currentPosition && capturedSize == currentSize
+            return frameMatches && (allowsWindowScopedMatch || windowMatches)
+        }
+
+        return allowsWindowScopedMatch && windowMatches
     }
 
     func replaceSelection(text: String, target: TextSelectionSnapshot?) async throws {
@@ -134,17 +165,20 @@ extension AXTextInjector {
                 description: "The captured selection is no longer available"
             )
         }
+        defer { clearLatestSelectionContext(ifMatching: context) }
 
         try Task.checkCancellation()
         let currentProcessID = await MainActor.run {
             NSWorkspace.shared.frontmostApplication?.processIdentifier
         }
         try Task.checkCancellation()
-        let preparation = try await performSelectionReplacementWork {
+        let cancellationToken = SelectionReplacementCancellationToken()
+        let preparation = try await performSelectionReplacementWork(cancellationToken: cancellationToken) {
             try self.prepareSelectionReplacement(
                 text: text,
                 context: context,
-                currentFrontmostProcessID: currentProcessID
+                currentFrontmostProcessID: currentProcessID,
+                cancellationToken: cancellationToken
             )
         }
 
@@ -156,29 +190,44 @@ extension AXTextInjector {
             try await commitSelectionPaste(text: text, targetProcessID: context.processID)
             lastInjectionMethod = .paste
         }
-
-        clearLatestSelectionContext(ifMatching: context)
     }
 
     func performSelectionReplacementWork<T>(
         _ work: @escaping () throws -> T
     ) async throws -> T {
+        let cancellationToken = SelectionReplacementCancellationToken()
+        return try await performSelectionReplacementWork(
+            cancellationToken: cancellationToken,
+            work
+        )
+    }
+
+    private func performSelectionReplacementWork<T>(
+        cancellationToken: SelectionReplacementCancellationToken,
+        _ work: @escaping () throws -> T
+    ) async throws -> T {
         let sendableWork = UncheckedSendableReference(work)
-        return try await withCheckedThrowingContinuation { continuation in
-            selectionReplacementQueue.async {
-                do {
-                    continuation.resume(returning: try sendableWork.value())
-                } catch {
-                    continuation.resume(throwing: error)
+        return try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                selectionReplacementQueue.async {
+                    do {
+                        try cancellationToken.checkCancellation()
+                        continuation.resume(returning: try sendableWork.value())
+                    } catch {
+                        continuation.resume(throwing: error)
+                    }
                 }
             }
+        } onCancel: {
+            cancellationToken.cancel()
         }
     }
 
-    func prepareSelectionReplacement(
+    private func prepareSelectionReplacement(
         text: String,
         context: SelectionContext,
-        currentFrontmostProcessID: pid_t?
+        currentFrontmostProcessID: pid_t?,
+        cancellationToken: SelectionReplacementCancellationToken
     ) throws -> SelectionReplacementPreparation {
         let element = try validatedCurrentSelectionElement(
             context: context,
@@ -192,6 +241,7 @@ extension AXTextInjector {
             return .requiresPaste
         }
 
+        try cancellationToken.checkCancellation()
         guard setSelectedTextRange(range, on: element) else {
             throw selectionReplacementError(
                 code: 22,

--- a/Sources/Typeflux/Workflow/WorkflowController+Processing.swift
+++ b/Sources/Typeflux/Workflow/WorkflowController+Processing.swift
@@ -354,9 +354,9 @@ extension WorkflowController {
             )
             return (.inserted, text)
         } catch {
-            NetworkDebugLogger.logError(context: "[Apply Text] fallback to copied result notice", error: error)
-            presentInsertionFailureFallback(text: text)
-            return (.copiedToClipboard, text)
+            NetworkDebugLogger.logError(context: "[Apply Text] fallback to result dialog", error: error)
+            presentResultDialog(title: fallbackTitle, text: text)
+            return (.presentedInDialog, text)
         }
     }
 
@@ -2429,23 +2429,6 @@ extension WorkflowController {
             guard let self else { return }
             lastDialogResultText = text
             overlayController.showResultDialog(title: title, message: text)
-        }
-
-        if Thread.isMainThread {
-            work()
-        } else {
-            DispatchQueue.main.sync(execute: work)
-        }
-    }
-
-    func presentInsertionFailureFallback(text: String) {
-        let work = { [weak self] in
-            guard let self else { return }
-            clipboard.write(text: text)
-            lastDialogResultText = text
-            overlayController.showPassiveNotice(
-                message: L("workflow.result.insertionFailedCopied")
-            )
         }
 
         if Thread.isMainThread {

--- a/Tests/TypefluxTests/AXTextInjectorTests.swift
+++ b/Tests/TypefluxTests/AXTextInjectorTests.swift
@@ -104,7 +104,7 @@ final class AXTextInjectorTests: XCTestCase {
         ))
     }
 
-    func testClipboardCapturedSelectionRequiresExactElementIdentity() {
+    func testClipboardCapturedSelectionAcceptsExactOrSemanticElementIdentity() {
         XCTAssertTrue(AXTextInjector.capturedSelectionStillMatches(
             source: "clipboard-copy",
             elementMatches: true,
@@ -117,15 +117,59 @@ final class AXTextInjectorTests: XCTestCase {
             capturedWindowTitle: "Draft",
             currentWindowTitle: "Draft"
         ))
+        XCTAssertTrue(AXTextInjector.capturedSelectionStillMatches(
+            source: "clipboard-copy",
+            elementMatches: false,
+            capturedRange: nil,
+            currentRange: nil,
+            capturedText: "meeting",
+            currentText: "meeting",
+            capturedRole: "AXTextArea",
+            currentRole: "AXTextArea",
+            capturedPosition: CGPoint(x: 10, y: 20),
+            currentPosition: CGPoint(x: 10, y: 20),
+            capturedSize: CGSize(width: 300, height: 120),
+            currentSize: CGSize(width: 300, height: 120),
+            capturedWindowTitle: "Draft",
+            currentWindowTitle: "Draft"
+        ))
+        XCTAssertTrue(AXTextInjector.capturedSelectionStillMatches(
+            source: "clipboard-copy",
+            elementMatches: false,
+            capturedRange: nil,
+            currentRange: nil,
+            capturedText: "meeting",
+            currentText: "meeting",
+            capturedRole: "AXTextArea",
+            currentRole: "AXTextArea",
+            capturedPosition: CGPoint(x: 10, y: 20),
+            currentPosition: CGPoint(x: 10, y: 20),
+            capturedSize: CGSize(width: 300, height: 120),
+            currentSize: CGSize(width: 300, height: 120),
+            capturedWindowTitle: nil,
+            currentWindowTitle: nil
+        ))
+        XCTAssertTrue(AXTextInjector.capturedSelectionStillMatches(
+            source: "clipboard-copy",
+            elementMatches: false,
+            capturedRange: nil,
+            currentRange: nil,
+            capturedText: "meeting",
+            currentText: "meeting",
+            capturedRole: "AXTextArea",
+            currentRole: "AXTextArea",
+            capturedWindowTitle: "Draft",
+            currentWindowTitle: "Draft"
+        ))
         XCTAssertFalse(AXTextInjector.capturedSelectionStillMatches(
             source: "clipboard-copy",
-            elementMatches: true,
+            elementMatches: false,
             capturedRange: nil,
             currentRange: nil,
             capturedText: "meeting",
             currentText: "changed",
-            capturedRole: nil,
-            currentRole: nil,
+            capturedRole: "AXTextArea",
+            currentRole: "AXTextArea",
             capturedWindowTitle: "Draft",
             currentWindowTitle: "Draft"
         ))
@@ -136,10 +180,10 @@ final class AXTextInjectorTests: XCTestCase {
             currentRange: nil,
             capturedText: "meeting",
             currentText: "meeting",
-            capturedRole: nil,
-            currentRole: nil,
+            capturedRole: "AXTextArea",
+            currentRole: "AXTextArea",
             capturedWindowTitle: "Draft",
-            currentWindowTitle: "Draft"
+            currentWindowTitle: "Other Draft"
         ))
     }
 

--- a/Tests/TypefluxTests/AXTextInjectorTests.swift
+++ b/Tests/TypefluxTests/AXTextInjectorTests.swift
@@ -2,6 +2,23 @@ import ApplicationServices
 @testable import Typeflux
 import XCTest
 
+private final class LockedTestFlag: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storedValue = false
+
+    var value: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return storedValue
+    }
+
+    func setTrue() {
+        lock.lock()
+        storedValue = true
+        lock.unlock()
+    }
+}
+
 final class AXTextInjectorTests: XCTestCase {
     func testSelectionReplacementWorkRunsOffMainThread() async throws {
         let injector = AXTextInjector()
@@ -11,6 +28,34 @@ final class AXTextInjectorTests: XCTestCase {
         }
 
         XCTAssertFalse(ranOnMainThread)
+    }
+
+    func testCancelledQueuedSelectionReplacementWorkDoesNotRun() async throws {
+        let injector = AXTextInjector()
+        let queueBlocked = DispatchSemaphore(value: 0)
+        let releaseQueue = DispatchSemaphore(value: 0)
+        injector.selectionReplacementQueue.async {
+            queueBlocked.signal()
+            releaseQueue.wait()
+        }
+        XCTAssertEqual(queueBlocked.wait(timeout: .now() + 1), .success)
+
+        let workRan = LockedTestFlag()
+        let task = Task {
+            try await injector.performSelectionReplacementWork {
+                workRan.setTrue()
+            }
+        }
+        task.cancel()
+        releaseQueue.signal()
+
+        do {
+            try await task.value
+            XCTFail("Expected cancellation")
+        } catch is CancellationError {
+            // Expected.
+        }
+        XCTAssertFalse(workRan.value)
     }
 
     func testSelectionReplacementContextCanOnlyBeConsumedOnce() {
@@ -184,6 +229,40 @@ final class AXTextInjectorTests: XCTestCase {
             currentRole: "AXTextArea",
             capturedWindowTitle: "Draft",
             currentWindowTitle: "Other Draft"
+        ))
+        XCTAssertFalse(AXTextInjector.capturedSelectionStillMatches(
+            source: "clipboard-copy",
+            elementMatches: false,
+            capturedRange: nil,
+            currentRange: nil,
+            capturedText: "meeting",
+            currentText: "meeting",
+            capturedRole: "AXTextArea",
+            currentRole: "AXTextArea",
+            capturedIdentifier: "composer-a",
+            currentIdentifier: "composer-b",
+            capturedPosition: CGPoint(x: 10, y: 20),
+            currentPosition: CGPoint(x: 10, y: 20),
+            capturedSize: CGSize(width: 300, height: 120),
+            currentSize: CGSize(width: 300, height: 120),
+            capturedWindowTitle: "Draft",
+            currentWindowTitle: "Draft"
+        ))
+        XCTAssertFalse(AXTextInjector.capturedSelectionStillMatches(
+            source: "clipboard-copy",
+            elementMatches: false,
+            capturedRange: nil,
+            currentRange: nil,
+            capturedText: "meeting",
+            currentText: "meeting",
+            capturedRole: "AXTextArea",
+            currentRole: "AXTextArea",
+            capturedPosition: CGPoint(x: 10, y: 20),
+            currentPosition: CGPoint(x: 40, y: 20),
+            capturedSize: CGSize(width: 300, height: 120),
+            currentSize: CGSize(width: 300, height: 120),
+            capturedWindowTitle: "Draft",
+            currentWindowTitle: "Draft"
         ))
     }
 

--- a/Tests/TypefluxTests/WorkflowControllerProcessingTests.swift
+++ b/Tests/TypefluxTests/WorkflowControllerProcessingTests.swift
@@ -94,9 +94,9 @@ final class WorkflowControllerProcessingTests: XCTestCase {
         XCTAssertTrue(textInjector.insertedTexts.isEmpty)
     }
 
-    func testApplyTextCopiesResultWhenInsertThrows() async {
+    func testApplyTextPresentsResultWithoutChangingClipboardWhenReplacementThrows() async {
         let textInjector = MockProcessingTextInjector(
-            insertError: NSError(
+            replaceError: NSError(
                 domain: "AXTextInjector",
                 code: 2,
                 userInfo: [NSLocalizedDescriptionKey: "Paste insertion could not be verified"]
@@ -108,14 +108,20 @@ final class WorkflowControllerProcessingTests: XCTestCase {
             clipboard: clipboard
         )
 
-        let (outcome, processed) = await controller.applyText("Manual copy fallback", replace: false)
+        let (outcome, processed) = await controller.applyText("Manual copy fallback", replace: true)
 
-        XCTAssertEqual(outcome, .copiedToClipboard)
+        XCTAssertEqual(outcome, .presentedInDialog)
         XCTAssertEqual(processed, "Manual copy fallback")
         XCTAssertEqual(controller.lastDialogResultText, "Manual copy fallback")
-        XCTAssertEqual(clipboard.storedText, "Manual copy fallback")
-        XCTAssertTrue(controller.overlayController.isShowingPassiveNotice)
+        XCTAssertNil(clipboard.storedText)
+        XCTAssertTrue(controller.overlayController.isShowingResultDialogForTesting)
+        XCTAssertFalse(controller.overlayController.isShowingPassiveNotice)
         XCTAssertTrue(textInjector.insertedTexts.isEmpty)
+        XCTAssertTrue(textInjector.replacedTexts.isEmpty)
+
+        controller.copyLastResultFromDialog()
+
+        XCTAssertEqual(clipboard.storedText, "Manual copy fallback")
     }
 
     func testCancelledSelectionApplyDoesNotCommitLateReplacement() async {
@@ -139,7 +145,9 @@ final class WorkflowControllerProcessingTests: XCTestCase {
         task.cancel()
         let (outcome, _) = await task.value
 
-        XCTAssertEqual(outcome, .copiedToClipboard)
+        XCTAssertEqual(outcome, .presentedInDialog)
+        XCTAssertNil(controller.clipboard.getString())
+        XCTAssertTrue(controller.overlayController.isShowingResultDialogForTesting)
         XCTAssertTrue(injector.replacedTexts.isEmpty)
     }
 


### PR DESCRIPTION
Closes GUL-75

## Summary

- accept rebuilt Electron/Chromium accessibility elements when a fresh selection copy plus process/window/control semantics still identify the original target
- make selection paste validation finish before changing the clipboard, then commit clipboard write and Cmd-V together
- restore the result dialog fallback: show generated text and copy only after the user clicks Copy

## Verification

- `swift test`: 2,532 XCTest + 8 Swift Testing tests passed
- focused selection/fallback regression tests passed
- `xcodebuild -project TypefluxApp.xcodeproj -scheme TypefluxApp -configuration Debug CODE_SIGNING_ALLOWED=NO build` passed
- `swift build -Xswiftc -strict-concurrency=complete` passed (existing unrelated warnings remain)
- `git diff --check` passed
