### PR TITLE
GUL-83: restore explicit selection persona compatibility

### DIFF
--- a/Sources/Typeflux/TextInjection/AXTextInjector.swift
+++ b/Sources/Typeflux/TextInjection/AXTextInjector.swift
@@ -753,7 +753,7 @@ final class AXTextInjector: TextInjector {
         }
     }
 
-    func getSelectionSnapshot() async -> TextSelectionSnapshot {
+    func selectionSnapshot(for intent: SelectionCaptureIntent) async -> TextSelectionSnapshot {
         let preflight = await MainActor.run {
             self.selectionCapturePreflight()
         }
@@ -765,7 +765,10 @@ final class AXTextInjector: TextInjector {
             return await withCheckedContinuation { continuation in
                 selectionReplacementQueue.async {
                     continuation.resume(
-                        returning: injector.value.readExternalSelectionSnapshot(target: target)
+                        returning: injector.value.readExternalSelectionSnapshot(
+                            target: target,
+                            intent: intent
+                        )
                     )
                 }
             }
@@ -830,7 +833,10 @@ final class AXTextInjector: TextInjector {
         ))
     }
 
-    func readExternalSelectionSnapshot(target: ExternalSelectionCaptureTarget) -> TextSelectionSnapshot {
+    func readExternalSelectionSnapshot(
+        target: ExternalSelectionCaptureTarget,
+        intent: SelectionCaptureIntent
+    ) -> TextSelectionSnapshot {
         let processID = target.processID
         let processName = target.processName
         let bundleIdentifier = target.bundleIdentifier
@@ -868,7 +874,8 @@ final class AXTextInjector: TextInjector {
         let clipboardProbeRange = clipboardProbeElement.flatMap(copySelectedTextRange(from:))
         let clipboardProbeIsEditable = clipboardProbeElement.map(isLikelyEditable(element:)) ?? false
         let shouldProbeClipboardSelection = Self.shouldProbeClipboardSelection(
-            selectedRange: clipboardProbeRange
+            selectedRange: clipboardProbeRange,
+            intent: intent
         )
         if shouldProbeClipboardSelection {
             logger.debug("ax-api returned nil — trying clipboard-copy")
@@ -968,10 +975,19 @@ final class AXTextInjector: TextInjector {
     }
 
     /// A copy response alone is not proof of a selection: some applications copy the
-    /// entire field when no range is selected. Require positive range evidence before
-    /// using Cmd+C as a fallback for reading the selected text.
-    static func shouldProbeClipboardSelection(selectedRange: CFRange?) -> Bool {
-        selectedRange?.length ?? 0 > 0
+    /// entire field when no range is selected. Ordinary dictation therefore requires
+    /// positive range evidence. An explicit selection command may probe an opaque target,
+    /// while still respecting a range that Accessibility confirms is collapsed.
+    static func shouldProbeClipboardSelection(
+        selectedRange: CFRange?,
+        intent: SelectionCaptureIntent
+    ) -> Bool {
+        switch intent {
+        case .automaticInsertion:
+            selectedRange?.length ?? 0 > 0
+        case .explicitSelectionAction:
+            selectedRange?.length != 0
+        }
     }
 
     func insert(text: String) throws {

--- a/Sources/Typeflux/TextInjection/TextInjector.swift
+++ b/Sources/Typeflux/TextInjection/TextInjector.swift
@@ -1,5 +1,15 @@
 import Foundation
 
+enum SelectionCaptureIntent: Equatable {
+    /// Selection detection is incidental to ordinary dictation. Ambiguous clipboard
+    /// responses must not turn insertion into replacement.
+    case automaticInsertion
+
+    /// The user explicitly invoked an action that operates on selected text. Apps
+    /// with opaque accessibility trees may use the transactional clipboard fallback.
+    case explicitSelectionAction
+}
+
 struct TextSelectionSnapshot {
     var processID: pid_t?
     var processName: String?
@@ -53,7 +63,7 @@ struct CurrentInputTextSnapshot {
 
 protocol TextInjector {
     var lastInjectionMethod: TextInjectionMethod? { get }
-    func getSelectionSnapshot() async -> TextSelectionSnapshot
+    func selectionSnapshot(for intent: SelectionCaptureIntent) async -> TextSelectionSnapshot
     func currentInputTextSnapshot() async -> CurrentInputTextSnapshot
     func currentInputText() async -> String?
     func insert(text: String) throws

--- a/Sources/Typeflux/Workflow/WorkflowController+Processing.swift
+++ b/Sources/Typeflux/Workflow/WorkflowController+Processing.swift
@@ -2309,6 +2309,11 @@ extension WorkflowController {
         return snapshot.selectedText?.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
+    func selectionContextText(from snapshot: TextSelectionSnapshot) -> String? {
+        guard snapshot.hasAskSelectionContext else { return nil }
+        return snapshot.selectedText?.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
     func askContextText(
         from snapshot: TextSelectionSnapshot,
         inputContext: InputContextSnapshot?

--- a/Sources/Typeflux/Workflow/WorkflowController.swift
+++ b/Sources/Typeflux/Workflow/WorkflowController.swift
@@ -818,7 +818,7 @@ final class WorkflowController {
             guard let self else { return }
 
             let selectionSnapshot: TextSelectionSnapshot = if settingsStore.personaHotkeyAppliesToSelection {
-                await textInjector.getSelectionSnapshot()
+                await textInjector.selectionSnapshot(for: .explicitSelectionAction)
             } else {
                 TextSelectionSnapshot()
             }
@@ -828,7 +828,7 @@ final class WorkflowController {
                     "snapshot: isFocusedTarget=\(selectionSnapshot.isFocusedTarget) isEditable=\(selectionSnapshot.isEditable) hasSelection=\(selectionSnapshot.hasSelection) source=\(selectionSnapshot.source) selectedText=\(selectionSnapshot.selectedText?.prefix(32) ?? "nil")"
                 )
 
-            let selectedText = editingSelectedText(from: selectionSnapshot)
+            let selectedText = selectionContextText(from: selectionSnapshot)
             let frontmostApplicationContext = Self.frontmostApplicationContext()
             let appName = selectionSnapshot.processName ?? frontmostApplicationContext.appName
             let bundleIdentifier = selectionSnapshot.bundleIdentifier ?? frontmostApplicationContext.bundleIdentifier
@@ -1181,7 +1181,7 @@ final class WorkflowController {
                         isFocusedTarget: false
                     )
                 }
-                return await textInjector.getSelectionSnapshot()
+                return await textInjector.selectionSnapshot(for: .automaticInsertion)
             }
             if settingsStore.inputContextOptimizationEnabled, !shouldSkipSelectionCapture {
                 let selectionTask = selectionTask

--- a/Tests/TypefluxTests/AXTextInjectorTests.swift
+++ b/Tests/TypefluxTests/AXTextInjectorTests.swift
@@ -1730,19 +1730,37 @@ final class AXTextInjectorTests: XCTestCase {
 
     func testClipboardSelectionProbeRejectsCollapsedSelection() {
         XCTAssertFalse(AXTextInjector.shouldProbeClipboardSelection(
-            selectedRange: CFRange(location: 12, length: 0)
+            selectedRange: CFRange(location: 12, length: 0),
+            intent: .automaticInsertion
+        ))
+        XCTAssertFalse(AXTextInjector.shouldProbeClipboardSelection(
+            selectedRange: CFRange(location: 12, length: 0),
+            intent: .explicitSelectionAction
         ))
     }
 
-    func testClipboardSelectionProbeRejectsOpaqueTargetWithoutRange() {
+    func testAutomaticClipboardSelectionProbeRejectsOpaqueTargetWithoutRange() {
         XCTAssertFalse(AXTextInjector.shouldProbeClipboardSelection(
-            selectedRange: nil
+            selectedRange: nil,
+            intent: .automaticInsertion
+        ))
+    }
+
+    func testExplicitClipboardSelectionProbeAllowsOpaqueTargetWithoutRange() {
+        XCTAssertTrue(AXTextInjector.shouldProbeClipboardSelection(
+            selectedRange: nil,
+            intent: .explicitSelectionAction
         ))
     }
 
     func testClipboardSelectionProbeAllowsExplicitNonEmptyRange() {
         XCTAssertTrue(AXTextInjector.shouldProbeClipboardSelection(
-            selectedRange: CFRange(location: 4, length: 8)
+            selectedRange: CFRange(location: 4, length: 8),
+            intent: .automaticInsertion
+        ))
+        XCTAssertTrue(AXTextInjector.shouldProbeClipboardSelection(
+            selectedRange: CFRange(location: 4, length: 8),
+            intent: .explicitSelectionAction
         ))
     }
 

--- a/Tests/TypefluxTests/WorkflowControllerAutomaticVocabularyTests.swift
+++ b/Tests/TypefluxTests/WorkflowControllerAutomaticVocabularyTests.swift
@@ -398,7 +398,7 @@ private final class MockWorkflowTextInjector: TextInjector {
         self.snapshots = snapshots
     }
 
-    func getSelectionSnapshot() async -> TextSelectionSnapshot {
+    func selectionSnapshot(for _: SelectionCaptureIntent) async -> TextSelectionSnapshot {
         TextSelectionSnapshot()
     }
 

--- a/Tests/TypefluxTests/WorkflowControllerProcessingTests.swift
+++ b/Tests/TypefluxTests/WorkflowControllerProcessingTests.swift
@@ -511,6 +511,70 @@ final class WorkflowControllerProcessingTests: XCTestCase {
         XCTAssertFalse(eventRecorder.snapshot().contains("cue-play"))
     }
 
+    func testPersonaPickerUsesExplicitCaptureForOpaqueSelection() async throws {
+        let selectedText = "Selected in Zed"
+        let snapshot = TextSelectionSnapshot(
+            processID: 42,
+            processName: "Zed",
+            bundleIdentifier: "dev.zed.Zed",
+            selectedRange: nil,
+            selectedText: selectedText,
+            source: "clipboard-copy",
+            isEditable: false,
+            role: "AXWindow",
+            windowTitle: "Editor",
+            isFocusedTarget: true,
+            replacementContextID: UUID()
+        )
+        let textInjector = MockProcessingTextInjector(selectionSnapshot: snapshot)
+        let controller = makeWorkflowController(
+            textInjector: textInjector,
+            configureSettings: { $0.personaHotkeyAppliesToSelection = true }
+        )
+
+        controller.handlePersonaPickerRequested()
+        await waitUntil { controller.isPersonaPickerPresented }
+
+        XCTAssertEqual(textInjector.selectionCaptureIntents, [.explicitSelectionAction])
+        guard case let .applySelection(context) = controller.personaPickerMode else {
+            return XCTFail("Expected persona picker to apply a persona to the selected text")
+        }
+        XCTAssertEqual(context.selectedText, selectedText)
+        XCTAssertEqual(
+            controller.personaPickerTitle(for: controller.personaPickerMode),
+            L("overlay.personaPicker.applyTitle")
+        )
+    }
+
+    func testPersonaPickerSeparatesSelectionContextFromReplacementCapability() async {
+        let snapshot = TextSelectionSnapshot(
+            processID: 42,
+            processName: "Preview",
+            bundleIdentifier: "com.apple.Preview",
+            selectedRange: CFRange(location: 2, length: 8),
+            selectedText: "Read only",
+            source: "accessibility",
+            isEditable: false,
+            role: "AXStaticText",
+            windowTitle: "Document",
+            isFocusedTarget: true
+        )
+        let controller = makeWorkflowController(
+            textInjector: MockProcessingTextInjector(selectionSnapshot: snapshot),
+            configureSettings: { $0.personaHotkeyAppliesToSelection = true }
+        )
+
+        controller.handlePersonaPickerRequested()
+        await waitUntil { controller.isPersonaPickerPresented }
+
+        guard case let .applySelection(context) = controller.personaPickerMode else {
+            return XCTFail("Expected read-only selected text to remain valid persona context")
+        }
+        XCTAssertEqual(context.selectedText, "Read only")
+        XCTAssertFalse(context.snapshot.canReplaceSelection)
+        XCTAssertTrue(controller.shouldPresentResultDialog(for: context.snapshot))
+    }
+
     func testHistoryPickerConfirmCopiesAndInsertsSelectedHistory() async {
         let textInjector = MockProcessingTextInjector()
         let clipboard = MockClipboardService()
@@ -1007,6 +1071,7 @@ final class WorkflowControllerProcessingTests: XCTestCase {
         let audioStartIndex = try XCTUnwrap(events.firstIndex(of: "audio-start"))
         let selectionStartIndex = try XCTUnwrap(events.firstIndex(of: "selection-start"))
         XCTAssertLessThan(audioStartIndex, selectionStartIndex)
+        XCTAssertTrue(events.contains("selection-intent-automatic"))
         XCTAssertFalse(events.contains("cue-play"))
         XCTAssertFalse(events.contains("unexpected-sleep"))
         XCTAssertEqual(eventRecorder.durationSnapshot(), [])
@@ -2350,6 +2415,7 @@ private final class MockProcessingTextInjector: TextInjector {
     private(set) var insertedTexts: [String] = []
     private(set) var replacedTexts: [String] = []
     private(set) var replacementTargets: [TextSelectionSnapshot?] = []
+    private(set) var selectionCaptureIntents: [SelectionCaptureIntent] = []
     private let selectionSnapshot: TextSelectionSnapshot
     private let inputSnapshot: CurrentInputTextSnapshot
     private let insertError: Error?
@@ -2367,8 +2433,9 @@ private final class MockProcessingTextInjector: TextInjector {
         self.replaceError = replaceError
     }
 
-    func getSelectionSnapshot() async -> TextSelectionSnapshot {
-        selectionSnapshot
+    func selectionSnapshot(for intent: SelectionCaptureIntent) async -> TextSelectionSnapshot {
+        selectionCaptureIntents.append(intent)
+        return selectionSnapshot
     }
 
     func currentInputTextSnapshot() async -> CurrentInputTextSnapshot {
@@ -2409,7 +2476,13 @@ private final class SlowSelectionTextInjector: TextInjector {
         self.eventRecorder = eventRecorder
     }
 
-    func getSelectionSnapshot() async -> TextSelectionSnapshot {
+    func selectionSnapshot(for intent: SelectionCaptureIntent) async -> TextSelectionSnapshot {
+        switch intent {
+        case .automaticInsertion:
+            eventRecorder.append("selection-intent-automatic")
+        case .explicitSelectionAction:
+            eventRecorder.append("selection-intent-explicit")
+        }
         eventRecorder.append("selection-start")
         try? await Task.sleep(for: .seconds(30))
         return TextSelectionSnapshot()


### PR DESCRIPTION
## Summary

- distinguish automatic dictation from explicit selection actions
- keep strict accessibility range evidence for ordinary dictation while restoring the protected clipboard fallback for opaque apps
- separate persona selection context from safe in-place replacement capability
- add regression coverage for opaque, collapsed, read-only, and normal selection paths

## Tests

- `swift test --filter 'AXTextInjectorTests|WorkflowControllerProcessingTests'` (209 tests, 0 failures)
- `swift test` (2,564 XCTest tests and 8 Swift Testing tests, 0 failures)
- `./scripts/coverage.sh` (all tests pass; existing repository line-coverage baseline: 34.41%)
- `git diff --check`

GUL-83
