### PR TITLE
GUL-81: restore voice processing fallback

### DIFF
--- a/Sources/Typeflux/Resources/en.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/en.lproj/Localizable.strings
@@ -154,7 +154,7 @@
 "settings.advanced.soundEffects.title" = "Enable sound effects";
 "settings.advanced.soundEffects.subtitle" = "Play start, done, and error sounds during recording workflow feedback.";
 "settings.advanced.voiceProcessingTimeout.title" = "Recognition wait time";
-"settings.advanced.voiceProcessingTimeout.subtitle" = "Set the maximum time for speech recognition and AI processing. Typeflux stops and reports a timeout if processing does not finish in time.";
+"settings.advanced.voiceProcessingTimeout.subtitle" = "Choose how long cloud speech recognition and AI rewriting get priority before Typeflux uses the available fallback result.";
 "settings.advanced.voiceProcessingTimeout.option" = "%d seconds";
 "settings.advanced.autoUpdate.title" = "Automatic Updates";
 "settings.advanced.autoUpdate.subtitle" = "Automatically check for and install updates every 3 hours.";

--- a/Sources/Typeflux/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/ja.lproj/Localizable.strings
@@ -154,7 +154,7 @@
 "settings.advanced.soundEffects.title" = "効果音を有効にする";
 "settings.advanced.soundEffects.subtitle" = "ワークフローのフィードバックの記録中に、開始音、完了音、エラー音を再生します。";
 "settings.advanced.voiceProcessingTimeout.title" = "認識の待機時間";
-"settings.advanced.voiceProcessingTimeout.subtitle" = "音声認識と AI 処理の最大時間を設定します。時間内に完了しない場合は処理を停止してタイムアウトを通知します。";
+"settings.advanced.voiceProcessingTimeout.subtitle" = "クラウド音声認識と AI 書き換えを優先して待つ時間を選択します。時間を超えると、利用可能な代替結果を使用します。";
 "settings.advanced.voiceProcessingTimeout.option" = "%d 秒";
 "settings.advanced.autoUpdate.title" = "自動アップデート";
 "settings.advanced.autoUpdate.subtitle" = "3 時間ごとに自動的に新しいバージョンを確認してインストールします。";

--- a/Sources/Typeflux/Resources/ko.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/ko.lproj/Localizable.strings
@@ -154,7 +154,7 @@
 "settings.advanced.soundEffects.title" = "음향 효과 활성화";
 "settings.advanced.soundEffects.subtitle" = "워크플로 피드백을 기록하는 동안 시작, 완료 및 오류 소리를 재생합니다.";
 "settings.advanced.voiceProcessingTimeout.title" = "인식 대기 시간";
-"settings.advanced.voiceProcessingTimeout.subtitle" = "음성 인식과 AI 처리의 최대 시간을 설정합니다. 제시간에 완료되지 않으면 처리를 중지하고 시간 초과를 알립니다.";
+"settings.advanced.voiceProcessingTimeout.subtitle" = "클라우드 음성 인식과 AI 재작성 결과를 우선 대기할 시간을 선택합니다. 시간이 지나면 사용 가능한 대체 결과를 사용합니다.";
 "settings.advanced.voiceProcessingTimeout.option" = "%d초";
 "settings.advanced.autoUpdate.title" = "자동 업데이트";
 "settings.advanced.autoUpdate.subtitle" = "3시간마다 자동으로 새 버전을 확인하고 설치합니다.";

--- a/Sources/Typeflux/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/zh-Hans.lproj/Localizable.strings
@@ -146,7 +146,7 @@
 "settings.advanced.soundEffects.title" = "启用声音特效";
 "settings.advanced.soundEffects.subtitle" = "在开始录音、完成操作和发生错误时播放提示音。";
 "settings.advanced.voiceProcessingTimeout.title" = "识别等待时间";
