### PR TITLE
GUL-83: prevent stale clipboard selection detection

### DIFF
--- a/Sources/Typeflux/TextInjection/AXTextInjector+Paste.swift
+++ b/Sources/Typeflux/TextInjection/AXTextInjector+Paste.swift
@@ -309,8 +309,7 @@ extension AXTextInjector {
                     ]
                 )
             }
-            pasteboard.clearContents()
-            guard pasteboard.setString(text, forType: .string) else {
+            guard writeTransientPasteboardString(text, to: pasteboard) else {
                 throw NSError(
                     domain: "AXTextInjector",
                     code: 15,
@@ -380,6 +379,7 @@ extension AXTextInjector {
         let deliveryProbe = PasteboardDeliveryProbe(text: text)
         let pasteboardItem = NSPasteboardItem()
         pasteboardItem.setDataProvider(deliveryProbe, forTypes: [.string])
+        pasteboardItem.setData(Data(), forType: Self.transientPasteboardType)
         pasteboard.clearContents()
         pasteboard.writeObjects([pasteboardItem])
         activePasteboardDeliveryProbe = deliveryProbe
@@ -845,6 +845,16 @@ extension AXTextInjector {
 
         guard pasteboard.changeCount == initialChangeCount else { return nil }
         return PasteboardSnapshot(changeCount: initialChangeCount, items: capturedItems)
+    }
+
+    func writeTransientPasteboardString(_ text: String, to pasteboard: NSPasteboard) -> Bool {
+        let item = NSPasteboardItem()
+        guard item.setString(text, forType: .string),
+              item.setData(Data(), forType: Self.transientPasteboardType)
+        else { return false }
+
+        pasteboard.clearContents()
+        return pasteboard.writeObjects([item])
     }
 
     func restorePasteboard(_ snapshot: PasteboardSnapshot, to pasteboard: NSPasteboard) {

--- a/Sources/Typeflux/TextInjection/AXTextInjector+Paste.swift
+++ b/Sources/Typeflux/TextInjection/AXTextInjector+Paste.swift
@@ -664,15 +664,58 @@ extension AXTextInjector {
     }
 
     func readSelectedTextViaCopy(processID: pid_t?, milliseconds: Int) -> String? {
-        let pasteboard = NSPasteboard.general
-        let previousChangeCount = pasteboard.changeCount
+        readSelectedTextViaCopy(
+            milliseconds: milliseconds,
+            pasteboard: .general,
+            sendCopy: { sendCopyShortcut(to: processID) }
+        )
+    }
 
-        sendCopyShortcut(to: processID)
+    func readSelectedTextViaCopy(
+        milliseconds: Int,
+        pasteboard: NSPasteboard,
+        sendCopy: () -> Void
+    ) -> String? {
+        guard let previousSnapshot = capturePasteboardSnapshotWithTimeout(from: pasteboard) else {
+            NetworkDebugLogger.logMessage(
+                "[Text Selection] clipboard-copy skipped because the clipboard could not be preserved"
+            )
+            return nil
+        }
+        guard pasteboard.changeCount == previousSnapshot.changeCount else {
+            NetworkDebugLogger.logMessage(
+                "[Text Selection] clipboard-copy skipped because the clipboard changed before probing"
+            )
+            return nil
+        }
+
+        let probeType = NSPasteboard.PasteboardType("ai.gulu.app.typeflux.selection-probe")
+        pasteboard.clearContents()
+        guard pasteboard.setData(Data(UUID().uuidString.utf8), forType: probeType) else {
+            restorePasteboardIfUnchanged(
+                previousSnapshot,
+                to: pasteboard,
+                expectedChangeCount: pasteboard.changeCount
+            )
+            return nil
+        }
+
+        var transactionChangeCount = pasteboard.changeCount
+        defer {
+            restorePasteboardIfUnchanged(
+                previousSnapshot,
+                to: pasteboard,
+                expectedChangeCount: transactionChangeCount
+            )
+        }
+
+        sendCopy()
 
         let timeout = Date().addingTimeInterval(Double(milliseconds) / 1000.0)
         while Date() < timeout {
-            if pasteboard.changeCount != previousChangeCount {
-                let copiedText = readPasteboardStringWithTimeout()
+            if pasteboard.changeCount != transactionChangeCount {
+                transactionChangeCount = pasteboard.changeCount
+                let copiedText = readPasteboardStringWithTimeout(from: pasteboard)
                 let trimmed = copiedText?.trimmingCharacters(in: .whitespacesAndNewlines)
                 return trimmed?.isEmpty == false ? trimmed : nil
             }
@@ -682,14 +725,29 @@ extension AXTextInjector {
         return nil
     }
 
+    func restorePasteboardIfUnchanged(
+        _ snapshot: PasteboardSnapshot,
+        to pasteboard: NSPasteboard,
+        expectedChangeCount: Int
+    ) {
+        guard pasteboard.changeCount == expectedChangeCount else {
+            NetworkDebugLogger.logMessage(
+                "[Text Selection] clipboard restore skipped because it changed after probing"
+            )
+            return
+        }
+        restorePasteboard(snapshot, to: pasteboard)
+    }
+
     /// Pasteboard owners can provide data lazily and may block indefinitely. Read on a
     /// dedicated serial queue so a broken provider cannot freeze Typeflux's main thread.
     /// Once that queue is wedged, later reads still time out without creating more workers.
-    func readPasteboardStringWithTimeout() -> String? {
+    func readPasteboardStringWithTimeout(from pasteboard: NSPasteboard) -> String? {
         let result = LockedPasteboardStringResult()
         let completed = DispatchSemaphore(value: 0)
+        let pasteboardReference = UncheckedSendableReference(pasteboard)
         pasteboardReadQueue.async {
-            result.store(NSPasteboard.general.string(forType: .string))
+            result.store(pasteboardReference.value.string(forType: .string))
             completed.signal()
         }
         guard completed.wait(

--- a/Sources/Typeflux/TextInjection/AXTextInjector+Transaction.swift
+++ b/Sources/Typeflux/TextInjection/AXTextInjector+Transaction.swift
@@ -572,8 +572,7 @@ extension AXTextInjector {
                     description: "The clipboard changed before replacement could begin"
                 )
             }
-            pasteboard.clearContents()
-            guard pasteboard.setString(text, forType: .string) else {
+            guard injector.value.writeTransientPasteboardString(text, to: pasteboard) else {
                 throw injector.value.selectionReplacementError(
                     code: 31,
                     description: "Unable to prepare the replacement text"

--- a/Sources/Typeflux/TextInjection/AXTextInjector.swift
+++ b/Sources/Typeflux/TextInjection/AXTextInjector.swift
@@ -303,6 +303,10 @@ final class AXTextInjector: TextInjector {
     static let pasteboardReadTimeoutMilliseconds = 250
     static let pasteboardSnapshotTimeoutMilliseconds = 250
     static let maximumPasteboardSnapshotBytes = 8 * 1_024 * 1_024
+    /// Pasteboard history tools use this convention to exclude temporary payloads.
+    static let transientPasteboardType = NSPasteboard.PasteboardType(
+        "org.nspasteboard.TransientType"
+    )
 
     var storedLatestSelectionContext: SelectionContext?
     var storedLastInjectionMethod: TextInjectionMethod?

--- a/Sources/Typeflux/TextInjection/AXTextInjector.swift
+++ b/Sources/Typeflux/TextInjection/AXTextInjector.swift
@@ -859,17 +859,24 @@ final class AXTextInjector: TextInjector {
                 replacementContextID: replacementContextID
             )
         }
-        logger.debug("ax-api returned nil — trying clipboard-copy")
 
-        if let copiedText = readSelectedTextViaCopy(
+        let clipboardProbeElement = processID.flatMap(focusedElement(for:))
+        let clipboardProbeRange = clipboardProbeElement.flatMap(copySelectedTextRange(from:))
+        let shouldSkipClipboardProbe = Self.shouldSkipClipboardSelectionProbe(
+            selectedRange: clipboardProbeRange
+        )
+        if shouldSkipClipboardProbe {
+            logger.debug("ax-api returned nil — empty selection range, skipping clipboard-copy")
+        } else {
+            logger.debug("ax-api returned nil — trying clipboard-copy")
+        }
+
+        if !shouldSkipClipboardProbe,
+           let copiedText = readSelectedTextViaCopy(
             processID: processID,
             milliseconds: Self.copySelectionTimeoutMilliseconds
         ) {
-            let focusedElement = processID.flatMap { processID -> AXUIElement? in
-                let application = AXUIElementCreateApplication(processID)
-                AXUIElementSetMessagingTimeout(application, Self.replacementAXMessagingTimeout)
-                return lightweightFocusedElement(application: application)
-            }
+            let focusedElement = clipboardProbeElement
             let focusedWindow = processID.flatMap(focusedWindowElement(for:))
             let selectionWindow = focusedElement.flatMap(containingWindow(of:))
             let editability = focusedElement.map(isLikelyEditable(element:)) ?? false
@@ -953,6 +960,10 @@ final class AXTextInjector: TextInjector {
             windowTitle: focused.flatMap(containingWindowTitle(of:)),
             isFocusedTarget: false
         )
+    }
+
+    static func shouldSkipClipboardSelectionProbe(selectedRange: CFRange?) -> Bool {
+        selectedRange?.length == 0
     }
 
     func insert(text: String) throws {

--- a/Tests/TypefluxTests/AXTextInjectorTests.swift
+++ b/Tests/TypefluxTests/AXTextInjectorTests.swift
@@ -1838,6 +1838,33 @@ final class AXTextInjectorTests: XCTestCase {
         )
     }
 
+    func testWriteTransientPasteboardStringMarksPayloadForClipboardHistoryExclusion() {
+        let injector = AXTextInjector()
+        let pasteboard = NSPasteboard.withUniqueName()
+
+        XCTAssertTrue(injector.writeTransientPasteboardString("dictation", to: pasteboard))
+
+        XCTAssertEqual(pasteboard.string(forType: .string), "dictation")
+        XCTAssertNotNil(pasteboard.data(forType: AXTextInjector.transientPasteboardType))
+        XCTAssertEqual(pasteboard.pasteboardItems?.count, 1)
+    }
+
+    func testTransientPasteboardPayloadCanBeCapturedAndRestored() throws {
+        let injector = AXTextInjector()
+        let pasteboard = NSPasteboard.withUniqueName()
+        pasteboard.setString("original", forType: .string)
+        let snapshot = try XCTUnwrap(AXTextInjector.capturePasteboardSnapshot(
+            from: pasteboard,
+            maximumBytes: 1_024
+        ))
+
+        XCTAssertTrue(injector.writeTransientPasteboardString("dictation", to: pasteboard))
+        injector.restorePasteboard(snapshot, to: pasteboard)
+
+        XCTAssertEqual(pasteboard.string(forType: .string), "original")
+        XCTAssertNil(pasteboard.data(forType: AXTextInjector.transientPasteboardType))
+    }
+
     func testCapturePasteboardSnapshotPreservesEmptyClipboard() throws {
         let pasteboard = NSPasteboard.withUniqueName()
         pasteboard.clearContents()

--- a/Tests/TypefluxTests/AXTextInjectorTests.swift
+++ b/Tests/TypefluxTests/AXTextInjectorTests.swift
@@ -1728,6 +1728,89 @@ final class AXTextInjectorTests: XCTestCase {
         XCTAssertFalse(result)
     }
 
+    func testClipboardSelectionProbeSkipsCollapsedSelection() {
+        XCTAssertTrue(AXTextInjector.shouldSkipClipboardSelectionProbe(
+            selectedRange: CFRange(location: 12, length: 0)
+        ))
+    }
+
+    func testClipboardSelectionProbeAllowsUnknownOrNonEmptySelection() {
+        XCTAssertFalse(AXTextInjector.shouldSkipClipboardSelectionProbe(selectedRange: nil))
+        XCTAssertFalse(AXTextInjector.shouldSkipClipboardSelectionProbe(
+            selectedRange: CFRange(location: 4, length: 8)
+        ))
+    }
+
+    func testClipboardCopyProbeRejectsStaleTextWhenCopyDoesNothing() {
+        let injector = AXTextInjector()
+        let pasteboard = NSPasteboard.withUniqueName()
+        pasteboard.setString("previous transcription", forType: .string)
+
+        let selectedText = injector.readSelectedTextViaCopy(
+            milliseconds: 1,
+            pasteboard: pasteboard,
+            sendCopy: {}
+        )
+
+        XCTAssertNil(selectedText)
+        XCTAssertEqual(pasteboard.string(forType: .string), "previous transcription")
+    }
+
+    func testClipboardCopyProbeRejectsChangeWithoutCopiedText() {
+        let injector = AXTextInjector()
+        let pasteboard = NSPasteboard.withUniqueName()
+        pasteboard.setString("previous transcription", forType: .string)
+
+        let selectedText = injector.readSelectedTextViaCopy(
+            milliseconds: 25,
+            pasteboard: pasteboard,
+            sendCopy: {
+                pasteboard.clearContents()
+            }
+        )
+
+        XCTAssertNil(selectedText)
+        XCTAssertEqual(pasteboard.string(forType: .string), "previous transcription")
+    }
+
+    func testClipboardCopyProbeReturnsNewSelectionAndRestoresClipboard() {
+        let injector = AXTextInjector()
+        let pasteboard = NSPasteboard.withUniqueName()
+        pasteboard.setString("original clipboard", forType: .string)
+
+        let selectedText = injector.readSelectedTextViaCopy(
+            milliseconds: 25,
+            pasteboard: pasteboard,
+            sendCopy: {
+                pasteboard.clearContents()
+                pasteboard.setString("selected text", forType: .string)
+            }
+        )
+
+        XCTAssertEqual(selectedText, "selected text")
+        XCTAssertEqual(pasteboard.string(forType: .string), "original clipboard")
+    }
+
+    func testClipboardProbeDoesNotOverwriteLaterClipboardChange() throws {
+        let injector = AXTextInjector()
+        let pasteboard = NSPasteboard.withUniqueName()
+        pasteboard.setString("original clipboard", forType: .string)
+        let snapshot = try XCTUnwrap(AXTextInjector.capturePasteboardSnapshot(
+            from: pasteboard,
+            maximumBytes: 1024
+        ))
+
+        pasteboard.clearContents()
+        pasteboard.setString("new clipboard", forType: .string)
+        injector.restorePasteboardIfUnchanged(
+            snapshot,
+            to: pasteboard,
+            expectedChangeCount: snapshot.changeCount
+        )
+
+        XCTAssertEqual(pasteboard.string(forType: .string), "new clipboard")
+    }
+
     func testCapturePasteboardSnapshotPreservesAllRepresentations() throws {
         let pasteboard = NSPasteboard.withUniqueName()
         let item = NSPasteboardItem()


### PR DESCRIPTION
## Summary

- prevent stale clipboard contents from being mistaken for a text selection
- skip clipboard probing when Accessibility reports a collapsed selection
- preserve and safely restore the clipboard around fallback selection probes
- cover no-op copy, non-text copy, successful copy, collapsed selection, and concurrent clipboard changes

## Verification

- `swift test --filter AXTextInjectorTests` (110 tests passed)
- `swift test` (2557 XCTest tests and 8 Swift Testing tests passed)
- `swift test --enable-code-coverage --filter AXTextInjectorTests` (110 tests passed)

Closes GUL-83
