### PR TITLE
GUL-83: require explicit selection evidence before copy probe

### DIFF
--- a/Sources/Typeflux/TextInjection/AXTextInjector.swift
+++ b/Sources/Typeflux/TextInjection/AXTextInjector.swift
@@ -866,16 +866,17 @@ final class AXTextInjector: TextInjector {
 
         let clipboardProbeElement = processID.flatMap(focusedElement(for:))
         let clipboardProbeRange = clipboardProbeElement.flatMap(copySelectedTextRange(from:))
-        let shouldSkipClipboardProbe = Self.shouldSkipClipboardSelectionProbe(
+        let clipboardProbeIsEditable = clipboardProbeElement.map(isLikelyEditable(element:)) ?? false
+        let shouldProbeClipboardSelection = Self.shouldProbeClipboardSelection(
             selectedRange: clipboardProbeRange
         )
-        if shouldSkipClipboardProbe {
-            logger.debug("ax-api returned nil — empty selection range, skipping clipboard-copy")
-        } else {
+        if shouldProbeClipboardSelection {
             logger.debug("ax-api returned nil — trying clipboard-copy")
+        } else {
+            logger.debug("ax-api returned nil — no reliable selection target, skipping clipboard-copy")
         }
 
-        if !shouldSkipClipboardProbe,
+        if shouldProbeClipboardSelection,
            let copiedText = readSelectedTextViaCopy(
             processID: processID,
             milliseconds: Self.copySelectionTimeoutMilliseconds
@@ -883,7 +884,7 @@ final class AXTextInjector: TextInjector {
             let focusedElement = clipboardProbeElement
             let focusedWindow = processID.flatMap(focusedWindowElement(for:))
             let selectionWindow = focusedElement.flatMap(containingWindow(of:))
-            let editability = focusedElement.map(isLikelyEditable(element:)) ?? false
+            let editability = clipboardProbeIsEditable
             // Clipboard copy succeeded → text IS selected in the frontmost app's process.
             // When selectionWindow is nil (e.g. Electron/Chromium AX hierarchy doesn't expose
             // a traversable parent chain to the window), we still trust isFocusedTarget = true
@@ -966,8 +967,11 @@ final class AXTextInjector: TextInjector {
         )
     }
 
-    static func shouldSkipClipboardSelectionProbe(selectedRange: CFRange?) -> Bool {
-        selectedRange?.length == 0
+    /// A copy response alone is not proof of a selection: some applications copy the
+    /// entire field when no range is selected. Require positive range evidence before
+    /// using Cmd+C as a fallback for reading the selected text.
+    static func shouldProbeClipboardSelection(selectedRange: CFRange?) -> Bool {
+        selectedRange?.length ?? 0 > 0
     }
 
     func insert(text: String) throws {

--- a/Tests/TypefluxTests/AXTextInjectorTests.swift
+++ b/Tests/TypefluxTests/AXTextInjectorTests.swift
@@ -1728,15 +1728,20 @@ final class AXTextInjectorTests: XCTestCase {
         XCTAssertFalse(result)
     }
 
-    func testClipboardSelectionProbeSkipsCollapsedSelection() {
-        XCTAssertTrue(AXTextInjector.shouldSkipClipboardSelectionProbe(
+    func testClipboardSelectionProbeRejectsCollapsedSelection() {
+        XCTAssertFalse(AXTextInjector.shouldProbeClipboardSelection(
             selectedRange: CFRange(location: 12, length: 0)
         ))
     }
 
-    func testClipboardSelectionProbeAllowsUnknownOrNonEmptySelection() {
-        XCTAssertFalse(AXTextInjector.shouldSkipClipboardSelectionProbe(selectedRange: nil))
-        XCTAssertFalse(AXTextInjector.shouldSkipClipboardSelectionProbe(
+    func testClipboardSelectionProbeRejectsOpaqueTargetWithoutRange() {
+        XCTAssertFalse(AXTextInjector.shouldProbeClipboardSelection(
+            selectedRange: nil
+        ))
+    }
+
+    func testClipboardSelectionProbeAllowsExplicitNonEmptyRange() {
+        XCTAssertTrue(AXTextInjector.shouldProbeClipboardSelection(
             selectedRange: CFRange(location: 4, length: 8)
         ))
     }


### PR DESCRIPTION
## Summary

- require a positive non-empty Accessibility selection range before using `Cmd+C` to read selected text
- treat targets with an unknown or collapsed range as ordinary insertion targets
- prevent copied whole-field content from being mistaken for a replaceable selection

The previous fix only proved that the copy response was fresh. It did not prove that the copied text represented an active selection; some applications copy the whole field even when no range is selected.

## Verification

- `swift test --filter AXTextInjectorTests` (113 tests passed)
- `swift test --enable-code-coverage --filter AXTextInjectorTests` (113 tests passed; new policy helper fully covered)
- `swift test --skip-build` (2562 XCTest tests and 8 Swift Testing tests passed)

Closes GUL-83