-"settings.advanced.voiceProcessingTimeout.subtitle" = "设置语音识别和 AI 处理的最长时间，未能按时完成时将停止处理并提示超时。";
+"settings.advanced.voiceProcessingTimeout.subtitle" = "设置云端语音识别和 AI 改写的优先等待时间，超时后使用已有的备用结果。";
 "settings.advanced.voiceProcessingTimeout.option" = "%d 秒";
 "settings.advanced.autoUpdate.title" = "自动更新";
 "settings.advanced.autoUpdate.subtitle" = "每 3 小时自动检查并安装新版本。";

--- a/Sources/Typeflux/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/Typeflux/Resources/zh-Hant.lproj/Localizable.strings
@@ -146,7 +146,7 @@
 "settings.advanced.soundEffects.title" = "啟用音效";
 "settings.advanced.soundEffects.subtitle" = "在開始錄音、完成操作與發生錯誤時播放提示音。";
 "settings.advanced.voiceProcessingTimeout.title" = "辨識等待時間";
-"settings.advanced.voiceProcessingTimeout.subtitle" = "設定語音辨識和 AI 處理的最長時間，未能按時完成時將停止處理並提示逾時。";
+"settings.advanced.voiceProcessingTimeout.subtitle" = "設定雲端語音辨識和 AI 改寫的優先等待時間，逾時後使用已有的備用結果。";
 "settings.advanced.voiceProcessingTimeout.option" = "%d 秒";
 "settings.advanced.autoUpdate.title" = "自動更新";
 "settings.advanced.autoUpdate.subtitle" = "每 3 小時自動檢查並安裝新版本。";

--- a/Sources/Typeflux/Workflow/WorkflowController+Persona.swift
+++ b/Sources/Typeflux/Workflow/WorkflowController+Persona.swift
@@ -176,8 +176,8 @@ extension WorkflowController {
 
         cancelCurrentProcessing(resetUI: false, reason: L("workflow.cancel.newRecording"))
         let sessionID = beginProcessingSession()
-        let timeoutSeconds = settingsStore.voiceProcessingTimeout.seconds
-        startProcessingTimeout(sessionID: sessionID, timeoutSeconds: timeoutSeconds)
+        let fallbackWaitSeconds = settingsStore.voiceProcessingTimeout.seconds
+        startProcessingWatchdog(sessionID: sessionID)
 
         var record = HistoryRecord(
             date: Date(),
@@ -194,7 +194,7 @@ extension WorkflowController {
 
         Task { @MainActor in
             self.appState.setStatus(.processing)
-            self.overlayController.showLLMProcessing(timeout: timeoutSeconds)
+            self.overlayController.showLLMProcessing(timeout: fallbackWaitSeconds)
         }
 
         let shouldShowResultDialog = shouldPresentResultDialog(for: context.snapshot)
@@ -300,7 +300,7 @@ extension WorkflowController {
                     if shouldPresentBilling {
                         await presentCloudBillingError(billingError)
                     }
-                    cancelProcessingTimeout()
+                    cancelProcessingWatchdog()
                     return
                 }
 
@@ -316,7 +316,7 @@ extension WorkflowController {
                 }
             }
 
-            cancelProcessingTimeout()
+            cancelProcessingWatchdog()
         }
     }
 }

