### PR TITLE
GUL-95: retry history from the failed pipeline stage

### DIFF
--- a/Sources/Typeflux/History/HistoryRetryPlan.swift
+++ b/Sources/Typeflux/History/HistoryRetryPlan.swift
@@ -1,0 +1,62 @@
+import Foundation
+
+enum HistoryRetryPlan: Equatable {
+    case retranscribe(audioURL: URL)
+    case rewriteSelection(sourceText: String, personaPrompt: String)
+    case rewriteTranscript(sourceText: String, personaPrompt: String)
+    case presentResult(String)
+    case unavailable(HistoryRetryUnavailableReason)
+
+    var isAvailable: Bool {
+        if case .unavailable = self {
+            return false
+        }
+        return true
+    }
+}
+
+enum HistoryRetryUnavailableReason: Equatable {
+    case audioMissing
+    case audioGone
+}
+
+enum HistoryRetryPlanner {
+    static func plan(
+        for record: HistoryRecord,
+        fileExists: (String) -> Bool = FileManager.default.fileExists(atPath:)
+    ) -> HistoryRetryPlan {
+        if record.applyStatus == .failed,
+           let finalText = nonEmpty(record.finalText) {
+            return .presentResult(finalText)
+        }
+
+        if record.mode == .editSelection,
+           record.recordingStatus == .skipped,
+           record.transcriptionStatus == .skipped,
+           let sourceText = nonEmpty(record.selectionOriginalText),
+           let personaPrompt = nonEmpty(record.personaPrompt) {
+            return .rewriteSelection(sourceText: sourceText, personaPrompt: personaPrompt)
+        }
+
+        if record.mode == .personaRewrite || record.mode == .dictation,
+           let transcriptText = nonEmpty(record.transcriptText),
+           let personaPrompt = nonEmpty(record.personaPrompt) {
+            return .rewriteTranscript(sourceText: transcriptText, personaPrompt: personaPrompt)
+        }
+
+        guard let audioFilePath = nonEmpty(record.audioFilePath) else {
+            return .unavailable(.audioMissing)
+        }
+        guard fileExists(audioFilePath) else {
+            return .unavailable(.audioGone)
+        }
+        return .retranscribe(audioURL: URL(fileURLWithPath: audioFilePath))
+    }
+
+    private static func nonEmpty(_ value: String?) -> String? {
+        guard let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !trimmed.isEmpty
+        else { return nil }
+        return trimmed
+    }
+}

