### PR TITLE
GUL-83 restore robust selection persona capture

### DIFF
--- a/Sources/Typeflux/TextInjection/AXTextInjector+Paste.swift
+++ b/Sources/Typeflux/TextInjection/AXTextInjector+Paste.swift
@@ -664,10 +664,23 @@ extension AXTextInjector {
     }
 
     func readSelectedTextViaCopy(processID: pid_t?, milliseconds: Int) -> String? {
-        readSelectedTextViaCopy(
+        let processScopedResult = readSelectedTextViaCopy(
             milliseconds: milliseconds,
             pasteboard: .general,
             sendCopy: { sendCopyShortcut(to: processID) }
+        )
+        if let processScopedResult {
+            return processScopedResult
+        }
+
+        guard let processID, frontmostProcessID() == processID else { return nil }
+        NetworkDebugLogger.logMessage(
+            "[Text Selection] process-scoped copy did not respond; retrying through HID event tap"
+        )
+        return readSelectedTextViaCopy(
+            milliseconds: milliseconds,
+            pasteboard: .general,
+            sendCopy: { sendCopyShortcutViaHID() }
         )
     }
 
@@ -776,6 +789,20 @@ extension AXTextInjector {
     }
 
     func sendCopyShortcut(to processID: pid_t?) {
+        postCopyShortcut { event in
+            if let processID {
+                event.postToPid(processID)
+            } else {
+                event.post(tap: .cghidEventTap)
+            }
+        }
+    }
+
+    func sendCopyShortcutViaHID() {
+        postCopyShortcut { $0.post(tap: .cghidEventTap) }
+    }
+
+    private func postCopyShortcut(post: (CGEvent) -> Void) {
         let source = CGEventSource(stateID: .combinedSessionState)
         let down = CGEvent(
             keyboardEventSource: source,
@@ -790,13 +817,8 @@ extension AXTextInjector {
         )
         up?.flags = .maskCommand
 
-        if let processID {
-            down?.postToPid(processID)
-            up?.postToPid(processID)
-        } else {
-            down?.post(tap: .cghidEventTap)
-            up?.post(tap: .cghidEventTap)
-        }
+        if let down { post(down) }
+        if let up { post(up) }
     }
 
     func capturePasteboardSnapshotWithTimeout(from pasteboard: NSPasteboard) -> PasteboardSnapshot? {

--- a/Sources/Typeflux/TextInjection/AXTextInjector+Selection.swift
+++ b/Sources/Typeflux/TextInjection/AXTextInjector+Selection.swift
@@ -105,56 +105,27 @@ extension AXTextInjector {
         }
         let application = AXUIElementCreateApplication(processID)
         AXUIElementSetMessagingTimeout(application, Self.replacementAXMessagingTimeout)
-        guard let element = lightweightFocusedElement(application: application) else {
+        guard let element = resolvedFocusedElement(application: application) else {
             return nil
         }
 
         let role = copyStringAttribute(kAXRoleAttribute as String, from: element)
-        let isNativeText = Self.nativeEditableRoles.contains(role ?? "")
-        let isSettable = isAttributeSettable(kAXSelectedTextRangeAttribute as CFString, on: element)
-            || isAttributeSettable(kAXValueAttribute as CFString, on: element)
-            || isAttributeSettable(kAXSelectedTextAttribute as CFString, on: element)
-
-        if !isNativeText, !isSettable {
-            return nil
-        }
-
         let range = copySelectedTextRange(from: element)
-        if let range, range.length == 0 {
-            return nil
-        }
-
-        guard let text = copyStringAttribute(kAXSelectedTextAttribute, from: element) else {
-            return nil
-        }
-
-        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
-        if trimmed.isEmpty {
-            return nil
-        }
-
-        if let placeholder = copyStringAttribute(kAXPlaceholderValueAttribute as String, from: element),
-           placeholder == text {
-            return nil
-        }
-        if let title = copyStringAttribute(kAXTitleAttribute as String, from: element),
-           title == text {
-            return nil
-        }
-
-        if range == nil, role == "AXWebArea" || role == "AXGroup" || role == "AXUnknown",
-           let value = copyStringAttribute(kAXValueAttribute as String, from: element),
-           value == text {
-            return nil
-        }
-
-        guard let range else { return nil }
+        guard let text = Self.validSelectionText(
+            selectedText: copyTextAttribute(kAXSelectedTextAttribute as String, from: element),
+            selectedRange: range,
+            value: copyTextAttribute(kAXValueAttribute as String, from: element),
+            placeholder: copyTextAttribute(kAXPlaceholderValueAttribute as String, from: element),
+            title: copyTextAttribute(kAXTitleAttribute as String, from: element),
+            role: role
+        ) else { return nil }
 
         let focusedWindow = focusedWindowElement(for: processID)
         let selectionWindow = containingWindow(of: element)
-        let isFocusedTarget = focusedWindow.map { window in
+        let windowMatches = focusedWindow.map { window in
             selectionWindow.map { selection in windowsMatch(window, selection) } ?? true
-        } ?? false
+        } ?? true
+        let isFocusedTarget = frontmostProcessID() == processID && windowMatches
 
         let context = SelectionContext(
             element: element,
@@ -181,6 +152,35 @@ extension AXTextInjector {
         )
 
         return (text, context)
+    }
+
+    /// Web accessibility bridges can expose a stale collapsed range while still
+    /// returning the real DOM selection. Non-empty selected text is therefore
+    /// positive context evidence; the range only controls replacement safety.
+    static func validSelectionText(
+        selectedText: String?,
+        selectedRange: CFRange?,
+        value: String?,
+        placeholder: String?,
+        title: String?,
+        role: String?
+    ) -> String? {
+        guard let selectedText else { return nil }
+        let trimmed = selectedText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        let normalizedPlaceholder = placeholder?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let normalizedTitle = title?.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard normalizedPlaceholder != trimmed, normalizedTitle != trimmed else { return nil }
+
+        let lacksPositiveRange = selectedRange?.length ?? 0 <= 0
+        let isOpaqueContainer = role == "AXWebArea" || role == "AXGroup" || role == "AXUnknown"
+        let normalizedValue = value?.trimmingCharacters(in: .whitespacesAndNewlines)
+        if lacksPositiveRange, isOpaqueContainer, normalizedValue == trimmed {
+            // Several web containers expose their full value through AXSelectedText
+            // even with a collapsed caret. Do not treat that as a real selection.
+            return nil
+        }
+        return trimmed
     }
 
     func isAttributeSettable(_ attribute: CFString, on element: AXUIElement) -> Bool {
@@ -240,7 +240,11 @@ extension AXTextInjector {
         let appElement = AXUIElementCreateApplication(processID)
         AXUIElementSetMessagingTimeout(appElement, Self.replacementAXMessagingTimeout)
 
-        if let focused = copyElementAttribute(kAXFocusedUIElementAttribute as String, from: appElement),
+        return resolvedFocusedElement(application: appElement)
+    }
+
+    func resolvedFocusedElement(application: AXUIElement) -> AXUIElement? {
+        if let focused = copyElementAttribute(kAXFocusedUIElementAttribute as String, from: application),
            let resolved = resolveFocusedElement(focused) {
             logFocusResolution(
                 context: "focusedElement(appFocusedUIElement)",
@@ -250,7 +254,7 @@ extension AXTextInjector {
             return resolved
         }
 
-        if let focusedWindow = copyElementAttribute(kAXFocusedWindowAttribute as String, from: appElement),
+        if let focusedWindow = copyElementAttribute(kAXFocusedWindowAttribute as String, from: application),
            let resolved = resolveFocusedElement(focusedWindow) {
             logFocusResolution(
                 context: "focusedElement(focusedWindow)",
@@ -1091,8 +1095,15 @@ extension AXTextInjector {
 
     func resolveFocusedElement(_ element: AXUIElement) -> AXUIElement? {
         let role = copyStringAttribute(kAXRoleAttribute as String, from: element)
+        let isContainer = role == "AXWindow"
+            || Self.genericEditableRoles.contains(role ?? "")
+            || Self.opaqueContainerRoles.contains(role ?? "")
 
-        if role != "AXWindow" {
+        if !isContainer {
+            return element
+        }
+
+        if role != "AXWindow", validSelectionText(from: element) != nil {
             return element
         }
 
@@ -1107,6 +1118,13 @@ extension AXTextInjector {
             depthRemaining: Self.focusedDescendantSearchDepth
         ) {
             return descendant
+        }
+
+        if let selectionDescendant = findSelectionDescendant(
+            in: element,
+            depthRemaining: Self.focusedDescendantSearchDepth
+        ) {
+            return selectionDescendant
         }
 
         if let editableDescendant = findBestEditableDescendant(
@@ -1134,6 +1152,53 @@ extension AXTextInjector {
         }
 
         return element
+    }
+
+    func validSelectionText(from element: AXUIElement) -> String? {
+        guard let selectedText = copyTextAttribute(kAXSelectedTextAttribute as String, from: element) else {
+            return nil
+        }
+        return Self.validSelectionText(
+            selectedText: selectedText,
+            selectedRange: copySelectedTextRange(from: element),
+            value: copyTextAttribute(kAXValueAttribute as String, from: element),
+            placeholder: copyTextAttribute(kAXPlaceholderValueAttribute as String, from: element),
+            title: copyTextAttribute(kAXTitleAttribute as String, from: element),
+            role: copyStringAttribute(kAXRoleAttribute as String, from: element)
+        )
+    }
+
+    func findSelectionDescendant(in element: AXUIElement, depthRemaining: Int) -> AXUIElement? {
+        var remainingNodes = Self.selectionDescendantSearchMaxNodes
+        return findSelectionDescendant(
+            in: element,
+            depthRemaining: depthRemaining,
+            remainingNodes: &remainingNodes
+        )
+    }
+
+    private func findSelectionDescendant(
+        in element: AXUIElement,
+        depthRemaining: Int,
+        remainingNodes: inout Int
+    ) -> AXUIElement? {
+        guard depthRemaining > 0, remainingNodes > 0 else { return nil }
+
+        for child in copyElementArrayAttribute(kAXChildrenAttribute as String, from: element) {
+            guard remainingNodes > 0 else { return nil }
+            remainingNodes -= 1
+            if validSelectionText(from: child) != nil {
+                return child
+            }
+            if let nested = findSelectionDescendant(
+                in: child,
+                depthRemaining: depthRemaining - 1,
+                remainingNodes: &remainingNodes
+            ) {
+                return nested
+            }
+        }
+        return nil
     }
 
     func findFocusedDescendant(in element: AXUIElement, depthRemaining: Int) -> AXUIElement? {

--- a/Sources/Typeflux/TextInjection/AXTextInjector+Transaction.swift
+++ b/Sources/Typeflux/TextInjection/AXTextInjector+Transaction.swift
@@ -418,7 +418,7 @@ extension AXTextInjector {
         AXUIElementSetMessagingTimeout(application, Self.replacementAXMessagingTimeout)
         AXUIElementSetMessagingTimeout(context.element, Self.replacementAXMessagingTimeout)
 
-        guard var currentElement = lightweightFocusedElement(application: application) else {
+        guard var currentElement = resolvedFocusedElement(application: application) else {
             throw selectionReplacementError(code: 28, description: "The target no longer has a focused input")
         }
         AXUIElementSetMessagingTimeout(currentElement, Self.replacementAXMessagingTimeout)
@@ -429,7 +429,7 @@ extension AXTextInjector {
                 processID: processID,
                 milliseconds: Self.copySelectionTimeoutMilliseconds
             )
-            guard let focusedAfterCopy = lightweightFocusedElement(application: application) else {
+            guard let focusedAfterCopy = resolvedFocusedElement(application: application) else {
                 throw selectionReplacementError(
                     code: 29,
                     description: "The selected text changed while the result was being generated"
@@ -440,7 +440,7 @@ extension AXTextInjector {
         } else if context.source == "clipboard-copy" {
             currentText = context.selectedText
         } else {
-            currentText = copyStringAttribute(kAXSelectedTextAttribute as String, from: currentElement)
+            currentText = copyTextAttribute(kAXSelectedTextAttribute as String, from: currentElement)
         }
         let elementMatches = CFEqual(context.element, currentElement)
         let currentRange = copySelectedTextRange(from: currentElement)

--- a/Sources/Typeflux/TextInjection/AXTextInjector.swift
+++ b/Sources/Typeflux/TextInjection/AXTextInjector.swift
@@ -299,6 +299,7 @@ final class AXTextInjector: TextInjector {
     static let selectionContextLifetime: TimeInterval = 180
     static let maximumSelectionContextCount = 16
     static let focusedDescendantSearchDepth = 10
+    static let selectionDescendantSearchMaxNodes = 96
     static let replacementAXMessagingTimeout: Float = 0.25
     static let pasteboardReadTimeoutMilliseconds = 250
     static let pasteboardSnapshotTimeoutMilliseconds = 250
@@ -840,6 +841,19 @@ final class AXTextInjector: TextInjector {
         let processID = target.processID
         let processName = target.processName
         let bundleIdentifier = target.bundleIdentifier
+        guard processID != nil, processID == frontmostProcessID() else {
+            logger.debug("selection target changed before capture started")
+            latestSelectionContext = nil
+            return TextSelectionSnapshot(
+                processID: processID,
+                processName: processName,
+                bundleIdentifier: bundleIdentifier,
+                source: "target-changed",
+                isEditable: false,
+                isFocusedTarget: false,
+                replacementSafety: SelectionReplacementSafety.none
+            )
+        }
         logger
             .debug(
                 "getSelectionSnapshot — app: \(processName ?? "?", privacy: .public) (pid: \(processID.map(String.init) ?? "?", privacy: .public))"
@@ -866,7 +880,13 @@ final class AXTextInjector: TextInjector {
                 role: result.context.role,
                 windowTitle: result.context.windowTitle,
                 isFocusedTarget: result.context.isFocusedTarget,
-                replacementContextID: replacementContextID
+                replacementContextID: replacementContextID,
+                replacementSafety: Self.replacementSafety(
+                    source: result.context.source,
+                    selectedRange: result.context.range,
+                    isEditable: editability,
+                    isFocusedTarget: result.context.isFocusedTarget
+                )
             )
         }
 
@@ -896,9 +916,10 @@ final class AXTextInjector: TextInjector {
             // When selectionWindow is nil (e.g. Electron/Chromium AX hierarchy doesn't expose
             // a traversable parent chain to the window), we still trust isFocusedTarget = true
             // because the Cmd+C was sent to processID (the frontmost app) and succeeded.
-            let isFocusedTarget = focusedWindow.map { w in
+            let windowMatches = focusedWindow.map { w in
                 selectionWindow.map { s in windowsMatch(w, s) } ?? true
             } ?? (focusedElement != nil)
+            let isFocusedTarget = frontmostProcessID() == processID && windowMatches
             let context = SelectionContext(
                 element: focusedElement ?? AXUIElementCreateSystemWide(),
                 windowElement: focusedWindow ?? selectionWindow,
@@ -952,7 +973,13 @@ final class AXTextInjector: TextInjector {
                 role: context.role,
                 windowTitle: context.windowTitle,
                 isFocusedTarget: context.isFocusedTarget,
-                replacementContextID: replacementContextID
+                replacementContextID: replacementContextID,
+                replacementSafety: Self.replacementSafety(
+                    source: "clipboard-copy",
+                    selectedRange: clipboardProbeRange,
+                    isEditable: editability,
+                    isFocusedTarget: context.isFocusedTarget
+                )
             )
         }
         logger.debug("clipboard-copy returned nil — no selection detected")
@@ -977,7 +1004,8 @@ final class AXTextInjector: TextInjector {
     /// A copy response alone is not proof of a selection: some applications copy the
     /// entire field when no range is selected. Ordinary dictation therefore requires
     /// positive range evidence. An explicit selection command may probe an opaque target,
-    /// while still respecting a range that Accessibility confirms is collapsed.
+    /// including web bridges that report a stale collapsed range; ambiguous results are
+    /// context-only and never authorized for destructive replacement.
     static func shouldProbeClipboardSelection(
         selectedRange: CFRange?,
         intent: SelectionCaptureIntent
@@ -986,8 +1014,20 @@ final class AXTextInjector: TextInjector {
         case .automaticInsertion:
             selectedRange?.length ?? 0 > 0
         case .explicitSelectionAction:
-            selectedRange?.length != 0
+            true
         }
+    }
+
+    static func replacementSafety(
+        source: String,
+        selectedRange: CFRange?,
+        isEditable: Bool,
+        isFocusedTarget: Bool
+    ) -> SelectionReplacementSafety {
+        guard isFocusedTarget else { return .resultOnly }
+        guard selectedRange?.length ?? 0 > 0 else { return .resultOnly }
+        guard isEditable else { return .resultOnly }
+        return source == "clipboard-copy" ? .verifiedPaste : .directAccessibility
     }
 
     func insert(text: String) throws {

--- a/Sources/Typeflux/TextInjection/TextInjector.swift
+++ b/Sources/Typeflux/TextInjection/TextInjector.swift
@@ -10,6 +10,22 @@ enum SelectionCaptureIntent: Equatable {
     case explicitSelectionAction
 }
 
+enum SelectionReplacementSafety: Equatable {
+    /// The capture did not produce usable selection context.
+    case none
+
+    /// Accessibility exposed a stable, writable non-empty range.
+    case directAccessibility
+
+    /// A non-empty Accessibility range was completed through a clipboard read and
+    /// must be revalidated immediately before paste.
+    case verifiedPaste
+
+    /// The text is valid context for an explicit action, but the target does not
+    /// expose enough evidence for safe in-place replacement.
+    case resultOnly
+}
+
 struct TextSelectionSnapshot {
     var processID: pid_t?
     var processName: String?
@@ -22,6 +38,7 @@ struct TextSelectionSnapshot {
     var windowTitle: String?
     var isFocusedTarget: Bool = false
     var replacementContextID: UUID?
+    var replacementSafety: SelectionReplacementSafety?
 
     var hasSelection: Bool {
         let trimmed = selectedText?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
@@ -33,7 +50,13 @@ struct TextSelectionSnapshot {
     }
 
     var canReplaceSelection: Bool {
-        hasAskSelectionContext && (
+        if let replacementSafety {
+            return hasAskSelectionContext && (
+                replacementSafety == .directAccessibility ||
+                    replacementSafety == .verifiedPaste
+            )
+        }
+        return hasAskSelectionContext && (
             isEditable ||
                 source == "clipboard-copy"
         )

--- a/Tests/TypefluxTests/AXTextInjectorTests.swift
+++ b/Tests/TypefluxTests/AXTextInjectorTests.swift
@@ -1728,12 +1728,15 @@ final class AXTextInjectorTests: XCTestCase {
         XCTAssertFalse(result)
     }
 
-    func testClipboardSelectionProbeRejectsCollapsedSelection() {
+    func testAutomaticClipboardSelectionProbeRejectsCollapsedSelection() {
         XCTAssertFalse(AXTextInjector.shouldProbeClipboardSelection(
             selectedRange: CFRange(location: 12, length: 0),
             intent: .automaticInsertion
         ))
-        XCTAssertFalse(AXTextInjector.shouldProbeClipboardSelection(
+    }
+
+    func testExplicitClipboardSelectionProbeAllowsStaleCollapsedRange() {
+        XCTAssertTrue(AXTextInjector.shouldProbeClipboardSelection(
             selectedRange: CFRange(location: 12, length: 0),
             intent: .explicitSelectionAction
         ))
@@ -1762,6 +1765,123 @@ final class AXTextInjectorTests: XCTestCase {
             selectedRange: CFRange(location: 4, length: 8),
             intent: .explicitSelectionAction
         ))
+    }
+
+    func testValidSelectionTextAcceptsWebSelectionWithStaleCollapsedRange() {
+        XCTAssertEqual(
+            AXTextInjector.validSelectionText(
+                selectedText: "selected words",
+                selectedRange: CFRange(location: 42, length: 0),
+                value: "the selected words remain inside a larger value",
+                placeholder: nil,
+                title: nil,
+                role: "AXWebArea"
+            ),
+            "selected words"
+        )
+    }
+
+    func testValidSelectionTextRejectsOpaqueFullValueAtCollapsedCaret() {
+        XCTAssertNil(AXTextInjector.validSelectionText(
+            selectedText: "entire editor",
+            selectedRange: CFRange(location: 13, length: 0),
+            value: "entire editor",
+            placeholder: nil,
+            title: nil,
+            role: "AXGroup"
+        ))
+    }
+
+    func testValidSelectionTextAcceptsReadOnlySelectionWithoutRange() {
+        XCTAssertEqual(
+            AXTextInjector.validSelectionText(
+                selectedText: "message excerpt",
+                selectedRange: nil,
+                value: nil,
+                placeholder: nil,
+                title: nil,
+                role: "AXStaticText"
+            ),
+            "message excerpt"
+        )
+    }
+
+    func testValidSelectionTextRejectsPlaceholderTitleAndWhitespace() {
+        XCTAssertNil(AXTextInjector.validSelectionText(
+            selectedText: "Prompt",
+            selectedRange: CFRange(location: 0, length: 6),
+            value: nil,
+            placeholder: "Prompt",
+            title: nil,
+            role: "AXTextArea"
+        ))
+        XCTAssertNil(AXTextInjector.validSelectionText(
+            selectedText: "Window",
+            selectedRange: CFRange(location: 0, length: 6),
+            value: nil,
+            placeholder: nil,
+            title: "Window",
+            role: "AXTextArea"
+        ))
+        XCTAssertNil(AXTextInjector.validSelectionText(
+            selectedText: " \n ",
+            selectedRange: CFRange(location: 0, length: 3),
+            value: nil,
+            placeholder: nil,
+            title: nil,
+            role: "AXTextArea"
+        ))
+    }
+
+    func testReplacementSafetyRequiresPositiveWritableFocusedRange() {
+        XCTAssertEqual(
+            AXTextInjector.replacementSafety(
+                source: "accessibility",
+                selectedRange: CFRange(location: 4, length: 8),
+                isEditable: true,
+                isFocusedTarget: true
+            ),
+            .directAccessibility
+        )
+        XCTAssertEqual(
+            AXTextInjector.replacementSafety(
+                source: "clipboard-copy",
+                selectedRange: CFRange(location: 4, length: 8),
+                isEditable: true,
+                isFocusedTarget: true
+            ),
+            .verifiedPaste
+        )
+    }
+
+    func testReplacementSafetyFallsBackToResultForAmbiguousTargets() {
+        XCTAssertEqual(
+            AXTextInjector.replacementSafety(
+                source: "clipboard-copy",
+                selectedRange: nil,
+                isEditable: true,
+                isFocusedTarget: true
+            ),
+            .resultOnly
+        )
+        XCTAssertEqual(
+            AXTextInjector.replacementSafety(
+                source: "accessibility",
+                selectedRange: CFRange(location: 4, length: 8),
+                isEditable: false,
+                isFocusedTarget: true
+            ),
+            .resultOnly
+        )
+        XCTAssertEqual(
+            AXTextInjector.replacementSafety(
+                source: "accessibility",
+                selectedRange: CFRange(location: 4, length: 8),
+                isEditable: true,
+                isFocusedTarget: false
+            ),
+            .resultOnly
+        )
     }
 
     func testClipboardCopyProbeRejectsStaleTextWhenCopyDoesNothing() {

--- a/Tests/TypefluxTests/TextSelectionSnapshotTests.swift
+++ b/Tests/TypefluxTests/TextSelectionSnapshotTests.swift
@@ -66,4 +66,28 @@ final class TextSelectionSnapshotTests: XCTestCase {
         XCTAssertTrue(snapshot.canReplaceSelection)
         XCTAssertFalse(snapshot.canSafelyRestoreSelection)
     }
+
+    func testExplicitReplacementSafetyOverridesLegacySourceInference() {
+        var snapshot = TextSelectionSnapshot()
+        snapshot.selectedText = "Selected from an opaque web view"
+        snapshot.isFocusedTarget = true
+        snapshot.isEditable = true
+        snapshot.source = "clipboard-copy"
+        snapshot.replacementSafety = .resultOnly
+
+        XCTAssertTrue(snapshot.hasAskSelectionContext)
+        XCTAssertFalse(snapshot.canReplaceSelection)
+        XCTAssertFalse(snapshot.canSafelyRestoreSelection)
+    }
+
+    func testVerifiedPasteSafetyAllowsReplacement() {
+        var snapshot = TextSelectionSnapshot()
+        snapshot.selectedText = "Verified selection"
+        snapshot.isFocusedTarget = true
+        snapshot.source = "clipboard-copy"
+        snapshot.replacementSafety = .verifiedPaste
+
+        XCTAssertTrue(snapshot.canReplaceSelection)
+        XCTAssertFalse(snapshot.canSafelyRestoreSelection)
+    }
 }

--- a/Tests/TypefluxTests/WorkflowControllerProcessingTests.swift
+++ b/Tests/TypefluxTests/WorkflowControllerProcessingTests.swift
@@ -524,7 +524,8 @@ final class WorkflowControllerProcessingTests: XCTestCase {
             role: "AXWindow",
             windowTitle: "Editor",
             isFocusedTarget: true,
-            replacementContextID: UUID()
+            replacementContextID: UUID(),
+            replacementSafety: .resultOnly
         )
         let textInjector = MockProcessingTextInjector(selectionSnapshot: snapshot)
         let controller = makeWorkflowController(
@@ -544,6 +545,7 @@ final class WorkflowControllerProcessingTests: XCTestCase {
             controller.personaPickerTitle(for: controller.personaPickerMode),
             L("overlay.personaPicker.applyTitle")
         )
+        XCTAssertTrue(controller.shouldPresentResultDialog(for: context.snapshot))
     }
 
     func testPersonaPickerSeparatesSelectionContextFromReplacementCapability() async {


### PR DESCRIPTION
## Summary

- restore bounded deep Accessibility focus resolution for Chromium/Electron selection targets
- accept non-empty `AXSelectedText` when a web bridge exposes a stale collapsed range
- retry explicit selection capture through a protected HID clipboard probe when process-scoped copy is unsupported
- separate selection context usability from replacement safety so ambiguous captures use the result window instead of overwriting content
- revalidate the same resolved target before replacement and reject app/window/focus changes

## Tests

- `swift test --enable-code-coverage --filter 'AXTextInjectorTests|TextSelectionSnapshotTests|WorkflowControllerProcessingTests/testPersonaPicker'` (133 passed)
- targeted changed model line coverage: `TextInjector.swift` 91.49%
- `git diff --check`

## Full-suite note

The full XCTest process reaches an existing `OverlayController deallocated with non-zero retain count` AppKit abort in `WorkflowControllerProcessingTests`; it also reproduces without coverage and is outside the selection code paths. The complete selection/persona regression set above passes with zero failures.