--- a/Sources/Typeflux/Workflow/WorkflowController+Processing.swift
+++ b/Sources/Typeflux/Workflow/WorkflowController+Processing.swift
@@ -535,13 +535,13 @@ extension WorkflowController {
             let personaPrompt = activePersonaProfile.map {
                 settingsStore.resolvedPersonaPrompt(for: $0)
             }
-            let processingTimeoutSeconds = settingsStore.voiceProcessingTimeout.seconds
+            let fallbackWaitSeconds = settingsStore.voiceProcessingTimeout.seconds
 
             NetworkDebugLogger.logMessage(selectionSnapshotLog(selectionSnapshot))
             if WorkflowOverlayPresentationPolicy.shouldShowProcessingAfterRecording() {
                 await MainActor.run {
                     self.appState.setStatus(.processing)
-                    self.overlayController.showProcessing(timeout: processingTimeoutSeconds)
+                    self.overlayController.showProcessing(timeout: fallbackWaitSeconds)
                 }
             }
 
@@ -576,10 +576,7 @@ extension WorkflowController {
             activeProcessingRecordID = record.id
             let sessionID = beginProcessingSession()
 
-            startProcessingTimeout(
-                sessionID: sessionID,
-                timeoutSeconds: processingTimeoutSeconds
-            )
+            startProcessingWatchdog(sessionID: sessionID)
             processingTask = Task { [weak self] in
                 guard let self else { return }
                 defer {
@@ -613,7 +610,7 @@ extension WorkflowController {
                 NetworkDebugLogger.logMessage(
                     "[Ask Timing] process completed in \(Self.formatDurationSince(processingStartedAt))"
                 )
-                cancelProcessingTimeout()
+                cancelProcessingWatchdog()
                 await MainActor.run {
                     if self.processingSessionID == sessionID {
                         self.processingTask = nil
@@ -2170,7 +2167,7 @@ extension WorkflowController {
         processingSessionID = UUID()
         processingTask?.cancel()
         processingTask = nil
-        cancelProcessingTimeout()
+        cancelProcessingWatchdog()
         lastRetryableFailureRecord = nil
 
         if let activeProcessingRecordID,

--- a/Sources/Typeflux/Workflow/WorkflowController.swift
+++ b/Sources/Typeflux/Workflow/WorkflowController.swift
@@ -11,6 +11,9 @@ struct RecordingStartupContext: Sendable, Equatable {
 final class WorkflowController {
     let logger = Logger(subsystem: "ai.gulu.app.typeflux", category: "WorkflowController")
     static let recordingTimeoutNanoseconds: UInt64 = 600_000_000_000 // 10 minutes
+    /// Last-resort protection for a processing pipeline that remains stuck.
+    /// User-configured recognition wait time controls fallback selection instead.
+    static let processingWatchdogTimeoutSeconds: TimeInterval = 30
     static let minimumRecordingDuration: TimeInterval = 0.35
     static let recordingTailCaptureDuration: Duration = .milliseconds(200)
     static let shortAudioRetryDuration: TimeInterval = 1.5
@@ -132,7 +135,7 @@ final class WorkflowController {
     var audioRecorderStartedAt: TimeInterval?
     var recordingStartupContext: RecordingStartupContext?
     var recordingTimeoutTask: Task<Void, Never>?
-    var processingTimeoutTask: Task<Void, Never>?
+    var processingWatchdogTask: Task<Void, Never>?
     var selectionTask: Task<TextSelectionSnapshot, Never>?
     var inputContextTask: Task<InputContextSnapshot?, Never>?
     var processingTask: Task<Void, Never>?
@@ -425,19 +428,16 @@ final class WorkflowController {
         cancelCurrentProcessing(resetUI: false, reason: L("workflow.cancel.retry"))
 
         let sessionID = beginProcessingSession()
-        let timeoutSeconds = settingsStore.voiceProcessingTimeout.seconds
-        startProcessingTimeout(
-            sessionID: sessionID,
-            timeoutSeconds: timeoutSeconds
-        )
+        let fallbackWaitSeconds = settingsStore.voiceProcessingTimeout.seconds
+        startProcessingWatchdog(sessionID: sessionID)
         processingTask = Task { [weak self] in
             guard let self else { return }
             await MainActor.run {
                 self.appState.setStatus(.processing)
-                self.overlayController.showProcessing(timeout: timeoutSeconds)
+                self.overlayController.showProcessing(timeout: fallbackWaitSeconds)
             }
             await reprocess(record: record, sessionID: sessionID)
-            cancelProcessingTimeout()
+            cancelProcessingWatchdog()
             await MainActor.run {
                 if self.processingSessionID == sessionID {
                     self.processingTask = nil
@@ -514,26 +514,26 @@ final class WorkflowController {
         }
     }
 
-    func startProcessingTimeout(
+    func startProcessingWatchdog(
         sessionID: UUID,
-        timeoutSeconds: TimeInterval
+        timeoutSeconds: TimeInterval = WorkflowController.processingWatchdogTimeoutSeconds
     ) {
         let timeoutNanoseconds = UInt64(max(0, timeoutSeconds) * 1_000_000_000)
-        processingTimeoutTask?.cancel()
-        processingTimeoutTask = Task { [weak self] in
+        processingWatchdogTask?.cancel()
+        processingWatchdogTask = Task { [weak self] in
             try? await Task.sleep(nanoseconds: timeoutNanoseconds)
             guard !Task.isCancelled else { return }
-            NSLog("[Workflow] Processing timeout after %llu seconds", timeoutNanoseconds / 1_000_000_000)
-            self?.handleProcessingTimeout(sessionID: sessionID, timeoutSeconds: timeoutSeconds)
+            NSLog("[Workflow] Processing watchdog fired after %llu seconds", timeoutNanoseconds / 1_000_000_000)
+            await self?.handleProcessingWatchdog(sessionID: sessionID, timeoutSeconds: timeoutSeconds)
         }
     }
 
-    func cancelProcessingTimeout() {
-        processingTimeoutTask?.cancel()
-        processingTimeoutTask = nil
+    func cancelProcessingWatchdog() {
+        processingWatchdogTask?.cancel()
+        processingWatchdogTask = nil
     }
 
-    func handleProcessingTimeout(sessionID: UUID, timeoutSeconds: TimeInterval) {
+    func handleProcessingWatchdog(sessionID: UUID, timeoutSeconds: TimeInterval) async {
         guard processingSessionID == sessionID else { return }
         let recordID = activeProcessingRecordID
         let timeoutRecord = recordID.flatMap { historyStore.record(id: $0) }
@@ -545,7 +545,7 @@ final class WorkflowController {
         }
         let timeoutSeconds = Int(timeoutSeconds)
         cancelCurrentProcessing(resetUI: false, reason: L("workflow.timeout.reason", timeoutSeconds))
-        Task { @MainActor in
+        await MainActor.run {
             self.lastRetryableFailureRecord = timeoutRecord
             self.soundEffectPlayer.play(.error)
             self.appState.setStatus(.failed(message: L("workflow.timeout.status")))

--- a/Tests/TypefluxTests/WorkflowControllerProcessingTests.swift
+++ b/Tests/TypefluxTests/WorkflowControllerProcessingTests.swift
@@ -670,7 +670,16 @@ final class WorkflowControllerProcessingTests: XCTestCase {
         XCTAssertEqual(controller.llmTimeoutAfterTranscription, 30)
     }
 
-    func testProcessingDeadlineCancelsSessionAndReportsConfiguredTimeout() async throws {
+    func testProcessingWatchdogIsIndependentFromFallbackWaitSetting() {
+        let controller = makeWorkflowController(configureSettings: { settingsStore in
+            settingsStore.voiceProcessingTimeout = .oneSecond
+        })
+
+        XCTAssertEqual(controller.settingsStore.voiceProcessingTimeout.seconds, 1)
+        XCTAssertEqual(WorkflowController.processingWatchdogTimeoutSeconds, 30)
+    }
+
+    func testProcessingWatchdogCancelsStuckSession() async throws {
         let historyStore = MockProcessingHistoryStore()
         let controller = makeWorkflowController(historyStore: historyStore)
         let record = HistoryRecord(
@@ -684,7 +693,7 @@ final class WorkflowControllerProcessingTests: XCTestCase {
         controller.activeProcessingRecordID = record.id
         let sessionID = controller.beginProcessingSession()
 
-        controller.startProcessingTimeout(sessionID: sessionID, timeoutSeconds: 0.01)
+        controller.startProcessingWatchdog(sessionID: sessionID, timeoutSeconds: 0.01)
         await waitUntil { controller.processingSessionID != sessionID }
         await waitForMainActorWork()
 


### PR DESCRIPTION
## Summary

- decouple the configurable recognition/fallback wait from the processing watchdog
- retain a fixed 30-second last-resort watchdog for genuinely stuck pipelines
- restore the settings copy in all locales and add watchdog regression coverage

## Testing

- `make coverage` (2,534 XCTest tests + 8 Swift Testing tests passed; repository line coverage 40.10%)
- `swift test --filter WorkflowControllerProcessingTests.testProcessingWatchdog` (2 passed)
- `git diff --check`

Closes GUL-81
