### PR TITLE
GUL-82: restore clipboard after text insertion

### DIFF
--- a/Sources/Typeflux/TextInjection/AXTextInjector+Paste.swift
+++ b/Sources/Typeflux/TextInjection/AXTextInjector+Paste.swift
@@ -261,9 +261,16 @@ extension AXTextInjector {
         }
 
         let pasteboard = NSPasteboard.general
-        // The external replacement branch below is retained only for source compatibility;
-        // the guard above makes it unreachable. Never materialize arbitrary clipboard data.
-        let previousSnapshot = PasteboardSnapshot(items: [])
+        guard let previousSnapshot = capturePasteboardSnapshotWithTimeout(from: pasteboard) else {
+            throw NSError(
+                domain: "AXTextInjector",
+                code: 16,
+                userInfo: [
+                    NSLocalizedDescriptionKey:
+                        "Unable to preserve the current clipboard before paste"
+                ]
+            )
+        }
         let strictFallbackEnabled = settingsStore?.strictEditApplyFallbackEnabled ?? false
         let stubbornPasteFallbackEnabled = settingsStore?.stubbornPasteFallbackEnabled ?? false
         let replacementContext = replaceSelection ? activeSelectionContext() : nil
@@ -292,6 +299,16 @@ extension AXTextInjector {
         )
 
         if !replaceSelection {
+            guard pasteboard.changeCount == previousSnapshot.changeCount else {
+                throw NSError(
+                    domain: "AXTextInjector",
+                    code: 17,
+                    userInfo: [
+                        NSLocalizedDescriptionKey:
+                            "The clipboard changed before paste could begin"
+                    ]
+                )
+            }
             pasteboard.clearContents()
             guard pasteboard.setString(text, forType: .string) else {
                 throw NSError(
@@ -300,7 +317,13 @@ extension AXTextInjector {
                     userInfo: [NSLocalizedDescriptionKey: "Unable to prepare text for paste"]
                 )
             }
+            let injectionChangeCount = pasteboard.changeCount
             dispatchPasteShortcut(method: dispatchMethod, targetPID: targetPID)
+            restorePasteboardAfterPaste(
+                previousSnapshot,
+                capturedChangeCount: injectionChangeCount,
+                delayNanoseconds: Self.unverifiedPasteRestoreDelayNanoseconds
+            )
             NetworkDebugLogger.logMessage("[Text Injection] eager paste dispatched")
             return
         }
@@ -718,16 +741,52 @@ extension AXTextInjector {
         }
     }
 
