### PR TITLE
GUL-89: eliminate ASR token cold-start latency

### DIFF
--- a/Sources/Typeflux/App/AppCoordinator.swift
+++ b/Sources/Typeflux/App/AppCoordinator.swift
@@ -32,14 +32,23 @@ final class AppCoordinator {
             queue: .main
         ) { [weak reporter = di.analyticsReporter] _ in
             reporter?.report(eventName: "app_login", properties: [:])
-            Task { await CloudEndpointRegistry.shared.probeAll() }
+            Task {
+                await CloudEndpointRegistry.shared.probeAll()
+                await TypefluxOfficialASRRouteCache.shared.invalidate()
+                if let token = await MainActor.run(body: { AuthState.shared.accessToken }) {
+                    await TypefluxOfficialASRRouteCache.shared.prefetch(accessToken: token)
+                }
+            }
         }
         authLogoutObserver = NotificationCenter.default.addObserver(
             forName: .authDidLogout,
             object: nil,
             queue: .main
         ) { _ in
-            Task { await CloudEndpointRegistry.shared.probeAll() }
+            Task {
+                await CloudEndpointRegistry.shared.probeAll()
+                await TypefluxOfficialASRRouteCache.shared.invalidate()
+            }
         }
         let settingsStore = di.settingsStore
         let localModelManager = di.localModelManager
@@ -123,7 +132,12 @@ final class AppCoordinator {
         }
         cloudEndpointProbeScheduler.start()
         asrPublicConfigRefreshScheduler.start()
-        Task { await AuthState.shared.refreshTokenIfNeeded() }
+        Task {
+            await AuthState.shared.refreshTokenIfNeeded()
+            if let token = await MainActor.run(body: { AuthState.shared.accessToken }) {
+                await TypefluxOfficialASRRouteCache.shared.prefetch(accessToken: token)
+            }
+        }
 
         if !di.settingsStore.isOnboardingCompleted {
             presentOnboarding()
@@ -141,6 +155,7 @@ final class AppCoordinator {
         permissionAnalyticsTimer = nil
         cloudEndpointProbeScheduler.stop()
         asrPublicConfigRefreshScheduler.stop()
+        Task { await TypefluxOfficialASRRouteCache.shared.invalidate() }
         workflowController?.stop()
         statusBarController?.stop()
     }

--- a/Sources/Typeflux/Networking/TypefluxCloudRequestHeaders.swift
+++ b/Sources/Typeflux/Networking/TypefluxCloudRequestHeaders.swift
@@ -126,7 +126,7 @@ final class TypefluxCloudClientIdentityStore: @unchecked Sendable {
     }
 }
 
