### PR TITLE
GUL-75: make selection matching evidence-aware

### DIFF
--- a/Sources/Typeflux/TextInjection/AXTextInjector+Selection.swift
+++ b/Sources/Typeflux/TextInjection/AXTextInjector+Selection.swift
@@ -158,6 +158,7 @@ extension AXTextInjector {
 
         let context = SelectionContext(
             element: element,
+            windowElement: selectionWindow ?? focusedWindow,
             range: range,
             processID: processID,
             processName: processName,
@@ -167,6 +168,12 @@ extension AXTextInjector {
             identifier: copyStringAttribute(kAXIdentifierAttribute as String, from: element),
             position: copyCGPointAttribute(kAXPositionAttribute as String, from: element),
             size: copyCGSizeAttribute(kAXSizeAttribute as String, from: element),
+            windowPosition: (selectionWindow ?? focusedWindow).flatMap {
+                copyCGPointAttribute(kAXPositionAttribute as String, from: $0)
+            },
+            windowSize: (selectionWindow ?? focusedWindow).flatMap {
+                copyCGSizeAttribute(kAXSizeAttribute as String, from: $0)
+            },
             windowTitle: selectionWindow.flatMap(windowTitle(of:)),
             isFocusedTarget: isFocusedTarget,
             source: "accessibility",

--- a/Sources/Typeflux/TextInjection/AXTextInjector+Transaction.swift
+++ b/Sources/Typeflux/TextInjection/AXTextInjector+Transaction.swift
@@ -28,6 +28,30 @@ extension AXTextInjector {
         case requiresPaste
     }
 
+    enum SelectionEvidence: String, Equatable {
+        case match
+        case conflict
+        case unavailable
+    }
+
+    struct SelectionFingerprintAssessment: Equatable {
+        let accepted: Bool
+        let text: SelectionEvidence
+        let range: SelectionEvidence
+        let role: SelectionEvidence
+        let subrole: SelectionEvidence
+        let identifier: SelectionEvidence
+        let frame: SelectionEvidence
+        let window: SelectionEvidence
+
+        var diagnosticSummary: String {
+            "accepted=\(accepted) text=\(text.rawValue) range=\(range.rawValue) "
+                + "role=\(role.rawValue) subrole=\(subrole.rawValue) "
+                + "identifier=\(identifier.rawValue) frame=\(frame.rawValue) "
+                + "window=\(window.rawValue)"
+        }
+    }
+
     static func capturedSelectionStillMatches(
         source: String,
         elementMatches: Bool,
@@ -45,23 +69,21 @@ extension AXTextInjector {
         currentPosition: CGPoint? = nil,
         capturedSize: CGSize? = nil,
         currentSize: CGSize? = nil,
+        windowElementMatches: Bool? = nil,
+        capturedWindowPosition: CGPoint? = nil,
+        currentWindowPosition: CGPoint? = nil,
+        capturedWindowSize: CGSize? = nil,
+        currentWindowSize: CGSize? = nil,
         capturedWindowTitle: String?,
         currentWindowTitle: String?
     ) -> Bool {
-        guard capturedText == currentText else {
-            return false
-        }
-
-        if source != "clipboard-copy" {
-            guard capturedRange?.location == currentRange?.location,
-                  capturedRange?.length == currentRange?.length
-            else {
-                return false
-            }
-        }
-
-        return capturedElementStillMatches(
+        selectionFingerprintAssessment(
+            source: source,
             elementMatches: elementMatches,
+            capturedRange: capturedRange,
+            currentRange: currentRange,
+            capturedText: capturedText,
+            currentText: currentText,
             capturedRole: capturedRole,
             currentRole: currentRole,
             capturedSubrole: capturedSubrole,
@@ -72,14 +94,23 @@ extension AXTextInjector {
             currentPosition: currentPosition,
             capturedSize: capturedSize,
             currentSize: currentSize,
+            windowElementMatches: windowElementMatches,
+            capturedWindowPosition: capturedWindowPosition,
+            currentWindowPosition: currentWindowPosition,
+            capturedWindowSize: capturedWindowSize,
+            currentWindowSize: currentWindowSize,
             capturedWindowTitle: capturedWindowTitle,
-            currentWindowTitle: currentWindowTitle,
-            allowsWindowScopedMatch: source == "clipboard-copy"
-        )
+            currentWindowTitle: currentWindowTitle
+        ).accepted
     }
 
-    private static func capturedElementStillMatches(
+    static func selectionFingerprintAssessment(
+        source: String,
         elementMatches: Bool,
+        capturedRange: CFRange?,
+        currentRange: CFRange?,
+        capturedText: String?,
+        currentText: String?,
         capturedRole: String?,
         currentRole: String?,
         capturedSubrole: String?,
@@ -90,51 +121,145 @@ extension AXTextInjector {
         currentPosition: CGPoint?,
         capturedSize: CGSize?,
         currentSize: CGSize?,
+        windowElementMatches: Bool?,
+        capturedWindowPosition: CGPoint?,
+        currentWindowPosition: CGPoint?,
+        capturedWindowSize: CGSize?,
+        currentWindowSize: CGSize?,
         capturedWindowTitle: String?,
-        currentWindowTitle: String?,
-        allowsWindowScopedMatch: Bool
-    ) -> Bool {
-        if elementMatches {
-            return true
-        }
+        currentWindowTitle: String?
+    ) -> SelectionFingerprintAssessment {
+        let textEvidence = compare(capturedText, currentText)
+        let rangeEvidence = source == "clipboard-copy"
+            ? .unavailable
+            : compareRange(capturedRange, currentRange)
+        let roleEvidence = compareRoleCapability(capturedRole, currentRole)
+        let subroleEvidence = compareNormalized(capturedSubrole, currentSubrole)
+        let identifierEvidence = compareNormalized(capturedIdentifier, currentIdentifier)
+        let frameEvidence = compareFrame(
+            capturedPosition: capturedPosition,
+            capturedSize: capturedSize,
+            currentPosition: currentPosition,
+            currentSize: currentSize
+        )
+        let windowEvidence = compareWindow(
+            elementMatches: windowElementMatches,
+            capturedPosition: capturedWindowPosition,
+            capturedSize: capturedWindowSize,
+            currentPosition: currentWindowPosition,
+            currentSize: currentWindowSize,
+            capturedTitle: capturedWindowTitle,
+            currentTitle: currentWindowTitle
+        )
 
-        guard capturedRole == currentRole,
-              capturedSubrole == currentSubrole,
-              capturedRole?.isEmpty == false
+        let semanticElementEvidence = [roleEvidence, subroleEvidence, identifierEvidence, frameEvidence]
+        let hasElementConflict = roleEvidence == .conflict
+            || (!elementMatches && semanticElementEvidence.dropFirst().contains(.conflict))
+        let hasConflict = hasElementConflict
+            || (source == "clipboard-copy" && !elementMatches && windowEvidence == .conflict)
+        let hasStrongIdentityMatch = elementMatches
+            || identifierEvidence == .match
+            || frameEvidence == .match
+            || windowEvidence == .match
+        let nativeIdentityMatches = elementMatches || (
+            roleEvidence == .match
+                && (identifierEvidence == .match || frameEvidence == .match)
+        )
+        let accepted = textEvidence == .match
+            && (source == "clipboard-copy" || rangeEvidence == .match)
+            && !hasConflict
+            && (source == "clipboard-copy" ? hasStrongIdentityMatch : nativeIdentityMatches)
+
+        return SelectionFingerprintAssessment(
+            accepted: accepted,
+            text: textEvidence,
+            range: rangeEvidence,
+            role: roleEvidence,
+            subrole: subroleEvidence,
+            identifier: identifierEvidence,
+            frame: frameEvidence,
+            window: windowEvidence
+        )
+    }
+
+    private static func compare<T: Equatable>(_ captured: T?, _ current: T?) -> SelectionEvidence {
+        guard let captured, let current else { return .unavailable }
+        return captured == current ? .match : .conflict
+    }
+
+    private static func compareNormalized(_ captured: String?, _ current: String?) -> SelectionEvidence {
+        compare(normalizedEvidence(captured), normalizedEvidence(current))
+    }
+
+    private static func compareRange(_ captured: CFRange?, _ current: CFRange?) -> SelectionEvidence {
+        guard let captured, let current else { return .unavailable }
+        return captured.location == current.location && captured.length == current.length ? .match : .conflict
+    }
+
+    private static func compareFrame(
+        capturedPosition: CGPoint?,
+        capturedSize: CGSize?,
+        currentPosition: CGPoint?,
+        currentSize: CGSize?
+    ) -> SelectionEvidence {
+        guard let capturedPosition, let capturedSize, let currentPosition, let currentSize else {
+            return .unavailable
+        }
+        return capturedPosition == currentPosition && capturedSize == currentSize ? .match : .conflict
+    }
+
+    private static func compareRoleCapability(_ captured: String?, _ current: String?) -> SelectionEvidence {
+        let captured = normalizedEvidence(captured)
+        let current = normalizedEvidence(current)
+        if captured.map(nonEditableFalsePositiveRoles.contains) == true
+            || current.map(nonEditableFalsePositiveRoles.contains) == true {
+            return .conflict
+        }
+        guard let captured, let current else { return .unavailable }
+        if captured == current {
+            return .match
+        }
+        let compatibleRoles = nativeEditableRoles.union(genericEditableRoles).union(opaqueContainerRoles)
+        return compatibleRoles.contains(captured) && compatibleRoles.contains(current) ? .match : .conflict
+    }
+
+    private static func compareWindow(
+        elementMatches: Bool?,
+        capturedPosition: CGPoint?,
+        capturedSize: CGSize?,
+        currentPosition: CGPoint?,
+        currentSize: CGSize?,
+        capturedTitle: String?,
+        currentTitle: String?
+    ) -> SelectionEvidence {
+        if elementMatches == true {
+            return .match
+        }
+        let frame = compareFrame(
+            capturedPosition: capturedPosition,
+            capturedSize: capturedSize,
+            currentPosition: currentPosition,
+            currentSize: currentSize
+        )
+        let title = compareNormalized(capturedTitle, currentTitle)
+        if frame == .conflict || title == .conflict {
+            return .conflict
+        }
+        // A title is not unique enough to identify a window by itself. A stable
+        // frame plus a non-conflicting title can identify a rebuilt AXWindow.
+        if frame == .match {
+            return .match
+        }
+        return elementMatches == false ? .conflict : .unavailable
+    }
+
+    private static func normalizedEvidence(_ value: String?) -> String? {
+        guard let normalized = value?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !normalized.isEmpty
         else {
-            return false
+            return nil
         }
-
-        let normalizedCapturedWindowTitle = capturedWindowTitle?
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-        let normalizedCurrentWindowTitle = currentWindowTitle?
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-        let windowMatches = normalizedCapturedWindowTitle?.isEmpty == false &&
-            normalizedCapturedWindowTitle == normalizedCurrentWindowTitle
-
-        // Electron and Chromium frequently recreate the focused AX element while
-        // preserving the same role and window. A fresh Cmd-C that returned the
-        // original selected text is strong enough evidence for clipboard-backed
-        // selections. Prefer identifier/frame when available; otherwise use the
-        // focused window title, which is also captured for opaque AX hierarchies.
-        // Prefer the strongest evidence that both snapshots expose. A matching
-        // window title must never override an explicitly different identifier or
-        // frame; that could redirect a result to another editor in the same window.
-        let hasCapturedIdentifier = capturedIdentifier?.isEmpty == false
-        let hasCurrentIdentifier = currentIdentifier?.isEmpty == false
-        if hasCapturedIdentifier, hasCurrentIdentifier {
-            let identifierMatches = capturedIdentifier == currentIdentifier
-            return identifierMatches && (allowsWindowScopedMatch || windowMatches)
-        }
-
-        let hasCapturedFrame = capturedPosition != nil && capturedSize != nil
-        let hasCurrentFrame = currentPosition != nil && currentSize != nil
-        if hasCapturedFrame, hasCurrentFrame {
-            let frameMatches = capturedPosition == currentPosition && capturedSize == currentSize
-            return frameMatches && (allowsWindowScopedMatch || windowMatches)
-        }
-
-        return allowsWindowScopedMatch && windowMatches
+        return normalized
     }
 
     func replaceSelection(text: String, target: TextSelectionSnapshot?) async throws {
@@ -324,12 +449,28 @@ extension AXTextInjector {
         let currentIdentifier = copyStringAttribute(kAXIdentifierAttribute as String, from: currentElement)
         let currentPosition = copyCGPointAttribute(kAXPositionAttribute as String, from: currentElement)
         let currentSize = copyCGSizeAttribute(kAXSizeAttribute as String, from: currentElement)
+        let currentWindowElement = focusedWindowElement(for: processID) ?? containingWindow(of: currentElement)
+        if let currentWindowElement {
+            AXUIElementSetMessagingTimeout(currentWindowElement, Self.replacementAXMessagingTimeout)
+        }
+        let windowElementMatches: Bool? = if let capturedWindow = context.windowElement,
+                                            let currentWindowElement {
+            CFEqual(capturedWindow, currentWindowElement)
+        } else {
+            nil
+        }
+        let currentWindowPosition = currentWindowElement.flatMap {
+            copyCGPointAttribute(kAXPositionAttribute as String, from: $0)
+        }
+        let currentWindowSize = currentWindowElement.flatMap {
+            copyCGSizeAttribute(kAXSizeAttribute as String, from: $0)
+        }
         let currentWindowTitle = lightweightWindowTitle(
             of: currentElement,
             fallbackProcessID: processID
         )
 
-        guard Self.capturedSelectionStillMatches(
+        let assessment = Self.selectionFingerprintAssessment(
             source: context.source,
             elementMatches: elementMatches,
             capturedRange: context.range,
@@ -346,9 +487,18 @@ extension AXTextInjector {
             currentPosition: currentPosition,
             capturedSize: context.size,
             currentSize: currentSize,
+            windowElementMatches: windowElementMatches,
+            capturedWindowPosition: context.windowPosition,
+            currentWindowPosition: currentWindowPosition,
+            capturedWindowSize: context.windowSize,
+            currentWindowSize: currentWindowSize,
             capturedWindowTitle: context.windowTitle,
             currentWindowTitle: currentWindowTitle
-        ) else {
+        )
+        NetworkDebugLogger.logMessage(
+            "[Text Injection] selection fingerprint \(assessment.diagnosticSummary)"
+        )
+        guard assessment.accepted else {
             throw selectionReplacementError(
                 code: 29,
                 description: "The selected text changed while the result was being generated"

--- a/Sources/Typeflux/TextInjection/AXTextInjector.swift
+++ b/Sources/Typeflux/TextInjection/AXTextInjector.swift
@@ -179,6 +179,7 @@ final class AXTextInjector: TextInjector {
 
     struct SelectionContext {
         let element: AXUIElement
+        let windowElement: AXUIElement?
         let range: CFRange?
         let processID: pid_t?
         let processName: String?
@@ -188,6 +189,8 @@ final class AXTextInjector: TextInjector {
         let identifier: String?
         let position: CGPoint?
         let size: CGSize?
+        let windowPosition: CGPoint?
+        let windowSize: CGSize?
         let windowTitle: String?
         let isFocusedTarget: Bool
         let source: String
@@ -195,6 +198,7 @@ final class AXTextInjector: TextInjector {
 
         init(
             element: AXUIElement,
+            windowElement: AXUIElement? = nil,
             range: CFRange?,
             processID: pid_t?,
             processName: String?,
@@ -204,12 +208,15 @@ final class AXTextInjector: TextInjector {
             identifier: String? = nil,
             position: CGPoint? = nil,
             size: CGSize? = nil,
+            windowPosition: CGPoint? = nil,
+            windowSize: CGSize? = nil,
             windowTitle: String?,
             isFocusedTarget: Bool,
             source: String,
             capturedAt: Date
         ) {
             self.element = element
+            self.windowElement = windowElement
             self.range = range
             self.processID = processID
             self.processName = processName
@@ -219,6 +226,8 @@ final class AXTextInjector: TextInjector {
             self.identifier = identifier
             self.position = position
             self.size = size
+            self.windowPosition = windowPosition
+            self.windowSize = windowSize
             self.windowTitle = windowTitle
             self.isFocusedTarget = isFocusedTarget
             self.source = source
@@ -849,6 +858,7 @@ final class AXTextInjector: TextInjector {
             } ?? (focusedElement != nil)
             let context = SelectionContext(
                 element: focusedElement ?? AXUIElementCreateSystemWide(),
+                windowElement: focusedWindow ?? selectionWindow,
                 range: nil,
                 processID: processID,
                 processName: processName,
@@ -866,6 +876,12 @@ final class AXTextInjector: TextInjector {
                     copyCGPointAttribute(kAXPositionAttribute as String, from: $0)
                 },
                 size: focusedElement.flatMap {
+                    copyCGSizeAttribute(kAXSizeAttribute as String, from: $0)
+                },
+                windowPosition: (focusedWindow ?? selectionWindow).flatMap {
+                    copyCGPointAttribute(kAXPositionAttribute as String, from: $0)
+                },
+                windowSize: (focusedWindow ?? selectionWindow).flatMap {
                     copyCGSizeAttribute(kAXSizeAttribute as String, from: $0)
                 },
                 windowTitle: selectionWindow.flatMap(windowTitle(of:)) ?? focusedWindowTitle(for: processID),

--- a/Tests/TypefluxTests/AXTextInjectorTests.swift
+++ b/Tests/TypefluxTests/AXTextInjectorTests.swift
@@ -149,6 +149,25 @@ final class AXTextInjectorTests: XCTestCase {
         ))
     }
 
+    func testAccessibilitySelectionUsesElementIdentityWhenWindowTitleChanges() {
+        let range = CFRange(location: 4, length: 7)
+
+        XCTAssertTrue(AXTextInjector.capturedSelectionStillMatches(
+            source: "accessibility",
+            elementMatches: false,
+            capturedRange: range,
+            currentRange: range,
+            capturedText: "meeting",
+            currentText: "meeting",
+            capturedRole: "AXTextArea",
+            currentRole: "AXTextArea",
+            capturedIdentifier: "editor",
+            currentIdentifier: "editor",
+            capturedWindowTitle: "Draft",
+            currentWindowTitle: "Draft — Edited"
+        ))
+    }
+
     func testClipboardCapturedSelectionAcceptsExactOrSemanticElementIdentity() {
         XCTAssertTrue(AXTextInjector.capturedSelectionStillMatches(
             source: "clipboard-copy",
@@ -194,7 +213,7 @@ final class AXTextInjectorTests: XCTestCase {
             capturedWindowTitle: nil,
             currentWindowTitle: nil
         ))
-        XCTAssertTrue(AXTextInjector.capturedSelectionStillMatches(
+        XCTAssertFalse(AXTextInjector.capturedSelectionStillMatches(
             source: "clipboard-copy",
             elementMatches: false,
             capturedRange: nil,
@@ -264,6 +283,200 @@ final class AXTextInjectorTests: XCTestCase {
             capturedWindowTitle: "Draft",
             currentWindowTitle: "Draft"
         ))
+    }
+
+    func testClipboardFingerprintAcceptsMissingRoleBecomingEditableContainerInSameWindow() {
+        let assessment = AXTextInjector.selectionFingerprintAssessment(
+            source: "clipboard-copy",
+            elementMatches: false,
+            capturedRange: nil,
+            currentRange: CFRange(location: 0, length: 0),
+            capturedText: "meeting",
+            currentText: "meeting",
+            capturedRole: nil,
+            currentRole: "AXGroup",
+            capturedSubrole: nil,
+            currentSubrole: nil,
+            capturedIdentifier: nil,
+            currentIdentifier: nil,
+            capturedPosition: nil,
+            currentPosition: nil,
+            capturedSize: nil,
+            currentSize: nil,
+            windowElementMatches: true,
+            capturedWindowPosition: nil,
+            currentWindowPosition: nil,
+            capturedWindowSize: nil,
+            currentWindowSize: nil,
+            capturedWindowTitle: "ChatGPT",
+            currentWindowTitle: "ChatGPT"
+        )
+
+        XCTAssertTrue(assessment.accepted)
+        XCTAssertEqual(assessment.role, .unavailable)
+        XCTAssertEqual(assessment.window, .match)
+    }
+
+    func testClipboardFingerprintAcceptsCompatibleEditableRoleDrift() {
+        XCTAssertTrue(AXTextInjector.capturedSelectionStillMatches(
+            source: "clipboard-copy",
+            elementMatches: false,
+            capturedRange: nil,
+            currentRange: nil,
+            capturedText: "meeting",
+            currentText: "meeting",
+            capturedRole: "AXWebArea",
+            currentRole: "AXTextArea",
+            capturedIdentifier: "composer",
+            currentIdentifier: "composer",
+            capturedWindowTitle: "Draft",
+            currentWindowTitle: "Draft"
+        ))
+    }
+
+    func testClipboardFingerprintRejectsNonEditableRoleEvenWhenWindowMatches() {
+        let assessment = AXTextInjector.selectionFingerprintAssessment(
+            source: "clipboard-copy",
+            elementMatches: false,
+            capturedRange: nil,
+            currentRange: nil,
+            capturedText: "meeting",
+            currentText: "meeting",
+            capturedRole: nil,
+            currentRole: "AXButton",
+            capturedSubrole: nil,
+            currentSubrole: nil,
+            capturedIdentifier: nil,
+            currentIdentifier: nil,
+            capturedPosition: nil,
+            currentPosition: nil,
+            capturedSize: nil,
+            currentSize: nil,
+            windowElementMatches: true,
+            capturedWindowPosition: nil,
+            currentWindowPosition: nil,
+            capturedWindowSize: nil,
+            currentWindowSize: nil,
+            capturedWindowTitle: "Draft",
+            currentWindowTitle: "Draft"
+        )
+
+        XCTAssertFalse(assessment.accepted)
+        XCTAssertEqual(assessment.role, .conflict)
+    }
+
+    func testClipboardFingerprintRejectsSameTitleForDifferentWindow() {
+        let assessment = AXTextInjector.selectionFingerprintAssessment(
+            source: "clipboard-copy",
+            elementMatches: false,
+            capturedRange: nil,
+            currentRange: nil,
+            capturedText: "meeting",
+            currentText: "meeting",
+            capturedRole: "AXGroup",
+            currentRole: "AXGroup",
+            capturedSubrole: nil,
+            currentSubrole: nil,
+            capturedIdentifier: nil,
+            currentIdentifier: nil,
+            capturedPosition: nil,
+            currentPosition: nil,
+            capturedSize: nil,
+            currentSize: nil,
+            windowElementMatches: false,
+            capturedWindowPosition: nil,
+            currentWindowPosition: nil,
+            capturedWindowSize: nil,
+            currentWindowSize: nil,
+            capturedWindowTitle: "Draft",
+            currentWindowTitle: "Draft"
+        )
+
+        XCTAssertFalse(assessment.accepted)
+        XCTAssertEqual(assessment.window, .conflict)
+    }
+
+    func testClipboardFingerprintUsesAvailableStrongEvidenceWhenIdentifierDisappears() {
+        let assessment = AXTextInjector.selectionFingerprintAssessment(
+            source: "clipboard-copy",
+            elementMatches: false,
+            capturedRange: nil,
+            currentRange: nil,
+            capturedText: "meeting",
+            currentText: "meeting",
+            capturedRole: "AXGroup",
+            currentRole: "AXGroup",
+            capturedSubrole: nil,
+            currentSubrole: nil,
+            capturedIdentifier: "composer",
+            currentIdentifier: nil,
+            capturedPosition: nil,
+            currentPosition: nil,
+            capturedSize: nil,
+            currentSize: nil,
+            windowElementMatches: true,
+            capturedWindowPosition: nil,
+            currentWindowPosition: nil,
+            capturedWindowSize: nil,
+            currentWindowSize: nil,
+            capturedWindowTitle: "Draft",
+            currentWindowTitle: "Draft"
+        )
+
+        XCTAssertTrue(assessment.accepted)
+        XCTAssertEqual(assessment.identifier, .unavailable)
+    }
+
+    func testClipboardFingerprintAcceptsRebuiltWindowWithMatchingFrame() {
+        XCTAssertTrue(AXTextInjector.capturedSelectionStillMatches(
+            source: "clipboard-copy",
+            elementMatches: false,
+            capturedRange: nil,
+            currentRange: nil,
+            capturedText: "meeting",
+            currentText: "meeting",
+            capturedRole: "AXGroup",
+            currentRole: "AXGroup",
+            windowElementMatches: false,
+            capturedWindowPosition: CGPoint(x: 100, y: 80),
+            currentWindowPosition: CGPoint(x: 100, y: 80),
+            capturedWindowSize: CGSize(width: 900, height: 700),
+            currentWindowSize: CGSize(width: 900, height: 700),
+            capturedWindowTitle: "Draft",
+            currentWindowTitle: "Draft"
+        ))
+    }
+
+    func testClipboardFingerprintRejectsExplicitSubroleConflict() {
+        let assessment = AXTextInjector.selectionFingerprintAssessment(
+            source: "clipboard-copy",
+            elementMatches: false,
+            capturedRange: nil,
+            currentRange: nil,
+            capturedText: "meeting",
+            currentText: "meeting",
+            capturedRole: "AXGroup",
+            currentRole: "AXGroup",
+            capturedSubrole: "AXDocument",
+            currentSubrole: "AXDialog",
+            capturedIdentifier: nil,
+            currentIdentifier: nil,
+            capturedPosition: nil,
+            currentPosition: nil,
+            capturedSize: nil,
+            currentSize: nil,
+            windowElementMatches: true,
+            capturedWindowPosition: nil,
+            currentWindowPosition: nil,
+            capturedWindowSize: nil,
+            currentWindowSize: nil,
+            capturedWindowTitle: "Draft",
+            currentWindowTitle: "Draft"
+        )
+
+        XCTAssertFalse(assessment.accepted)
+        XCTAssertEqual(assessment.subrole, .conflict)
+        XCTAssertFalse(assessment.diagnosticSummary.contains("meeting"))
     }
 
     func testTargetCapabilityDistinguishesWritableNonWritableAndOpaqueTargets() {


### PR DESCRIPTION
## Summary

- replace binary selection matching with match/conflict/unavailable evidence
- retain actual AX window identity and frame for clipboard-backed selections
- accept Electron AX role drift when text and strong identity evidence remain stable
- reject explicit semantic conflicts and title-only window matches before touching the pasteboard
- add privacy-safe fingerprint diagnostics and regression coverage

## Validation

- `swift test` — 2541 XCTest + 8 Swift Testing tests passed
- `swift test --filter AXTextInjectorTests --enable-code-coverage` — 94 passed
- modified fingerprint decision block — 43/43 executable lines covered (100%)
- `swift build -Xswiftc -strict-concurrency=complete` — passed with pre-existing warnings
- `git diff --check` — passed

Manual verification in ChatGPT/Codex and other Electron/Chromium apps is recommended because real Accessibility element recreation depends on app state and macOS permissions.

Closes GUL-75