--- a/Sources/Typeflux/Settings/SettingsViewModel.swift
+++ b/Sources/Typeflux/Settings/SettingsViewModel.swift
@@ -3087,7 +3087,7 @@ final class StudioViewModel: ObservableObject {
             errorMessage: record.errorMessage,
             applyMessage: record.applyMessage,
             hasTranscriptToCopy: !(record.finalText?.isEmpty ?? true),
-            canRetry: record.audioFilePath.map { FileManager.default.fileExists(atPath: $0) } == true,
+            canRetry: HistoryRetryPlanner.plan(for: record).isAvailable,
             hasFailure: record.hasFailure,
             failureMessage: record.errorMessage,
             accentName: iconData.0,

--- a/Sources/Typeflux/Workflow/WorkflowController+Processing.swift
+++ b/Sources/Typeflux/Workflow/WorkflowController+Processing.swift
@@ -664,17 +664,35 @@ extension WorkflowController {
     }
 
     func reprocess(record: HistoryRecord, sessionID: UUID) async {
-        guard let audioFilePath = record.audioFilePath, !audioFilePath.isEmpty else {
+        switch HistoryRetryPlanner.plan(for: record) {
+        case let .retranscribe(audioURL):
+            await retranscribe(record: record, audioURL: audioURL, sessionID: sessionID)
+        case let .rewriteSelection(sourceText, personaPrompt):
+            await retryRewrite(
+                record: record,
+                sourceText: sourceText,
+                personaPrompt: personaPrompt,
+                source: .selection,
+                sessionID: sessionID
+            )
+        case let .rewriteTranscript(sourceText, personaPrompt):
+            await retryRewrite(
+                record: record,
+                sourceText: sourceText,
+                personaPrompt: personaPrompt,
+                source: .transcript,
+                sessionID: sessionID
+            )
+        case let .presentResult(text):
+            await presentRetryResult(text, record: record, sessionID: sessionID)
+        case .unavailable(.audioMissing):
             await failRetry(record: record, message: L("workflow.retry.audioMissing"))
-            return
-        }
-
-        let audioURL = URL(fileURLWithPath: audioFilePath)
-        guard FileManager.default.fileExists(atPath: audioURL.path) else {
+        case .unavailable(.audioGone):
             await failRetry(record: record, message: L("workflow.retry.audioGone"))
-            return
         }
+    }
 
+    private func retranscribe(record: HistoryRecord, audioURL: URL, sessionID: UUID) async {
         var mutableRecord = record
         mutableRecord.errorMessage = nil
         mutableRecord.applyMessage = nil
@@ -723,6 +741,152 @@ extension WorkflowController {
             sessionID: sessionID,
             forceResultDialogOnSuccess: true
         )
+    }
+
+    private enum RetryRewriteSource {
+        case selection
+        case transcript
+    }
+
+    private func retryRewrite(
+        record: HistoryRecord,
+        sourceText: String,
+        personaPrompt: String,
+        source: RetryRewriteSource,
+        sessionID: UUID
+    ) async {
+        var mutableRecord = record
+        mutableRecord.errorMessage = nil
+        mutableRecord.applyMessage = nil
+        mutableRecord.personaResultText = nil
+        mutableRecord.openCCResultText = nil
+        mutableRecord.postProcessedText = nil
+        mutableRecord.selectionEditedText = nil
+        mutableRecord.processingStatus = .running
+        mutableRecord.applyStatus = .pending
+        var pipelineTiming = mutableRecord.pipelineTiming ?? HistoryPipelineTiming()
+        pipelineTiming.llmProcessingStartedAt = Date()
+        pipelineTiming.llmFirstOutputAt = nil
+        pipelineTiming.llmProcessingCompletedAt = nil
+        pipelineTiming.llmOutcome = nil
+        mutableRecord.pipelineTiming = pipelineTiming
+        saveHistoryRecord(mutableRecord)
+        activeProcessingRecordID = mutableRecord.id
+
+        await MainActor.run {
+            guard self.processingSessionID == sessionID else { return }
+            self.lastRetryableFailureRecord = nil
+            self.overlayController.transitionToLLMPhase()
+        }
+
+        do {
+            let showsStreamingPreview = switch source {
+            case .selection:
+                WorkflowOverlayPresentationPolicy.shouldShowLLMStreamingPreviewForPersonaSelectionApplication()
+            case .transcript:
+                WorkflowOverlayPresentationPolicy.shouldShowLLMStreamingPreviewAfterTranscription()
+            }
+            let rewriteResult = try await generateRewrite(
+                request: LLMRewriteRequest(
+                    mode: .rewriteTranscript,
+                    sourceText: sourceText,
+                    spokenInstruction: nil,
+                    personaPrompt: personaPrompt,
+                    appSystemContext: AppSystemContext(snapshot: TextSelectionSnapshot())
+                ),
+                sessionID: sessionID,
+                showsStreamingPreview: showsStreamingPreview
+            )
+            try ensureProcessingIsActive(sessionID)
+
+            pipelineTiming.llmFirstOutputAt = rewriteResult.firstOutputAt
+            pipelineTiming.llmProcessingCompletedAt = rewriteResult.completedAt
+            pipelineTiming.llmRequestAttempts = rewriteResult.requestAttempts
+            mutableRecord.pipelineTiming = pipelineTiming
+
+            let rewrittenText = rewriteResult.text.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !rewrittenText.isEmpty else {
+                throw NSError(
+                    domain: "HistoryRetry",
+                    code: 1,
+                    userInfo: [NSLocalizedDescriptionKey: "Persona rewrite returned an empty response"]
+                )
+            }
+
+            let resultText: String
+            switch source {
+            case .selection:
+                resultText = await outputPostProcessor.process(rewrittenText)
+                mutableRecord.selectionEditedText = resultText
+            case .transcript:
+                mutableRecord.personaResultText = rewrittenText
+                let optimizedText = DictationOutputOptimizer.optimize(rewrittenText)
+                if let config = settingsStore.effectiveOutputOpenCCConfig {
+                    let converted = await outputPostProcessor.process(optimizedText)
+                    mutableRecord.openCCResultText = converted
+                    mutableRecord.openCCConfig = config
+                    resultText = converted
+                } else {
+                    resultText = optimizedText
+                }
+            }
+
+            try ensureProcessingIsActive(sessionID)
+            mutableRecord.postProcessedText = resultText
+            mutableRecord.processingStatus = .succeeded
+            mutableRecord.applyStatus = .succeeded
+            mutableRecord.applyMessage = L("workflow.apply.presentedInDialog")
+            saveHistoryRecord(mutableRecord)
+            UsageStatsStore.shared.recordSession(record: mutableRecord)
+            enforceHistoryRetentionPolicy()
+
+            await MainActor.run {
+                guard self.processingSessionID == sessionID else { return }
+                self.lastRetryableFailureRecord = nil
+                self.lastDialogResultText = resultText
+                self.appState.setStatus(.idle)
+                self.overlayController.showResultDialog(
+                    title: L("workflow.result.copyTitle"),
+                    message: resultText
+                )
+            }
+        } catch is CancellationError {
+            if processingSessionID == sessionID {
+                markCancelled(&mutableRecord)
+                saveHistoryRecord(mutableRecord)
+            }
+        } catch {
+            let message = "Processing failed: \(error.localizedDescription)"
+            markFailure(&mutableRecord, message: message)
+            saveHistoryRecord(mutableRecord)
+            let retryableRecord = mutableRecord
+            await MainActor.run {
+                guard self.processingSessionID == sessionID else { return }
+                self.lastRetryableFailureRecord = retryableRecord
+                self.soundEffectPlayer.play(.error)
+                self.appState.setStatus(.failed(message: L("workflow.processing.failed")))
+                self.overlayController.showRetryableFailure(message: message)
+            }
+        }
+    }
+
+    private func presentRetryResult(_ text: String, record: HistoryRecord, sessionID: UUID) async {
+        var mutableRecord = record
+        mutableRecord.errorMessage = nil
+        mutableRecord.applyStatus = .succeeded
+        mutableRecord.applyMessage = L("workflow.apply.presentedInDialog")
+        saveHistoryRecord(mutableRecord)
+
+        await MainActor.run {
+            guard self.processingSessionID == sessionID else { return }
+            self.lastRetryableFailureRecord = nil
+            self.lastDialogResultText = text
+            self.appState.setStatus(.idle)
+            self.overlayController.showResultDialog(
+                title: L("workflow.result.copyTitle"),
+                message: text
+            )
+        }
     }
 
     // swiftlint:disable:next cyclomatic_complexity

--- a/Tests/TypefluxTests/HistoryRetryPlanTests.swift
+++ b/Tests/TypefluxTests/HistoryRetryPlanTests.swift
@@ -1,0 +1,112 @@
+@testable import Typeflux
+import XCTest
+
+final class HistoryRetryPlanTests: XCTestCase {
+    func testSelectionPersonaRetryDoesNotRequireAudio() {
+        let record = HistoryRecord(
+            date: Date(),
+            mode: .editSelection,
+            personaPrompt: "Make it concise.",
+            selectionOriginalText: "Original text",
+            recordingStatus: .skipped,
+            transcriptionStatus: .skipped,
+            processingStatus: .failed,
+            applyStatus: .skipped
+        )
+
+        XCTAssertEqual(
+            HistoryRetryPlanner.plan(for: record, fileExists: { _ in false }),
+            .rewriteSelection(sourceText: "Original text", personaPrompt: "Make it concise.")
+        )
+    }
+
+    func testCompletedTranscriptionRetriesPersonaWithoutAudio() {
+        let record = HistoryRecord(
+            date: Date(),
+            mode: .personaRewrite,
+            audioFilePath: "/missing/audio.wav",
+            transcriptText: "Raw transcript",
+            personaPrompt: "Polish this.",
+            recordingStatus: .succeeded,
+            transcriptionStatus: .succeeded,
+            processingStatus: .failed,
+            applyStatus: .skipped
+        )
+
+        XCTAssertEqual(
+            HistoryRetryPlanner.plan(for: record, fileExists: { _ in false }),
+            .rewriteTranscript(sourceText: "Raw transcript", personaPrompt: "Polish this.")
+        )
+    }
+
+    func testCompletedTranscriptionRetriesPersonaBeforeModeTransition() {
+        let record = HistoryRecord(
+            date: Date(),
+            mode: .dictation,
+            transcriptText: "Raw transcript",
+            personaPrompt: "Polish this.",
+            recordingStatus: .succeeded,
+            transcriptionStatus: .succeeded,
+            processingStatus: .pending,
+            applyStatus: .pending
+        )
+
+        XCTAssertEqual(
+            HistoryRetryPlanner.plan(for: record, fileExists: { _ in false }),
+            .rewriteTranscript(sourceText: "Raw transcript", personaPrompt: "Polish this.")
+        )
+    }
+
+    func testFailedTranscriptionRetriesFromExistingAudio() {
+        let record = HistoryRecord(
+            date: Date(),
+            mode: .personaRewrite,
+            audioFilePath: "/audio.wav",
+            personaPrompt: "Polish this.",
+            recordingStatus: .succeeded,
+            transcriptionStatus: .failed,
+            processingStatus: .skipped,
+            applyStatus: .skipped
+        )
+
+        XCTAssertEqual(
+            HistoryRetryPlanner.plan(for: record, fileExists: { $0 == "/audio.wav" }),
+            .retranscribe(audioURL: URL(fileURLWithPath: "/audio.wav"))
+        )
+    }
+
+    func testFailedApplyReusesGeneratedResult() {
+        let record = HistoryRecord(
+            date: Date(),
+            mode: .personaRewrite,
+            transcriptText: "Raw transcript",
+            personaPrompt: "Polish this.",
+            postProcessedText: "Finished result",
+            recordingStatus: .succeeded,
+            transcriptionStatus: .succeeded,
+            processingStatus: .succeeded,
+            applyStatus: .failed
+        )
+
+        XCTAssertEqual(
+            HistoryRetryPlanner.plan(for: record, fileExists: { _ in false }),
+            .presentResult("Finished result")
+        )
+    }
+
+    func testMissingRequiredAudioIsUnavailable() {
+        let record = HistoryRecord(
+            date: Date(),
+            mode: .dictation,
+            recordingStatus: .succeeded,
+            transcriptionStatus: .failed,
+            processingStatus: .skipped,
+            applyStatus: .skipped
+        )
+
+        XCTAssertEqual(
+            HistoryRetryPlanner.plan(for: record, fileExists: { _ in false }),
+            .unavailable(.audioMissing)
+        )
+    }
+}

--- a/Tests/TypefluxTests/WorkflowControllerProcessingTests.swift
+++ b/Tests/TypefluxTests/WorkflowControllerProcessingTests.swift
@@ -864,6 +864,165 @@ final class WorkflowControllerProcessingTests: XCTestCase {
         XCTAssertNotNil(controller.processingTask)
     }
 
+    func testRetrySelectionPersonaRewritesStoredTextWithoutAudio() async {
+        let historyStore = MockProcessingHistoryStore()
+        let llmService = CountingProcessingLLMService(rewriteText: "Concise result")
+        let record = HistoryRecord(
+            date: Date(),
+            mode: .editSelection,
+            personaPrompt: "Make it concise.",
+            selectionOriginalText: "Original selection",
+            errorMessage: "Timed out",
+            recordingStatus: .skipped,
+            transcriptionStatus: .skipped,
+            processingStatus: .failed,
+            applyStatus: .skipped
+        )
+        historyStore.save(record: record)
+        let controller = makeWorkflowController(
+            llmService: llmService,
+            historyStore: historyStore,
+            configureSettings: configureReadyLLM
+        )
+
+        controller.retry(record: record)
+        await waitUntil { controller.overlayController.isShowingResultDialogForTesting }
+
+        let savedRecord = historyStore.record(id: record.id)
+        XCTAssertEqual(llmService.streamRewriteCallCount, 1)
+        XCTAssertEqual(savedRecord?.selectionOriginalText, "Original selection")
+        XCTAssertEqual(savedRecord?.selectionEditedText, "Concise result")
+        XCTAssertEqual(savedRecord?.applyStatus, .succeeded)
+        XCTAssertNil(savedRecord?.audioFilePath)
+        XCTAssertTrue(controller.overlayController.isShowingResultDialogForTesting)
+    }
+
+    func testRetryPersonaRewriteUsesCompletedTranscriptWhenAudioIsGone() async {
+        let historyStore = MockProcessingHistoryStore()
+        let llmService = CountingProcessingLLMService(rewriteText: "Polished transcript")
+        let record = HistoryRecord(
+            date: Date(),
+            mode: .personaRewrite,
+            audioFilePath: "/missing/retry-audio.wav",
+            transcriptText: "Raw transcript",
+            personaPrompt: "Polish this.",
+            errorMessage: "Timed out",
+            recordingStatus: .succeeded,
+            transcriptionStatus: .succeeded,
+            processingStatus: .failed,
+            applyStatus: .skipped
+        )
+        historyStore.save(record: record)
+        let controller = makeWorkflowController(
+            llmService: llmService,
+            historyStore: historyStore,
+            configureSettings: configureReadyLLM
+        )
+
+        controller.retry(record: record)
+        await waitUntil { controller.overlayController.isShowingResultDialogForTesting }
+
+        let savedRecord = historyStore.record(id: record.id)
+        XCTAssertEqual(llmService.streamRewriteCallCount, 1)
+        XCTAssertEqual(savedRecord?.transcriptText, "Raw transcript")
+        XCTAssertEqual(savedRecord?.personaResultText, "Polished transcript")
+        XCTAssertEqual(savedRecord?.postProcessedText, "Polished transcript")
+        XCTAssertNil(savedRecord?.errorMessage)
+        XCTAssertTrue(controller.overlayController.isShowingResultDialogForTesting)
+    }
+
+    func testRetryFailedApplyPresentsExistingResultWithoutRepeatingLLM() async {
+        let historyStore = MockProcessingHistoryStore()
+        let llmService = CountingProcessingLLMService(rewriteText: "Unexpected rewrite")
+        let record = HistoryRecord(
+            date: Date(),
+            mode: .personaRewrite,
+            transcriptText: "Raw transcript",
+            personaPrompt: "Polish this.",
+            postProcessedText: "Existing result",
+            errorMessage: "Apply failed",
+            recordingStatus: .succeeded,
+            transcriptionStatus: .succeeded,
+            processingStatus: .succeeded,
+            applyStatus: .failed
+        )
+        historyStore.save(record: record)
+        let controller = makeWorkflowController(
+            llmService: llmService,
+            historyStore: historyStore,
+            configureSettings: configureReadyLLM
+        )
+
+        controller.retry(record: record)
+        await waitUntil { controller.overlayController.isShowingResultDialogForTesting }
+
+        XCTAssertEqual(llmService.streamRewriteCallCount, 0)
+        XCTAssertEqual(controller.lastDialogResultText, "Existing result")
+        XCTAssertNil(historyStore.record(id: record.id)?.errorMessage)
+        XCTAssertTrue(controller.overlayController.isShowingResultDialogForTesting)
+    }
+
+    func testRetryFailedTranscriptionUsesExistingAudio() async throws {
+        let audioURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("history-retry-\(UUID().uuidString).wav")
+        try Data().write(to: audioURL)
+        defer { try? FileManager.default.removeItem(at: audioURL) }
+
+        let historyStore = MockProcessingHistoryStore()
+        let record = HistoryRecord(
+            date: Date(),
+            mode: .dictation,
+            audioFilePath: audioURL.path,
+            errorMessage: "ASR failed",
+            recordingStatus: .succeeded,
+            transcriptionStatus: .failed,
+            processingStatus: .skipped,
+            applyStatus: .skipped
+        )
+        historyStore.save(record: record)
+        let controller = makeWorkflowController(
+            sttTranscriber: MockProcessingTranscriber(transcript: "Recovered transcript"),
+            historyStore: historyStore
+        )
+
+        controller.retry(record: record)
+        await waitUntil { controller.overlayController.isShowingResultDialogForTesting }
+
+        let savedRecord = historyStore.record(id: record.id)
+        XCTAssertEqual(savedRecord?.transcriptText, "Recovered transcript")
+        XCTAssertEqual(savedRecord?.transcriptionStatus, .succeeded)
+        XCTAssertNil(savedRecord?.errorMessage)
+    }
+
+    func testRetryRewriteFailureRemainsRetryableWithoutAudio() async {
+        let historyStore = MockProcessingHistoryStore()
+        let llmService = CountingProcessingLLMService(rewriteText: "")
+        let record = HistoryRecord(
+            date: Date(),
+            mode: .editSelection,
+            personaPrompt: "Make it concise.",
+            selectionOriginalText: "Original selection",
+            errorMessage: "Timed out",
+            recordingStatus: .skipped,
+            transcriptionStatus: .skipped,
+            processingStatus: .failed,
+            applyStatus: .skipped
+        )
+        historyStore.save(record: record)
+        let controller = makeWorkflowController(
+            llmService: llmService,
+            historyStore: historyStore,
+            configureSettings: configureReadyLLM
+        )
+
+        controller.retry(record: record)
+        await waitUntil { controller.lastRetryableFailureRecord != nil }
+
+        XCTAssertEqual(llmService.streamRewriteCallCount, 1)
+        XCTAssertEqual(historyStore.record(id: record.id)?.processingStatus, .failed)
+        XCTAssertNotNil(controller.lastRetryableFailureRecord)
+    }
+
     func testConfirmingPersonaSelectionPlaysTipCue() async throws {
         let eventRecorder = ThreadSafeEventRecorder()
         let controller = makeWorkflowController(


### PR DESCRIPTION
Closes GUL-95

## Summary
- choose retry work from the failed pipeline stage instead of always requiring audio
- retry persona selection and completed transcription directly through the LLM
- reuse an existing final result when only delivery failed
- add planner and workflow regression coverage

## Validation
- swift test
- make coverage