-enum TypefluxCloudScenario: String, CaseIterable, Sendable {
+enum TypefluxCloudScenario: String, CaseIterable, Hashable, Sendable {
     case voiceInput = "voice-input"
     case askAnything = "ask-anything"
     case textRewrite = "text-rewrite"

--- a/Sources/Typeflux/STT/STTRouter+Recording.swift
+++ b/Sources/Typeflux/STT/STTRouter+Recording.swift
@@ -5,6 +5,8 @@ extension STTRouter {
             await (doubaoRealtime as? RecordingPrewarmingTranscriber)?.prepareForRecording()
         case .localModel:
             await (localModel as? RecordingPrewarmingTranscriber)?.prepareForRecording()
+        case .typefluxOfficial:
+            await (typefluxOfficial as? RecordingPrewarmingTranscriber)?.prepareForRecording()
         default:
             break
         }
@@ -16,6 +18,8 @@ extension STTRouter {
             await (doubaoRealtime as? RecordingPrewarmingTranscriber)?.cancelPreparedRecording()
         case .localModel:
             await (localModel as? RecordingPrewarmingTranscriber)?.cancelPreparedRecording()
+        case .typefluxOfficial:
+            await (typefluxOfficial as? RecordingPrewarmingTranscriber)?.cancelPreparedRecording()
         default:
             break
         }

--- a/Sources/Typeflux/STT/Transcriber.swift
+++ b/Sources/Typeflux/STT/Transcriber.swift
@@ -99,7 +99,7 @@ extension TypefluxCloudScenarioAwareTranscriber {
 }
 
 final class STTRouter {
-    static let typefluxOfficialCloudPriorityWindowSeconds: TimeInterval = 0.25
+    static let typefluxOfficialCloudPriorityWindowSeconds: TimeInterval = 1
 
     let settingsStore: SettingsStore
     let whisper: Transcriber

--- a/Sources/Typeflux/STT/Transcriber.swift
+++ b/Sources/Typeflux/STT/Transcriber.swift
@@ -99,7 +99,7 @@ extension TypefluxCloudScenarioAwareTranscriber {
 }
 
 final class STTRouter {
-    static let typefluxOfficialCloudPriorityWindowSeconds: TimeInterval = 3
+    static let typefluxOfficialCloudPriorityWindowSeconds: TimeInterval = 0.25
 
     let settingsStore: SettingsStore
     let whisper: Transcriber
@@ -120,7 +120,7 @@ final class STTRouter {
     private let typefluxOfficialCloudPriorityWindowOverride: TimeInterval?
 
     var typefluxOfficialCloudPriorityWindow: TimeInterval {
-        typefluxOfficialCloudPriorityWindowOverride ?? settingsStore.voiceProcessingTimeout.seconds
+        typefluxOfficialCloudPriorityWindowOverride ?? Self.typefluxOfficialCloudPriorityWindowSeconds
     }
 
     var usesTypefluxOfficialCloudLocalRace: Bool {

--- a/Sources/Typeflux/STT/TypefluxOfficialASRRouteCache.swift
+++ b/Sources/Typeflux/STT/TypefluxOfficialASRRouteCache.swift
@@ -1,0 +1,235 @@
+import Foundation
+
+/// Keeps one unused ASR route ready per scenario.
+///
+/// Routes are consumed once because the token callback contains a per-session
+/// usage report identifier. Reusing a token would merge multiple recordings
+/// into one billing record. After checkout, the next route is fetched in the
+/// background; an unused route is rotated 30 seconds before expiration.
+actor TypefluxOfficialASRRouteCache: TypefluxOfficialASRRoutingClient {
+    static let shared = TypefluxOfficialASRRouteCache()
+
+    typealias Sleep = @Sendable (TimeInterval) async throws -> Void
+
+    private struct Entry {
+        let accessToken: String
+        let route: TypefluxOfficialASRRouteDecision
+        let expiresAt: Date
+    }
+
+    private struct InFlightFetch {
+        let id: UUID
+        let accessToken: String
+        let task: Task<TypefluxOfficialASRRouteDecision, Error>
+        var reservedForConsumer: Bool
+    }
+
+    private static let refreshLeadTime: TimeInterval = 30
+    private static let fallbackLifetime: TimeInterval = 60 * 60
+    private static let refreshRetryDelay: TimeInterval = 5
+
+    private let upstream: any TypefluxOfficialASRRoutingClient
+    private let now: @Sendable () -> Date
+    private let sleep: Sleep
+    private var entries: [TypefluxCloudScenario: Entry] = [:]
+    private var fetches: [TypefluxCloudScenario: InFlightFetch] = [:]
+    private var refreshTasks: [TypefluxCloudScenario: Task<Void, Never>] = [:]
+
+    init(
+        upstream: any TypefluxOfficialASRRoutingClient = TypefluxOfficialASRRoutingHTTPClient(),
+        now: @escaping @Sendable () -> Date = { Date() },
+        sleep: @escaping Sleep = { delay in
+            try await Task.sleep(for: .seconds(delay))
+        }
+    ) {
+        self.upstream = upstream
+        self.now = now
+        self.sleep = sleep
+    }
+
+    func fetchRoute(
+        accessToken: String,
+        scenario: TypefluxCloudScenario
+    ) async throws -> TypefluxOfficialASRRouteDecision {
+        let current = now()
+        if let entry = entries[scenario],
+           entry.accessToken == accessToken,
+           entry.expiresAt > current.addingTimeInterval(Self.refreshLeadTime) {
+            entries[scenario] = nil
+            refreshTasks.removeValue(forKey: scenario)?.cancel()
+            refillInBackground(accessToken: accessToken, scenario: scenario)
+            return entry.route
+        }
+
+        entries[scenario] = nil
+        refreshTasks.removeValue(forKey: scenario)?.cancel()
+        let route = try await fetchForConsumer(accessToken: accessToken, scenario: scenario)
+        refillInBackground(accessToken: accessToken, scenario: scenario)
+        return route
+    }
+
+    func prefetch(accessToken: String, scenario: TypefluxCloudScenario = .voiceInput) async {
+        if let entry = entries[scenario],
+           entry.accessToken == accessToken,
+           entry.expiresAt > now().addingTimeInterval(Self.refreshLeadTime) {
+            return
+        }
+        do {
+            try await fillCache(accessToken: accessToken, scenario: scenario)
+        } catch is CancellationError {
+            return
+        } catch {
+            NetworkDebugLogger.logError(context: "ASR route prefetch failed", error: error)
+        }
+    }
+
+    func invalidate() {
+        entries.removeAll()
+        fetches.values.forEach { $0.task.cancel() }
+        fetches.removeAll()
+        refreshTasks.values.forEach { $0.cancel() }
+        refreshTasks.removeAll()
+    }
+
+    private func fetchForConsumer(
+        accessToken: String,
+        scenario: TypefluxCloudScenario
+    ) async throws -> TypefluxOfficialASRRouteDecision {
+        let fetch: InFlightFetch
+        if var current = fetches[scenario],
+           current.accessToken == accessToken,
+           !current.reservedForConsumer {
+            current.reservedForConsumer = true
+            fetches[scenario] = current
+            fetch = current
+        } else {
+            if let current = fetches[scenario], current.accessToken != accessToken {
+                current.task.cancel()
+                fetches[scenario] = nil
+            } else if fetches[scenario]?.reservedForConsumer == true {
+                // A route carries one usage report identifier, so concurrent
+                // consumers must never share the same in-flight token.
+                return try await upstream.fetchRoute(accessToken: accessToken, scenario: scenario)
+            }
+            fetch = makeFetch(accessToken: accessToken, scenario: scenario, reservedForConsumer: true)
+            fetches[scenario] = fetch
+        }
+        do {
+            let route = try await fetch.task.value
+            completeFetch(id: fetch.id, scenario: scenario)
+            return route
+        } catch {
+            completeFetch(id: fetch.id, scenario: scenario)
+            throw error
+        }
+    }
+
+    private func fillCache(accessToken: String, scenario: TypefluxCloudScenario) async throws {
+        let fetch: InFlightFetch
+        if let current = fetches[scenario], current.accessToken == accessToken {
+            fetch = current
+        } else {
+            fetches.removeValue(forKey: scenario)?.task.cancel()
+            fetch = makeFetch(accessToken: accessToken, scenario: scenario, reservedForConsumer: false)
+            fetches[scenario] = fetch
+        }
+        do {
+            let route = try await fetch.task.value
+            guard let current = fetches[scenario], current.id == fetch.id else { return }
+            fetches[scenario] = nil
+            if !current.reservedForConsumer {
+                store(route, accessToken: accessToken, scenario: scenario)
+            }
+        } catch {
+            completeFetch(id: fetch.id, scenario: scenario)
+            throw error
+        }
+    }
+
+    private func makeFetch(
+        accessToken: String,
+        scenario: TypefluxCloudScenario,
+        reservedForConsumer: Bool
+    ) -> InFlightFetch {
+        let upstream = upstream
+        return InFlightFetch(
+            id: UUID(),
+            accessToken: accessToken,
+            task: Task { try await upstream.fetchRoute(accessToken: accessToken, scenario: scenario) },
+            reservedForConsumer: reservedForConsumer
+        )
+    }
+
+    private func completeFetch(id: UUID, scenario: TypefluxCloudScenario) {
+        guard fetches[scenario]?.id == id else { return }
+        fetches[scenario] = nil
+    }
+
+    private func refillInBackground(accessToken: String, scenario: TypefluxCloudScenario) {
+        Task { [weak self] in
+            await self?.prefetch(accessToken: accessToken, scenario: scenario)
+        }
+    }
+
+    private func store(
+        _ route: TypefluxOfficialASRRouteDecision,
+        accessToken: String,
+        scenario: TypefluxCloudScenario
+    ) {
+        let current = now()
+        let expiration = route.expirationDate(relativeTo: current)
+        entries[scenario] = Entry(accessToken: accessToken, route: route, expiresAt: expiration)
+        scheduleRefresh(accessToken: accessToken, scenario: scenario, expiresAt: expiration)
+    }
+
+    private func scheduleRefresh(
+        accessToken: String,
+        scenario: TypefluxCloudScenario,
+        expiresAt: Date
+    ) {
+        refreshTasks.removeValue(forKey: scenario)?.cancel()
+        let delay = max(0, expiresAt.timeIntervalSince(now()) - Self.refreshLeadTime)
+        let sleep = sleep
+        refreshTasks[scenario] = Task { [weak self] in
+            do {
+                try await sleep(delay)
+                try Task.checkCancellation()
+                await self?.refresh(accessToken: accessToken, scenario: scenario)
+            } catch {
+                // Cancellation means the cached route was consumed or invalidated.
+            }
+        }
+    }
+
+    private func refresh(accessToken: String, scenario: TypefluxCloudScenario) async {
+        guard entries[scenario]?.accessToken == accessToken else { return }
+        do {
+            try await fillCache(accessToken: accessToken, scenario: scenario)
+        } catch is CancellationError {
+            return
+        } catch {
+            NetworkDebugLogger.logError(context: "Scheduled ASR route refresh failed", error: error)
+            guard entries[scenario]?.expiresAt ?? .distantPast > now() else {
+                entries[scenario] = nil
+                return
+            }
+            scheduleRefresh(
+                accessToken: accessToken,
+                scenario: scenario,
+                expiresAt: now().addingTimeInterval(Self.refreshLeadTime + Self.refreshRetryDelay)
+            )
+        }
+    }
+}
+
+private extension TypefluxOfficialASRRouteDecision {
+    func expirationDate(relativeTo now: Date) -> Date {
+        switch self {
+        case let .webSocket(_, _, expiresAt, expiresInSeconds, _):
+            if let expiresAt {
+                return Date(timeIntervalSince1970: TimeInterval(expiresAt))
+            }
+            return now.addingTimeInterval(TimeInterval(expiresInSeconds ?? 3_600))
+        }
+    }
+}

--- a/Sources/Typeflux/STT/TypefluxOfficialASRRoutingClient.swift
+++ b/Sources/Typeflux/STT/TypefluxOfficialASRRoutingClient.swift
@@ -54,6 +54,7 @@ struct TypefluxOfficialASRRoutingHTTPClient: TypefluxOfficialASRRoutingClient {
             request.httpMethod = "POST"
             request.timeoutInterval = 30
             request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+            request.setValue(UUID().uuidString.lowercased(), forHTTPHeaderField: TypefluxOfficialASRRequestFactory.traceIDHeader)
             TypefluxCloudRequestHeaders.applyScenario(scenario, to: &request)
             return request
         }

--- a/Sources/Typeflux/STT/TypefluxOfficialTranscriber.swift
+++ b/Sources/Typeflux/STT/TypefluxOfficialTranscriber.swift
@@ -70,14 +70,14 @@ protocol TypefluxOfficialASRTransport: Sendable {
 // MARK: - Main Transcriber
 
 final class TypefluxOfficialTranscriber: ASROptimizeAwareTranscriber, TypefluxCloudLLMIntegratedTranscriber,
-    OptimizeAwareRealtimeSessionFactory {
+    OptimizeAwareRealtimeSessionFactory, RecordingPrewarmingTranscriber {
     private let routingClient: any TypefluxOfficialASRRoutingClient
     private let transport: any TypefluxOfficialASRTransport
     private let serverRegistry: any TypefluxASRServerProviding
     private let accessTokenProvider: @Sendable () async -> String?
 
     init(
-        routingClient: any TypefluxOfficialASRRoutingClient = TypefluxOfficialASRRoutingHTTPClient(),
+        routingClient: any TypefluxOfficialASRRoutingClient = TypefluxOfficialASRRouteCache.shared,
         transport: any TypefluxOfficialASRTransport = DefaultTypefluxOfficialASRTransport(),
         serverRegistry: any TypefluxASRServerProviding = TypefluxASRServerRegistry.shared,
         accessTokenProvider: @escaping @Sendable () async -> String? = {
@@ -88,6 +88,18 @@ final class TypefluxOfficialTranscriber: ASROptimizeAwareTranscriber, TypefluxCl
         self.transport = transport
         self.serverRegistry = serverRegistry
         self.accessTokenProvider = accessTokenProvider
+    }
+
+    func prepareForRecording() async {
+        guard let cache = routingClient as? TypefluxOfficialASRRouteCache,
+              let token = await accessTokenProvider(),
+              !token.isEmpty
+        else { return }
+        await cache.prefetch(accessToken: token)
+    }
+
+    func cancelPreparedRecording() async {
+        // The prefetched route remains useful for the next recording.
     }
 
     func transcribeStream(

--- a/Tests/TypefluxTests/STTRouterTests.swift
+++ b/Tests/TypefluxTests/STTRouterTests.swift
@@ -443,17 +443,17 @@ final class STTRouterTests: XCTestCase {
         XCTAssertEqual(diagnosticsRecorder.snapshot()?.selectionReason, .cloudWithinPriorityWindow)
     }
 
-    func testTypefluxOfficialCloudPriorityWindowIsLowLatencyGracePeriod() {
-        XCTAssertEqual(STTRouter.typefluxOfficialCloudPriorityWindowSeconds, 0.25)
+    func testTypefluxOfficialCloudPriorityWindowIsOneSecondQualityGracePeriod() {
+        XCTAssertEqual(STTRouter.typefluxOfficialCloudPriorityWindowSeconds, 1)
     }
 
     func testTypefluxOfficialCloudPriorityWindowDoesNotFollowVoiceProcessingTimeout() {
         let router = makeRouter(typefluxOfficialCloudPriorityWindow: nil)
-        XCTAssertEqual(router.typefluxOfficialCloudPriorityWindow, 0.25)
+        XCTAssertEqual(router.typefluxOfficialCloudPriorityWindow, 1)
 
         settings.voiceProcessingTimeout = .thirtySeconds
 
-        XCTAssertEqual(router.typefluxOfficialCloudPriorityWindow, 0.25)
+        XCTAssertEqual(router.typefluxOfficialCloudPriorityWindow, 1)
     }
 
     func testTypefluxOfficialUsesReadyLocalResultWhenPriorityWindowExpires() async throws {

--- a/Tests/TypefluxTests/STTRouterTests.swift
+++ b/Tests/TypefluxTests/STTRouterTests.swift
@@ -443,17 +443,17 @@ final class STTRouterTests: XCTestCase {
         XCTAssertEqual(diagnosticsRecorder.snapshot()?.selectionReason, .cloudWithinPriorityWindow)
     }
 
-    func testTypefluxOfficialCloudPriorityWindowIsThreeSeconds() {
-        XCTAssertEqual(STTRouter.typefluxOfficialCloudPriorityWindowSeconds, 3)
+    func testTypefluxOfficialCloudPriorityWindowIsLowLatencyGracePeriod() {
+        XCTAssertEqual(STTRouter.typefluxOfficialCloudPriorityWindowSeconds, 0.25)
     }
 
-    func testTypefluxOfficialCloudPriorityWindowUsesCurrentSetting() {
+    func testTypefluxOfficialCloudPriorityWindowDoesNotFollowVoiceProcessingTimeout() {
         let router = makeRouter(typefluxOfficialCloudPriorityWindow: nil)
-        XCTAssertEqual(router.typefluxOfficialCloudPriorityWindow, 3)
+        XCTAssertEqual(router.typefluxOfficialCloudPriorityWindow, 0.25)
 
         settings.voiceProcessingTimeout = .thirtySeconds
 
-        XCTAssertEqual(router.typefluxOfficialCloudPriorityWindow, 30)
+        XCTAssertEqual(router.typefluxOfficialCloudPriorityWindow, 0.25)
     }
 
     func testTypefluxOfficialUsesReadyLocalResultWhenPriorityWindowExpires() async throws {

--- a/Tests/TypefluxTests/TypefluxOfficialASRRouteCacheTests.swift
+++ b/Tests/TypefluxTests/TypefluxOfficialASRRouteCacheTests.swift
@@ -1,0 +1,125 @@
+@testable import Typeflux
+import XCTest
+
+final class TypefluxOfficialASRRouteCacheTests: XCTestCase {
+    func testPrefetchedRouteIsConsumedOnceAndRefilledInBackground() async throws {
+        let upstream = RouteSequenceClient()
+        let cache = TypefluxOfficialASRRouteCache(
+            upstream: upstream,
+            sleep: { _ in try await Task.sleep(for: .seconds(60)) }
+        )
+
+        await cache.prefetch(accessToken: "account-token")
+        let first = try await cache.fetchRoute(accessToken: "account-token", scenario: .voiceInput)
+        let second = try await cache.fetchRoute(accessToken: "account-token", scenario: .voiceInput)
+
+        XCTAssertEqual(first.token, "route-1")
+        XCTAssertEqual(second.token, "route-2")
+        let requestCount = await upstream.requestCount()
+        XCTAssertGreaterThanOrEqual(requestCount, 2)
+        await cache.invalidate()
+    }
+
+    func testUnusedRouteSchedulesRefreshThirtySecondsBeforeExpiry() async {
+        let upstream = RouteSequenceClient(expiresInSeconds: 3_600)
+        let sleepRecorder = RouteCacheSleepRecorder()
+        let cache = TypefluxOfficialASRRouteCache(
+            upstream: upstream,
+            now: { Date(timeIntervalSince1970: 1_000) },
+            sleep: { delay in try await sleepRecorder.sleep(delay) }
+        )
+
+        await cache.prefetch(accessToken: "account-token")
+        for _ in 0 ..< 20 {
+            if !(await sleepRecorder.delays()).isEmpty { break }
+            await Task.yield()
+        }
+
+        let delays = await sleepRecorder.delays()
+        XCTAssertEqual(delays.first, 3_570)
+        await cache.invalidate()
+    }
+
+    func testConcurrentConsumersReceiveDistinctRoutes() async throws {
+        let upstream = RouteSequenceClient(delay: 0.05)
+        let cache = TypefluxOfficialASRRouteCache(
+            upstream: upstream,
+            sleep: { _ in try await Task.sleep(for: .seconds(60)) }
+        )
+
+        async let first = cache.fetchRoute(accessToken: "account-token", scenario: .voiceInput)
+        async let second = cache.fetchRoute(accessToken: "account-token", scenario: .voiceInput)
+        let tokens = try await [first.token, second.token]
+
+        XCTAssertEqual(Set(tokens).count, 2)
+        await cache.invalidate()
+    }
+
+    func testAccessTokenChangeDoesNotConsumePreviousAccountsRoute() async throws {
+        let upstream = RouteSequenceClient()
+        let cache = TypefluxOfficialASRRouteCache(
+            upstream: upstream,
+            sleep: { _ in try await Task.sleep(for: .seconds(60)) }
+        )
+
+        await cache.prefetch(accessToken: "first-account")
+        let route = try await cache.fetchRoute(accessToken: "second-account", scenario: .voiceInput)
+
+        XCTAssertEqual(route.token, "route-2")
+        await cache.invalidate()
+    }
+}
+
+private actor RouteSequenceClient: TypefluxOfficialASRRoutingClient {
+    private var count = 0
+    private let expiresInSeconds: Int
+    private let delay: TimeInterval
+
+    init(expiresInSeconds: Int = 3_600, delay: TimeInterval = 0) {
+        self.expiresInSeconds = expiresInSeconds
+        self.delay = delay
+    }
+
+    func fetchRoute(
+        accessToken _: String,
+        scenario _: TypefluxCloudScenario
+    ) async throws -> TypefluxOfficialASRRouteDecision {
+        count += 1
+        let token = "route-\(count)"
+        if delay > 0 {
+            try await Task.sleep(for: .seconds(delay))
+        }
+        return .webSocket(
+            token: token,
+            tokenType: "Bearer",
+            expiresAt: nil,
+            expiresInSeconds: expiresInSeconds,
+            serverBaseURLs: [URL(string: "https://asr.example.com")!]
+        )
+    }
+
+    func requestCount() -> Int {
+        count
+    }
+}
+
+private actor RouteCacheSleepRecorder {
+    private var recordedDelays: [TimeInterval] = []
+
+    func sleep(_ delay: TimeInterval) async throws {
+        recordedDelays.append(delay)
+        try await Task.sleep(for: .seconds(60))
+    }
+
+    func delays() -> [TimeInterval] {
+        recordedDelays
+    }
+}
+
+private extension TypefluxOfficialASRRouteDecision {
+    var token: String {
+        switch self {
+        case let .webSocket(token, _, _, _, _): token
+        }
+    }
+}

--- a/Tests/TypefluxTests/TypefluxOfficialASRRoutingClientTests.swift
+++ b/Tests/TypefluxTests/TypefluxOfficialASRRoutingClientTests.swift
@@ -8,6 +8,7 @@ final class TypefluxOfficialASRRoutingClientTests: XCTestCase {
             XCTAssertEqual(request.url?.path, "/api/v1/asr/token")
             XCTAssertEqual(request.httpMethod, "POST")
             XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer cloud-token")
+            XCTAssertNotNil(request.value(forHTTPHeaderField: TypefluxOfficialASRRequestFactory.traceIDHeader))
             XCTAssertEqual(request.value(forHTTPHeaderField: TypefluxCloudRequestHeaders.scenarioField), "voice-input")
             XCTAssertNil(request.httpBody)
             return (

--- a/Tests/TypefluxTests/WorkflowControllerProcessingTests.swift
+++ b/Tests/TypefluxTests/WorkflowControllerProcessingTests.swift
@@ -834,7 +834,7 @@ final class WorkflowControllerProcessingTests: XCTestCase {
         XCTAssertEqual(savedRecord?.pipelineTiming?.llmOutcome?.usedTranscriptFallback, true)
     }
 
-    func testLocalTranscriptIsAppliedWhenCloudASRAndRewriteFail() async {
+    func testLocalTranscriptIsAppliedWhenCloudASRIsCancelledAndRewriteFails() async {
         let transcript = "Keep this complete local transcript"
         let cases: [(Bool, Error)] = [
             (false, URLError(.cannotConnectToHost)),
@@ -882,7 +882,7 @@ final class WorkflowControllerProcessingTests: XCTestCase {
             XCTAssertEqual(textInjector.replacedTexts, replaceSelection ? [transcript] : [])
             let savedRecord = historyStore.list().last
             XCTAssertEqual(savedRecord?.pipelineTiming?.asrRace?.selectedSource, .local)
-            XCTAssertEqual(savedRecord?.pipelineTiming?.asrRace?.cloudAttempt.outcome, .failed)
+            XCTAssertEqual(savedRecord?.pipelineTiming?.asrRace?.cloudAttempt.outcome, .cancelled)
             XCTAssertEqual(savedRecord?.pipelineTiming?.asrRace?.localAttempt.outcome, .succeeded)
             XCTAssertEqual(savedRecord?.transcriptText, transcript)
             XCTAssertEqual(savedRecord?.postProcessedText, transcript)


### PR DESCRIPTION
## Summary

- prefetch a one-shot ASR route on startup, login, and recording preparation
- refill asynchronously after consumption and rotate unused routes 30 seconds before expiry
- prevent token reuse across concurrent sessions or account changes
- reduce the cloud-priority grace period from 3 seconds to 1 second
- propagate an ASR trace ID for server-side timing correlation

## Verification

- `swift test --enable-code-coverage --quiet` (2,568 tests passed)
- new cache module line coverage: 80.87%

GUL-89