-    func capturePasteboardSnapshot(from pasteboard: NSPasteboard) -> PasteboardSnapshot {
-        let items = (pasteboard.pasteboardItems ?? []).map { item in
-            let representations = item.types.compactMap {
-                type -> (type: NSPasteboard.PasteboardType, data: Data)? in
-                guard let data = item.data(forType: type) else { return nil }
-                return (type: type, data: data)
-            }
-            return PasteboardItemSnapshot(representations: representations)
+    func capturePasteboardSnapshotWithTimeout(from pasteboard: NSPasteboard) -> PasteboardSnapshot? {
+        let result = LockedPasteboardSnapshotResult()
+        let completed = DispatchSemaphore(value: 0)
+        let pasteboardReference = UncheckedSendableReference(pasteboard)
+        pasteboardSnapshotQueue.async {
+            result.store(Self.capturePasteboardSnapshot(
+                from: pasteboardReference.value,
+                maximumBytes: Self.maximumPasteboardSnapshotBytes
+            ))
+            completed.signal()
         }
-        return PasteboardSnapshot(items: items)
+        guard completed.wait(
+            timeout: .now() + .milliseconds(Self.pasteboardSnapshotTimeoutMilliseconds)
+        ) == .success else {
+            NetworkDebugLogger.logMessage("[Text Injection] pasteboard snapshot timed out")
+            return nil
+        }
+        guard let snapshot = result.load() else {
+            NetworkDebugLogger.logMessage("[Text Injection] pasteboard snapshot exceeded size limit")
+            return nil
+        }
+        return snapshot
+    }
+
+    static func capturePasteboardSnapshot(
+        from pasteboard: NSPasteboard,
+        maximumBytes: Int
+    ) -> PasteboardSnapshot? {
+        guard maximumBytes >= 0 else { return nil }
+        let initialChangeCount = pasteboard.changeCount
+        var totalBytes = 0
+        var capturedItems: [PasteboardItemSnapshot] = []
+
+        for item in pasteboard.pasteboardItems ?? [] {
+            var representations: [(type: NSPasteboard.PasteboardType, data: Data)] = []
+            for type in item.types {
+                guard let data = item.data(forType: type) else { return nil }
+                guard data.count <= maximumBytes - totalBytes else { return nil }
+                totalBytes += data.count
+                representations.append((type: type, data: data))
+            }
+            capturedItems.append(PasteboardItemSnapshot(representations: representations))
+        }
+
+        guard pasteboard.changeCount == initialChangeCount else { return nil }
+        return PasteboardSnapshot(changeCount: initialChangeCount, items: capturedItems)
     }
 
     func restorePasteboard(_ snapshot: PasteboardSnapshot, to pasteboard: NSPasteboard) {
@@ -748,20 +807,23 @@ extension AXTextInjector {
 
     func restorePasteboardAfterPaste(
         _ previousSnapshot: PasteboardSnapshot,
+        to pasteboard: NSPasteboard = .general,
+        capturedChangeCount: Int? = nil,
         delayNanoseconds: UInt64
     ) {
-        let capturedChangeCount = NSPasteboard.general.changeCount
+        let pasteboardReference = UncheckedSendableReference(pasteboard)
+        let expectedChangeCount = capturedChangeCount ?? pasteboard.changeCount
         Task.detached {
             try? await Task.sleep(nanoseconds: delayNanoseconds)
             await MainActor.run {
-                let pasteboard = NSPasteboard.general
+                let pasteboard = pasteboardReference.value
                 let currentChangeCount = pasteboard.changeCount
                 guard Self.shouldRestoreCapturedPasteboard(
-                    capturedChangeCount: capturedChangeCount,
+                    capturedChangeCount: expectedChangeCount,
                     currentChangeCount: currentChangeCount
                 ) else {
                     NetworkDebugLogger.logMessage(
-                        "[Text Injection] pasteboard restore skipped; changeCount moved \(capturedChangeCount) → \(currentChangeCount)"
+                        "[Text Injection] pasteboard restore skipped; changeCount moved \(expectedChangeCount) → \(currentChangeCount)"
                     )
                     return
                 }

--- a/Sources/Typeflux/TextInjection/AXTextInjector+Transaction.swift
+++ b/Sources/Typeflux/TextInjection/AXTextInjector+Transaction.swift
@@ -558,6 +558,20 @@ extension AXTextInjector {
             // a rejected post-write validation would leave a failed transaction's
             // result on the user's clipboard.
             let pasteboard = NSPasteboard.general
+            guard let previousSnapshot = injector.value.capturePasteboardSnapshotWithTimeout(
+                from: pasteboard
+            ) else {
+                throw injector.value.selectionReplacementError(
+                    code: 33,
+                    description: "Unable to preserve the current clipboard before replacement"
+                )
+            }
+            guard pasteboard.changeCount == previousSnapshot.changeCount else {
+                throw injector.value.selectionReplacementError(
+                    code: 34,
+                    description: "The clipboard changed before replacement could begin"
+                )
+            }
             pasteboard.clearContents()
             guard pasteboard.setString(text, forType: .string) else {
                 throw injector.value.selectionReplacementError(
@@ -565,8 +579,14 @@ extension AXTextInjector {
                     description: "Unable to prepare the replacement text"
                 )
             }
+            let injectionChangeCount = pasteboard.changeCount
             keyDown.postToPid(targetProcessID)
             keyUp.postToPid(targetProcessID)
+            injector.value.restorePasteboardAfterPaste(
+                previousSnapshot,
+                capturedChangeCount: injectionChangeCount,
+                delayNanoseconds: Self.unverifiedPasteRestoreDelayNanoseconds
+            )
             NetworkDebugLogger.logMessage(
                 "[Text Injection] selection transaction dispatched via eager paste"
             )

--- a/Sources/Typeflux/TextInjection/AXTextInjector.swift
+++ b/Sources/Typeflux/TextInjection/AXTextInjector.swift
@@ -76,6 +76,23 @@ final class LockedPasteboardStringResult: @unchecked Sendable {
     }
 }
 
+final class LockedPasteboardSnapshotResult: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value: AXTextInjector.PasteboardSnapshot?
+
+    func store(_ value: AXTextInjector.PasteboardSnapshot?) {
+        lock.lock()
+        self.value = value
+        lock.unlock()
+    }
+
+    func load() -> AXTextInjector.PasteboardSnapshot? {
+        lock.lock()
+        defer { lock.unlock() }
+        return value
+    }
+}
+
 final class UncheckedSendableReference<Value>: @unchecked Sendable {
     let value: Value
 
@@ -174,6 +191,7 @@ final class AXTextInjector: TextInjector {
     }
 
     struct PasteboardSnapshot {
+        let changeCount: Int
         let items: [PasteboardItemSnapshot]
     }
 
@@ -283,6 +301,8 @@ final class AXTextInjector: TextInjector {
     static let focusedDescendantSearchDepth = 10
     static let replacementAXMessagingTimeout: Float = 0.25
     static let pasteboardReadTimeoutMilliseconds = 250
+    static let pasteboardSnapshotTimeoutMilliseconds = 250
+    static let maximumPasteboardSnapshotBytes = 8 * 1_024 * 1_024
 
     var storedLatestSelectionContext: SelectionContext?
     var storedLastInjectionMethod: TextInjectionMethod?
@@ -320,6 +340,10 @@ final class AXTextInjector: TextInjector {
     )
     let pasteboardReadQueue = DispatchQueue(
         label: "ai.gulu.app.typeflux.pasteboard-read",
+        qos: .userInitiated
+    )
+    let pasteboardSnapshotQueue = DispatchQueue(
+        label: "ai.gulu.app.typeflux.pasteboard-snapshot",
         qos: .userInitiated
     )
 

--- a/Tests/TypefluxTests/AXTextInjectorTests.swift
+++ b/Tests/TypefluxTests/AXTextInjectorTests.swift
@@ -1728,6 +1728,175 @@ final class AXTextInjectorTests: XCTestCase {
         XCTAssertFalse(result)
     }
 
+    func testCapturePasteboardSnapshotPreservesAllRepresentations() throws {
+        let pasteboard = NSPasteboard.withUniqueName()
+        let item = NSPasteboardItem()
+        item.setString("original", forType: .string)
+        item.setData(Data([0x01, 0x02, 0x03]), forType: .init("dev.typeflux.test-data"))
+        pasteboard.writeObjects([item])
+
+        let snapshot = try XCTUnwrap(AXTextInjector.capturePasteboardSnapshot(
+            from: pasteboard,
+            maximumBytes: 1_024
+        ))
+
+        XCTAssertEqual(snapshot.items.count, 1)
+        XCTAssertEqual(snapshot.changeCount, pasteboard.changeCount)
+        XCTAssertEqual(snapshot.items[0].representations.count, 2)
+        XCTAssertEqual(
+            snapshot.items[0].representations.first { $0.type == .string }?.data,
+            "original".data(using: .utf8)
+        )
+        XCTAssertEqual(
+            snapshot.items[0].representations.first {
+                $0.type == .init("dev.typeflux.test-data")
+            }?.data,
+            Data([0x01, 0x02, 0x03])
+        )
+    }
+
+    func testCapturePasteboardSnapshotPreservesEmptyClipboard() throws {
+        let pasteboard = NSPasteboard.withUniqueName()
+        pasteboard.clearContents()
+
+        let snapshot = try XCTUnwrap(AXTextInjector.capturePasteboardSnapshot(
+            from: pasteboard,
+            maximumBytes: 1_024
+        ))
+
+        XCTAssertTrue(snapshot.items.isEmpty)
+    }
+
+    func testCapturePasteboardSnapshotRejectsOversizedClipboard() {
+        let pasteboard = NSPasteboard.withUniqueName()
+        pasteboard.setData(
+            Data(repeating: 0x01, count: 5),
+            forType: .init("dev.typeflux.oversized-test-data")
+        )
+
+        XCTAssertNil(AXTextInjector.capturePasteboardSnapshot(
+            from: pasteboard,
+            maximumBytes: 4
+        ))
+    }
+
+    func testCapturePasteboardSnapshotRejectsNegativeSizeLimit() {
+        let pasteboard = NSPasteboard.withUniqueName()
+        pasteboard.setString("original", forType: .string)
+
+        XCTAssertNil(AXTextInjector.capturePasteboardSnapshot(
+            from: pasteboard,
+            maximumBytes: -1
+        ))
+    }
+
+    func testCapturePasteboardSnapshotWithTimeoutReturnsAvailableSnapshot() throws {
+        let injector = AXTextInjector()
+        let pasteboard = NSPasteboard.withUniqueName()
+        pasteboard.setString("original", forType: .string)
+
+        let snapshot = try XCTUnwrap(injector.capturePasteboardSnapshotWithTimeout(
+            from: pasteboard
+        ))
+
+        XCTAssertEqual(snapshot.changeCount, pasteboard.changeCount)
+        XCTAssertEqual(snapshot.items.count, 1)
+    }
+
+    func testCapturePasteboardSnapshotWithTimeoutRejectsBlockingProvider() {
+        let injector = AXTextInjector()
+        let pasteboard = NSPasteboard.withUniqueName()
+        let provider = SlowPasteboardDataProvider(delay: 0.75, text: "original")
+        let item = NSPasteboardItem()
+        item.setDataProvider(provider, forTypes: [.string])
+        pasteboard.writeObjects([item])
+
+        let startedAt = Date()
+        let snapshot = injector.capturePasteboardSnapshotWithTimeout(from: pasteboard)
+
+        XCTAssertNil(snapshot)
+        XCTAssertLessThan(Date().timeIntervalSince(startedAt), 0.6)
+    }
+
+    func testRestorePasteboardRestoresSnapshotAndClearsTemporaryText() throws {
+        let injector = AXTextInjector()
+        let pasteboard = NSPasteboard.withUniqueName()
+        pasteboard.setString("original", forType: .string)
+        let snapshot = try XCTUnwrap(AXTextInjector.capturePasteboardSnapshot(
+            from: pasteboard,
+            maximumBytes: 1_024
+        ))
+        pasteboard.clearContents()
+        pasteboard.setString("transcription", forType: .string)
+
+        injector.restorePasteboard(snapshot, to: pasteboard)
+
+        XCTAssertEqual(pasteboard.string(forType: .string), "original")
+    }
+
+    func testRestorePasteboardRestoresEmptySnapshot() throws {
+        let injector = AXTextInjector()
+        let pasteboard = NSPasteboard.withUniqueName()
+        pasteboard.clearContents()
+        let snapshot = try XCTUnwrap(AXTextInjector.capturePasteboardSnapshot(
+            from: pasteboard,
+            maximumBytes: 1_024
+        ))
+        pasteboard.setString("transcription", forType: .string)
+
+        injector.restorePasteboard(snapshot, to: pasteboard)
+
+        XCTAssertTrue(pasteboard.pasteboardItems?.isEmpty ?? true)
+    }
+
+    func testRestorePasteboardAfterPasteRestoresWhenClipboardIsUnchanged() async throws {
+        let injector = AXTextInjector()
+        let pasteboard = NSPasteboard.withUniqueName()
+        pasteboard.setString("original", forType: .string)
+        let snapshot = try XCTUnwrap(AXTextInjector.capturePasteboardSnapshot(
+            from: pasteboard,
+            maximumBytes: 1_024
+        ))
+        pasteboard.clearContents()
+        pasteboard.setString("transcription", forType: .string)
+        let injectionChangeCount = pasteboard.changeCount
+
+        injector.restorePasteboardAfterPaste(
+            snapshot,
+            to: pasteboard,
+            capturedChangeCount: injectionChangeCount,
+            delayNanoseconds: 1_000_000
+        )
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        XCTAssertEqual(pasteboard.string(forType: .string), "original")
+    }
+
+    func testRestorePasteboardAfterPasteKeepsNewUserClipboard() async throws {
+        let injector = AXTextInjector()
+        let pasteboard = NSPasteboard.withUniqueName()
+        pasteboard.setString("original", forType: .string)
+        let snapshot = try XCTUnwrap(AXTextInjector.capturePasteboardSnapshot(
+            from: pasteboard,
+            maximumBytes: 1_024
+        ))
+        pasteboard.clearContents()
+        pasteboard.setString("transcription", forType: .string)
+        let injectionChangeCount = pasteboard.changeCount
+
+        injector.restorePasteboardAfterPaste(
+            snapshot,
+            to: pasteboard,
+            capturedChangeCount: injectionChangeCount,
+            delayNanoseconds: 25_000_000
+        )
+        pasteboard.clearContents()
+        pasteboard.setString("new user copy", forType: .string)
+        try await Task.sleep(nanoseconds: 75_000_000)
+
+        XCTAssertEqual(pasteboard.string(forType: .string), "new user copy")
+    }
+
     func testUnverifiedPasteRestoreDelayIsLongerThanVerifiedDelay() {
         // Slow clipboard consumers (iTerm2, Terminal, Warp) may not read the
         // pasteboard until well after Cmd+V is dispatched. When we cannot
@@ -1794,4 +1963,25 @@ private final class TestMonotonicClock: @unchecked Sendable {
         now = value
         lock.unlock()
     }
+}
+
+private final class SlowPasteboardDataProvider: NSObject, NSPasteboardItemDataProvider {
+    private let delay: TimeInterval
+    private let text: String
+
+    init(delay: TimeInterval, text: String) {
+        self.delay = delay
+        self.text = text
+    }
+
+    func pasteboard(
+        _: NSPasteboard?,
+        item: NSPasteboardItem,
+        provideDataForType type: NSPasteboard.PasteboardType
+    ) {
+        Thread.sleep(forTimeInterval: delay)
+        item.setString(text, forType: type)
+    }
+
+    func pasteboardFinishedWithDataProvider(_: NSPasteboard) {}
 }


### PR DESCRIPTION
## Summary

- preserve and restore the user's clipboard around eager paste injection
- bound clipboard snapshot reads by time and size
- avoid overwriting clipboard content copied by the user after injection
- apply the same behavior to ordinary insertion and selection replacement

## Tests

- `swift test` (2547 XCTest + 8 Swift Testing tests passed)
- `swift test --enable-code-coverage --filter AXTextInjectorTests` (104 passed)

Closes GUL-82
